### PR TITLE
Ensure traveling and available character in some travel danger events

### DIFF
--- a/events/travel_events/travel_danger_events_joe.txt
+++ b/events/travel_events/travel_danger_events_joe.txt
@@ -141,6 +141,7 @@ travel_danger_events.6000 = { #Animal attack
 	}
 
 	trigger = {
+		is_available_travelling_adult = yes #Unop Ensure traveling and available character
 		is_location_valid_for_travel_event_on_land = yes
 		location = {
 			exists = province_owner
@@ -171,7 +172,7 @@ travel_danger_events.6000 = { #Animal attack
 		save_scope_as = root_scope
 		save_scope_as = big_local_game
 		hunt_activity_dangerous_game_effect = { PROVINCE = location }
-		current_travel_plan = {
+		current_travel_plan ?= { #Unop Handle non-existing scope
 			random_entourage_character = {
 				limit = {
 					can_be_combatant_based_on_gender_trigger = { ARMY_OWNER = root }
@@ -284,7 +285,7 @@ travel_danger_events.6000 = { #Animal attack
 	option = { #Run!
 		name = travel_danger_events.6000.c
 		add_prestige = minor_prestige_loss
-		current_travel_plan = { 
+		current_travel_plan ?= { #Unop Handle non-existing scope
 			delay_travel_plan = { days = 10 }
 		}
 		stress_impact = {
@@ -450,6 +451,7 @@ travel_danger_events.6010 = { #Siege
 	cooldown = { months = 1 }
 
 	trigger = {
+		is_available_travelling_adult = yes #Unop Ensure traveling and available character
 		is_location_valid_for_travel_event_on_land = yes
 		location = {
 			exists = province_owner
@@ -925,6 +927,7 @@ travel_danger_events.6011 = { #Battal
 	cooldown = { months = 1 }
 
 	trigger = {
+		is_available_travelling_adult = yes #Unop Ensure traveling and available character
 		is_location_valid_for_travel_event_on_land = yes
 		location = {
 			exists = province_owner
@@ -1426,6 +1429,7 @@ travel_danger_events.6012 = { #Army
 	cooldown = { months = 1 }
 
 	trigger = {
+		is_available_travelling_adult = yes #Unop Ensure traveling and available character
 		is_location_valid_for_travel_event_on_land = yes
 		location = {
 			exists = province_owner
@@ -1849,6 +1853,7 @@ travel_danger_events.6013 = { #Occupation
 	cooldown = { months = 1 }
 
 	trigger = {
+		is_available_travelling_adult = yes #Unop Ensure traveling and available character
 		is_location_valid_for_travel_event_on_land = yes
 		location = {
 			exists = province_owner
@@ -2249,6 +2254,7 @@ travel_danger_events.6020 = { #Craig
 	cooldown = { months = 1 }
 
 	trigger = {
+		is_available_travelling_adult = yes #Unop Ensure traveling and available character
 		current_travel_plan.days_travelled >= 15
 		location = {
 			OR = {
@@ -2371,6 +2377,7 @@ travel_danger_events.6030 = { #Spoiled food
 	cooldown = { months = 6 }
 
 	trigger = {
+		is_available_travelling_adult = yes #Unop Ensure traveling and available character
 		current_travel_plan.days_travelled >= 15
 		is_adult = yes
 		current_travel_plan = {
@@ -3064,6 +3071,7 @@ travel_danger_events.6040 = { #Disease
 	cooldown = { months = 6 }
 
 	trigger = {
+		is_available_travelling_adult = yes #Unop Ensure traveling and available character
 		current_travel_plan.days_travelled >= 15
 		is_adult = yes
 		is_healthy = yes


### PR DESCRIPTION
The travel danger events in this file `events/travel_events/travel_danger_events_joe.txt` don't check whether the character is actually traveling and available for events (unlike I think all other travel danger events), so they may fire inappropriately on some occasions. 