### PR TITLE
Remove trigger from faith_creation.0003

### DIFF
--- a/events/religion_events/faith_creation_events.txt
+++ b/events/religion_events/faith_creation_events.txt
@@ -37,9 +37,10 @@ faith_creation.0002 = {
 faith_creation.0003 = {
 	hidden = yes
 	
-	trigger = {
-		is_ai = no
-	}
+	#Unop Enable this event also for AI
+	#trigger = {
+	#	is_ai = no
+	#}
 
 	immediate = {
 		if = {


### PR DESCRIPTION
See the discussion in Steam, https://steamcommunity.com/workshop/filedetails/discussion/2871648329/4697908845434539387/

Assuming AI can create new faiths, this trigger is definitely misplaced. The intention of the event is to set the variables `player_created_faith` (only for players) and `foundational_faith` (all rulers). Setting `is_ai = no` in the trigger means that `foundational_faith` is not correctly set for faiths created by AI rulers, causing all characters of such faiths to have the wrong appearance and denying them access to various decisions, events, etc.

However, I was not able to find any interactions, decisions, effects, or anything related to AI creating or reforming faiths, only the UI window which is player-only. I also added `debug_log` in `on_faith_created` (the only place that fires the event), then ran for ~70 years (1066 start), and didn't see anything in the logs. I guess it could still be possible but simply quite rare.

I am still proposing to remove the trigger as I think this wouldn't hurt.