### PR TITLE
Remove unused Private Tents parameter

### DIFF
--- a/common/domiciles/buildings/00_camp_buildings.txt
+++ b/common/domiciles/buildings/00_camp_buildings.txt
@@ -2280,7 +2280,8 @@ baggage_train_pleasure_tents = { # Pleasure Tents
 	}
 
 	parameters = {
-		camp_pleasure_tent_recruitment_events = yes
+		#Unop Remove this parameter as it's not used anywhere to avoid misleading description
+		#camp_pleasure_tent_recruitment_events = yes
 	}
 	
 	ai_value = {


### PR DESCRIPTION
See https://forum.paradoxplaza.com/forum/threads/private-tents-camp-upgrade-does-not-have-any-of-the-recruitment-events-despite-description-stating-otherwise.1713949/

Removing the unused parameter avoids the misleading description, there is no other easy fix as the events it's supposed to enable are completely missing.