### PR TITLE
Fix rescinding obligations on patron's death not removing from wars

### DIFF
--- a/common/task_contracts/laamp_extra_contracts.txt
+++ b/common/task_contracts/laamp_extra_contracts.txt
@@ -280,6 +280,10 @@ laamp_raid_contract = {
 					value = flag:laamp_raid_contract
 				}
 			}
+			#Unop Save war so it could be used in the invalidation event
+			var:task_contract_war ?= {
+				save_scope_as = task_contract_war
+			}
 			if = {
 				limit = {
 					task_contract_employer = {
@@ -559,6 +563,10 @@ laamp_join_war_contract = {
 					name = invalidated_task_contract_type
 					value = flag:laamp_join_war_contract
 				}
+			}
+			#Unop Save war so it could be used in the invalidation event
+			var:task_contract_war ?= {
+				save_scope_as = task_contract_war
 			}
 
 			if = {
@@ -840,6 +848,10 @@ laamp_help_claimant_contract = {
 					name = invalidated_task_contract_type
 					value = flag:laamp_help_claimant_contract
 				}
+			}
+			#Unop Save war so it could be used in the invalidation event
+			var:task_contract_war ?= {
+				save_scope_as = task_contract_war
 			}
 			if = {
 				limit = {

--- a/events/dlc/ep3/ep3_contract_events.txt
+++ b/events/dlc/ep3/ep3_contract_events.txt
@@ -2907,6 +2907,26 @@ ep3_contract_event.0012 = {
 			#Mysterious
 			custom_tooltip = treasure_map_disappeared.tt
 		}
+		#Unop Remove from the war if contract involves a war
+		if = {
+			limit = {
+				OR = {
+					var:invalidated_task_contract_type = flag:laamp_join_war_contract
+					var:invalidated_task_contract_type = flag:laamp_raid_contract
+					var:invalidated_task_contract_type = flag:laamp_help_claimant_contract
+				}
+			}
+			scope:task_contract_war ?= {
+				remove_participant = root
+			}
+		}
+		#Unop Save task contract as it is used by task_contract_invalidated_gold_gain_value
+		random_character_active_contract = {
+			limit = {
+				task_contract_employer = scope:task_contract_employer
+			}
+			save_temporary_scope_as = task_contract
+		}
 		#stuff that would be nice to see in tooltip, but is already executed in on_invalidation
 		show_as_tooltip = {
 			if = {


### PR DESCRIPTION
Fixes #29 

I checked that the same issue could potentially arise for raid and help claimant contracts (there may be a war saved in the `task_contract_war` variable), and tried to fix it as well.

When I tested this, I noticed missing scope errors due to `scope:task_contract` missing while calculating `task_contract_invalidated_gold_gain_value`. As a result, the value calculated is always 5 while it should be 10% of the full contract reward and depend on tier, perks, etc. I opted to fix this by saving this scope in the event to avoid changing all places where the event is fired.