### PR TITLE
Fix charioteer training task

### DIFF
--- a/common/court_positions/tasks/00_court_positions_tasks.txt
+++ b/common/court_positions/tasks/00_court_positions_tasks.txt
@@ -686,7 +686,10 @@ bookmaker_cook_the_books = {
 	is_shown = { is_independent_ruler = yes }
 
 	is_valid_showing_failures_only = {
-		NOT = { has_character_flag = cook_the_books_cooldown_flag }
+		#Unop Use scope:liege since the root scope here is the court position holder 
+		scope:liege = {
+			NOT = { has_character_flag = cook_the_books_cooldown_flag }
+		}
 	}
 
 	on_start = {
@@ -774,6 +777,7 @@ charioteer_training = {
 	court_position_types = { charioteer_court_position }
 	
 	# Task is unlocked from the Estate
+	#Unop Add tooltip
 	is_shown = {
 
 	}
@@ -781,7 +785,8 @@ charioteer_training = {
 	is_valid_showing_failures_only = {
 		custom_tooltip = {
 			text = unop_unlock_charioteer_training_task
-			domicile ?= { has_domicile_parameter = estate_charioteer_training_task }
+			#Unop Use scope:liege since the root scope here is the court position holder 
+			scope:liege.domicile ?= { has_domicile_parameter = estate_charioteer_training_task }
 		}
 	}
 	


### PR DESCRIPTION
Fixes the issue reported in Steam by `@James Keenan`:

> One bug I've found with this mod (I've isolated it to just this mod running, compared to an unmodded game), is that the charioteer special task will not allow you to select it while this mod is running.

It is indeed reproducible and is caused by `is_valid_showing_failures_only` having a different root scope from `is_shown` (most likely the court position holder).

The `bookmaker_cook_the_books` task seems to have a similar issue, so fixed it as well.