### PR TITLE
Fix ck3-tiger errors in newly added files

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -211,7 +211,11 @@ filter = {
 				text = "expects scope:councillor_liege to be set"
 				text = "expects scope:councillor to be set"
 			}
-			file = common/script_values/99_court_chaplain_values.txt
+			OR = {
+				file = common/script_values/99_court_chaplain_values.txt
+				file = common/script_values/99_marshal_values.txt
+				file = common/scripted_triggers/00_councillor_triggers.txt
+			}
 		}
 
 		# Ignored


### PR DESCRIPTION
```
warning(strict-scopes): `marshal_organize_levies_modifier_total` expects scope:councillor_liege to be set
   --> [MOD] common/council_tasks/00_marshal_tasks.txt
143 |         scale = marshal_organize_levies_modifier_total
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [CK3] common/scripted_triggers/00_councillor_triggers.txt
855 |     exists = scope:councillor_liege.dynasty
    |              ^^^^^^^^^^^^^^^^^^^^^^ <-- here

warning(strict-scopes): `marshal_organize_levies_maintenance_total` expects scope:councillor_liege to be set
   --> [MOD] common/council_tasks/00_marshal_tasks.txt
149 |         scale = marshal_organize_levies_maintenance_total
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [CK3] common/scripted_triggers/00_councillor_triggers.txt
855 |     exists = scope:councillor_liege.dynasty
    |              ^^^^^^^^^^^^^^^^^^^^^^ <-- here

warning(strict-scopes): `marshal_increase_control_total` expects scope:councillor_liege to be set
   --> [MOD] common/council_tasks/00_marshal_tasks.txt
653 |         scale = marshal_increase_control_total
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [CK3] common/script_values/99_marshal_values.txt
325 |             scope:councillor_liege = {
    |             ^^^^^^^^^^^^^^^^^^^^^^ <-- here

warning(strict-scopes): `marshal_increase_control_total` expects scope:councillor to be set
   --> [MOD] common/council_tasks/00_marshal_tasks.txt
653 |         scale = marshal_increase_control_total
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [CK3] common/script_values/99_marshal_values.txt
326 |                 has_relation_friend = scope:councillor
    |                                       ^^^^^^^^^^^^^^^^ <-- here

warning(strict-scopes): `marshal_overtime_boost_scale` expects scope:councillor_liege to be set
   --> [MOD] common/council_tasks/00_marshal_tasks.txt
832 |             value = marshal_overtime_boost_scale
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [CK3] common/script_values/99_marshal_values.txt
581 |             scope:councillor_liege = {
    |             ^^^^^^^^^^^^^^^^^^^^^^ <-- here

warning(strict-scopes): `marshal_overtime_decrease_scale` expects scope:councillor_liege to be set
   --> [MOD] common/council_tasks/00_marshal_tasks.txt
840 |             value = marshal_overtime_decrease_scale
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
   --> [CK3] common/script_values/99_marshal_values.txt
614 |             scope:councillor_liege = {
    |             ^^^^^^^^^^^^^^^^^^^^^^ <-- here
```