### PR TITLE
Fix ck3-tiger errors in newly added files

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -205,6 +205,14 @@ filter = {
 			}
 			file = events/dlc/ep1/ep1_fund_inspiration_events.txt
 		}
+		NAND = { # council_owner_modifier is likely setting these scopes, or it it's not, it can't be fixed anyway
+			key = strict-scopes
+			OR = {
+				text = "expects scope:councillor_liege to be set"
+				text = "expects scope:councillor to be set"
+			}
+			file = common/script_values/99_court_chaplain_values.txt
+		}
 
 		# Ignored
 		NAND = { # ignore missing-localization for now

--- a/events/travel_events/travel_events.txt
+++ b/events/travel_events/travel_events.txt
@@ -852,8 +852,10 @@ travel_events.1005 = { #Storm washes artifact overboard
 		animation = shock
 	}
 
-	lower_left_portrait = scope:overboard_artifact
-
+	artifact = { #Unop ck3-tiger
+		target = scope:overboard_artifact
+		position = lower_left_portrait
+	}
 
 	override_background = { reference = fp1_ocean }
 


### PR DESCRIPTION
Fix the following `ck3-tiger` errors in newly added files:

```
warning(strict-scopes): `court_chaplain_religious_relations_total_piety_gain` expects scope:councillor_liege to be set
   --> [CK3] common/council_tasks/00_court_chaplain_tasks.txt
124 |         scale = court_chaplain_religious_relations_total_piety_gain
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [MOD] common/script_values/99_court_chaplain_values.txt
 18 |             scope:councillor_liege = { has_perk = clerical_justifications_perk }
    |             ^^^^^^^^^^^^^^^^^^^^^^ <-- here

warning(strict-scopes): `court_chaplain_religious_relations_opinion_modifier` expects scope:councillor_liege to be set
   --> [CK3] common/council_tasks/00_court_chaplain_tasks.txt
130 |         scale = court_chaplain_religious_relations_opinion_modifier
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [MOD] common/script_values/99_court_chaplain_values.txt
198 |             scope:councillor_liege = {
    |             ^^^^^^^^^^^^^^^^^^^^^^ <-- here

warning(strict-scopes): `court_chaplain_religious_relations_no_hof_opinion_modifier` expects scope:councillor_liege to be set
   --> [CK3] common/council_tasks/00_court_chaplain_tasks.txt
136 |         scale = court_chaplain_religious_relations_no_hof_opinion_modifier
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [MOD] common/script_values/99_court_chaplain_values.txt
198 |             scope:councillor_liege = {
    |             ^^^^^^^^^^^^^^^^^^^^^^ <-- here

warning(strict-scopes): `court_chaplain_religious_relations_no_hof_opinion_modifier` expects scope:councillor to be set
   --> [CK3] common/council_tasks/00_court_chaplain_tasks.txt
136 |         scale = court_chaplain_religious_relations_no_hof_opinion_modifier
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [MOD] common/script_values/99_court_chaplain_values.txt
214 |             scope:councillor.faith = {
    |             ^^^^^^^^^^^^^^^^ <-- here

warning(scopes): `scope:overboard_artifact` produces artifact but expected character
   --> [MOD] events/travel_events/travel_events.txt
855 |     lower_left_portrait = scope:overboard_artifact
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^ 
891 |         random_character_artifact = {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ <-- scope was deduced from `random_character_artifact` here
```