### PR TITLE
Revert balance change in "Steal Artifact" interaction

### DIFF
--- a/common/character_interactions/00_artifact_interactions.txt
+++ b/common/character_interactions/00_artifact_interactions.txt
@@ -2881,27 +2881,6 @@ start_stealing_back_artifact = {
 				has_artifact_claim = scope:target
 			}
 		}
-
-		#Unop Landless adventurers can only steal masterwork artifacts without a claim or a contract
-		trigger_if = {
-			limit = {
-				scope:actor = {
-					NOR = {
-						has_artifact_claim = scope:target
-						any_character_active_contract = {
-							has_task_contract_type = laamp_steal_artifact_contract
-							var:task_contract_object ?= scope:target
-						}
-					}
-				}
-			}
-			scope:target = {
-				OR = {
-					rarity = common
-					rarity = masterwork
-				}
-			}
-		}
 	}
 	# Scheme Starter Packages
 	options_heading = schemes.t.agent_packages


### PR DESCRIPTION
After playing with this some more, I had second thoughts about LAs being able to steal only common and masterwork artifacts. The character I had at that time was rather OP in intrigue, with a few similarly OP followers. With a more balanced character, stealing most famed / illustrious artifacts is actually pretty hard, as they are usually owned by powerful rulers.

Also, this is really a balance change, not a bug fix, and I agree we should avoid such changes in this mod unless we are really convinced or had consistent feedback from multiple players.

So I am proposing now to revert this change.