### PR TITLE
Add availability checks to laamp events that don't have it

### DIFF
--- a/events/dlc/ep3/ep3_laamp_events.txt
+++ b/events/dlc/ep3/ep3_laamp_events.txt
@@ -4593,6 +4593,7 @@ ep3_laamps.5005 = {
 		#Standard checks
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
+		is_available_allow_travelling = yes #Unop Ensure availability
 		is_location_valid_for_travel_event_on_land = yes
 		#Ensure we're in a place that's held by someone
 		exists = location.county.holder
@@ -4853,8 +4854,10 @@ ep3_laamps.5010 = {
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
 		age < 65 #Just for loc tonality
+		is_available_allow_travelling = yes #Unop Ensure availability
 		is_location_valid_for_travel_event_on_land = yes
 		any_courtier = {
+			is_available_allow_travelling = yes #Unop Ensure availability
 			is_valid_active_event_recurrer_trigger = { LIEGE = ROOT }
 			is_adult = yes # is an adult
 			age < 65 # but not too old, so wincing in pain isn't just from being real old
@@ -4864,6 +4867,7 @@ ep3_laamps.5010 = {
 	immediate = {
 		random_courtier = {
 			limit = {
+				is_available_allow_travelling = yes #Unop Ensure availability
 				is_valid_active_event_recurrer_trigger = { LIEGE = ROOT }
 				is_adult = yes # is an adult
 				age < 65 # but not too old, so wincing in pain isn't just from being real old
@@ -5089,6 +5093,7 @@ ep3_laamps.5015 = {
 		#Standard checks
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
+		is_available_allow_travelling = yes #Unop Ensure availability
 		is_location_valid_for_travel_event_on_land = yes
 	}
 
@@ -5362,6 +5367,7 @@ ep3_laamps.5020 = {
 		#Standard checks
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
+		is_available_allow_travelling = yes #Unop Ensure availability
 		is_location_valid_for_travel_event_on_land = yes
 		NOT = {
 			culture = location.culture
@@ -5654,6 +5660,7 @@ ep3_laamps.5025 = {
 		#Standard checks
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
+		is_available_allow_travelling = yes #Unop Ensure availability
 	}
 
 	immediate = {
@@ -5845,6 +5852,7 @@ ep3_laamps.5030 = {
 		#Standard checks
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
+		is_available_allow_travelling = yes #Unop Ensure availability
 		is_location_valid_for_travel_event_on_land = yes
 	}
 
@@ -6218,6 +6226,7 @@ ep3_laamps.5035 = {
 		#Standard checks
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
+		is_available_allow_travelling = yes #Unop Ensure availability
 		is_location_valid_for_travel_event_on_land = yes
 	}
 
@@ -6493,6 +6502,7 @@ ep3_laamps.5040 = {
 		#Standard checks
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
+		is_available_allow_travelling = yes #Unop Ensure availability
 		is_location_valid_for_travel_event_on_land = yes
 	}
 
@@ -6646,6 +6656,7 @@ ep3_laamps.5045 = {
 		#Standard checks
 		has_ep3_dlc_trigger = yes
 		is_landless_adventurer = yes
+		is_available_allow_travelling = yes #Unop Ensure availability
 		is_location_valid_for_travel_event_on_land = yes
 		location.barony.holder ?= {
 			is_available_ai_adult = yes


### PR DESCRIPTION
Add availability checks to laamp events that don't have it. I preferred `is_available_allow_travelling` because it is used also in most other laamp events. Besides fixing the issue reported in the ticket, this ensures that these events won't fire for characters that are imprisoned, incapable, in an army, terminally ill, or in an activity.

Fixes #30 