### PR TITLE
Fix adding local_arbitration_perk boon modifier

### DIFF
--- a/common/scripted_effects/08_bp3_effects.txt
+++ b/common/scripted_effects/08_bp3_effects.txt
@@ -889,7 +889,7 @@ merge_aquitaine_effect = {
 					if = {
 						limit = {
 							NOR = { 
-								is_in_list = merge_aquitaine_list 
+								is_in_list = merge_aquitaine_cultures #Unop ck3-tiger Use a different list for cultures
 								this = root.culture
 								any_parent_culture_or_above = { this = root.culture }
 							}
@@ -899,7 +899,7 @@ merge_aquitaine_effect = {
 							value = -25
 							desc = cultural_acceptance_merge_aquitaine
 						}
-						add_to_list = merge_aquitaine_list
+						add_to_temporary_list = merge_aquitaine_cultures #Unop ck3-tiger Use a different list for cultures
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #18

See https://forum.paradoxplaza.com/forum/threads/adventurers-always-benefit-from-the-right-hand-man-perk-regardless-of-whether-the-perk-is-activated-or-not.1716386/