### PR TITLE
Prevent army characters from traveling with LAs, ensure prisoners also travel

### DIFF
--- a/common/on_action/travel_on_actions.txt
+++ b/common/on_action/travel_on_actions.txt
@@ -1591,14 +1591,15 @@ on_visited_ep3_monument = {
 #Used in the debug interaction debug_move_domicile_interaction
 on_travel_relocation_start = {
 	effect = {
-		every_courtier_or_guest = { #take everyone you have with you
-			limit = {
-				NOT = { exists = current_travel_plan }
-			}
-			root.current_travel_plan = {
-				add_companion = prev
-			}
-		}
+		#Unop Disable this, the correct logic is in ep3_contract_event.0002
+		#every_courtier_or_guest = { #take everyone you have with you
+		#	limit = {
+		#		NOT = { exists = current_travel_plan }
+		#	}
+		#	root.current_travel_plan = {
+		#		add_companion = prev
+		#	}
+		#}
 	}
 }
 

--- a/events/dlc/ep3/ep3_contract_events.txt
+++ b/events/dlc/ep3/ep3_contract_events.txt
@@ -634,6 +634,14 @@ ep3_contract_event.0002 = {
 		every_courtier_or_guest = {
 			limit = {
 				is_travelling = no
+				is_in_army = no #Unop Prevent army characters from leaving their army
+			}
+			add_to_list = task_contract_companions
+		}
+		#Unop Take prisoners as well
+		every_prisoner = {
+			limit = {
+				is_travelling = no
 			}
 			add_to_list = task_contract_companions
 		}


### PR DESCRIPTION
See https://forum.paradoxplaza.com/forum/threads/traveling-as-a-landless-adventurer-removes-all-army-commanders-and-prevents-them-from-being-reassigned.1709203/

The first commit contains just the newly added game files, the second one contains the actual changes.