### PR TITLE
Fix runtime errors from non-existing scopes

### DIFF
--- a/common/character_interactions/00_courtier_and_guest_interactions.txt
+++ b/common/character_interactions/00_courtier_and_guest_interactions.txt
@@ -1002,7 +1002,7 @@ invite_to_court_interaction = {
  			desc = AI_CAN_BE_PERSUADED_TO_STAY
 			
 			is_pool_guest = no
-			location.province_owner = {
+			location.province_owner ?= { #Unop Handle non-existing scope
 				OR = {
 					any_liege_or_above = { this = scope:actor }
 					this = scope:actor

--- a/events/travel_events/travel_events.txt
+++ b/events/travel_events/travel_events.txt
@@ -1643,7 +1643,7 @@ travel_events.1020 = {
 		}
 
 		current_travel_plan = {
-			next_destination_province = { save_scope_as = next_destination }
+			next_destination_province ?= { save_scope_as = next_destination } #Unop Handle non-existing scope
 		}
 	}
 


### PR DESCRIPTION
Fix 2 errors from non-existing scopes that are not very likely but tend to sometimes fill the error log due to other mods that I am using (e.g. Travelers).