### PR TITLE
Fix ck3-tiger errors in recently added vanilla code

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -90,6 +90,7 @@ filter = {
 			key = logic
 			text = "`provisions =` means exactly equal to that amount, which is usually not what you want"
 			OR = {
+				file = common/task_contracts/laamp_extra_contracts.txt
 				file = events/dlc/ep3/ep3_interactions_events.txt
 				file = events/dlc/ep3/ep3_laamp_decision_events.txt
 			}

--- a/common/task_contracts/laamp_extra_contracts.txt
+++ b/common/task_contracts/laamp_extra_contracts.txt
@@ -3961,7 +3961,7 @@ laamp_help_faith_conversion_contract = {
 			}
 			set_variable = {
 				name = task_contract_destination
-				value = root.task_contract_target.councillor_task_target
+				value = scope:task_contract_councillor.councillor_task_target #Unop ck3-tiger Use councillor as target
 			}
 			set_variable = {
 				name = task_contract_employer
@@ -3969,7 +3969,7 @@ laamp_help_faith_conversion_contract = {
 			}
 			set_variable = {
 				name = task_contract_target
-				value = root.task_contract_target
+				value = scope:task_contract_councillor #Unop ck3-tiger Use councillor as target
 			}
 			set_variable = {
 				name = task_contract_councillor


### PR DESCRIPTION
Fix the following ck3-tiger errors:

```
warning(logic): `provisions =` means exactly equal to that amount, which is usually not what you want
    --> [MOD] common/task_contracts/laamp_extra_contracts.txt
3326 |                 limit = { provisions = max_provisions }
     |                           ^^^^^^^^^^ 

warning(scopes): `task_contract_target` is for task contract but scope seems to be character
    --> [MOD] common/task_contracts/laamp_extra_contracts.txt
3964 |                 value = root.task_contract_target.councillor_task_target
     |                              ^^^^^^^^^^^^^^^^^^^^ 
3947 |     on_create = {
     |     ^^^^^^^^^ <-- scope was supplied by the game engine

warning(scopes): `task_contract_target` is for task contract but scope seems to be character
    --> [MOD] common/task_contracts/laamp_extra_contracts.txt
3972 |                 value = root.task_contract_target
     |                              ^^^^^^^^^^^^^^^^^^^^ 
3947 |     on_create = {
     |     ^^^^^^^^^ <-- scope was supplied by the game engine
```