### PR TITLE
Fix contracts populated for wrong area after sea travel

### DIFF
--- a/common/scripted_effects/00_laamp_effects.txt
+++ b/common/scripted_effects/00_laamp_effects.txt
@@ -56,8 +56,18 @@ populate_location_with_contracts_effect = {
 			every_character_task_contract = { add_to_list = pre_existing_contracts_list }
 		}
 		# Now populate.
+		#Unop Fix contracts populated for wrong area after sea travel
+		if = {
+			limit = {
+				current_travel_plan ?= { is_travel_with_domicile = yes }
+			}
+			$AREA_CHAR$.location = { save_temporary_scope_as = location }
+		}
+		else = {
+			$AREA_CHAR$.capital_province = { save_temporary_scope_as = location }
+		}
 		populate_task_contracts_for_area = {
-			location = $AREA_CHAR$.capital_province
+			location = scope:location #Unop Fix contracts populated for wrong area after sea travel
 			amount = $AMOUNT$
 			group = { 
 				laamp_contracts_transport_group 


### PR DESCRIPTION
See https://forum.paradoxplaza.com/forum/threads/moving-your-your-camp-by-sea-generates-contracts-near-your-origin-location-not-your-destination.1719475/