### PR TITLE
Fix ck3-tiger errors in newly added files

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -217,6 +217,16 @@ filter = {
 				file = common/scripted_triggers/00_councillor_triggers.txt
 			}
 		}
+		NAND = { # artifacts created in eastereggs.txt may not have scope:location but this is fine
+			key = strict-scopes
+			text = "`create_artifact_weapon_effect` expects scope:location to be set"
+			file = common/scripted_effects/00_ep1_artifact_creation_effects.txt
+		}
+		NAND = { # artifact_should_use_gfx_type_trigger will fallback correctly if there is no scope:artifact 
+			key = strict-scopes
+			text = "`create_artifact_weapon_effect` expects scope:artifact to be set"
+			file = common/scripted_effects/00_ep1_artifact_creation_effects.txt
+		}
 
 		# Ignored
 		NAND = { # ignore missing-localization for now

--- a/events/activities/tournaments/tournament_events.txt
+++ b/events/activities/tournaments/tournament_events.txt
@@ -4573,13 +4573,13 @@ tournament_events.1230 = {
 		}
 	}
 
-	weight_multiplier = {
-		base = 1
-		modifier = {
-			factor = 2
-			has_activity_intent = recruit_knights_intent
-		}
-	}
+	#weight_multiplier = { #Unop ck3-tiger Already defined above 
+	#	base = 1
+	#	modifier = {
+	#		factor = 2
+	#		has_activity_intent = recruit_knights_intent
+	#	}
+	#}
 
 	option = { # Make champion
 		name = tournament_events.1230.a
@@ -5652,7 +5652,9 @@ tournament_events.1251 = {
 				hidden_effect = {
 					if = {
 						limit = { exists = scope:favor_scheme }
-						add_scheme_modifier = { type = tournament_favor_scheme_modifier }
+						scope:favor_scheme = { #Unop ck3-tiger Use correct scope
+							add_scheme_modifier = { type = tournament_favor_scheme_modifier }
+						}
 					}
 				}
 			}
@@ -6650,25 +6652,33 @@ tournament_events.1270 = {
 				trigger = {
 					tournament_past_losing_versus_contestant_trigger = { CONTEST = joust }
 				}
-				tournament_1270_versus_effect = { CONTEST = joust }
+				scope:activity = { #Unop ck3-tiger Use correct scope
+					tournament_1270_versus_effect = { CONTEST = joust }
+				}
 			}
 			10 = {
 				trigger = {
 					tournament_past_losing_versus_contestant_trigger = { CONTEST = wrestling }
 				}
-				tournament_1270_versus_effect = { CONTEST = wrestling }
+				scope:activity = { #Unop ck3-tiger Use correct scope
+					tournament_1270_versus_effect = { CONTEST = wrestling }
+				}
 			}
 			10 = {
 				trigger = {
 					tournament_past_losing_versus_contestant_trigger = { CONTEST = duel }
 				}
-				tournament_1270_versus_effect = { CONTEST = duel }
+				scope:activity = { #Unop ck3-tiger Use correct scope
+					tournament_1270_versus_effect = { CONTEST = duel }
+				}
 			}
 			10 = {
 				trigger = {
 					tournament_past_losing_versus_contestant_trigger = { CONTEST = board_game }
 				}
-				tournament_1270_versus_effect = { CONTEST = board_game }
+				scope:activity = { #Unop ck3-tiger Use correct scope
+					tournament_1270_versus_effect = { CONTEST = board_game }
+				}
 			}
 			50 = {
 				trigger = {

--- a/events/travel_events/travel_events_bp3.txt
+++ b/events/travel_events/travel_events_bp3.txt
@@ -1583,8 +1583,8 @@ travel_events_bp3.30 = { # The Mercenaries of <X>
 			levies = {
 				value = 200
 				multiply = {
+					value = highest_held_title_tier #Unop ck3-tiger value should be before min
 					min = 1
-					value = highest_held_title_tier
 				}
 			}
 			location = root.capital_province


### PR DESCRIPTION
```
warning(scopes): `add_scheme_modifier` is for scheme but scope seems to be character
    --> [CK3] events/activities/tournaments/tournament_events.txt
5655 |                 add_scheme_modifier = { type = tournament_favor_scheme_modifier }
     |                 ^^^^^^^^^^^^^^^^^^^ 
    --> [MOD] common/scripted_effects/00_ep1_artifact_creation_effects.txt
 105 |                 exists = court_owner
     |                          ^^^^^^^^^^^ <-- scope was deduced from `court_owner` here

warning(logic): setting value here will overwrite the previous calculations
    --> [MOD] events/travel_events/travel_events_bp3.txt
1587 |                 value = highest_held_title_tier
     |                 ^^^^^ 

warning(strict-scopes): `create_artifact_weapon_effect` expects scope:location to be set
    --> [CK3] history/characters/eastereggs.txt
4992 |             create_artifact_weapon_effect = {
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
    --> [MOD] common/scripted_effects/00_ep1_artifact_creation_effects.txt
9066 |                 location = scope:location
     |                            ^^^^^^^^^^^^^^ <-- here
    --> [CK3] history/characters/eastereggs.txt
4992 |             create_artifact_weapon_effect = {
     |             ^ <-- from here

warning(strict-scopes): `create_artifact_weapon_effect` expects scope:artifact to be set
    --> [CK3] history/characters/eastereggs.txt
4992 |             create_artifact_weapon_effect = {
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
    --> [CK3] common/scripted_triggers/00_artifact_triggers.txt
 351 |         limit = { exists = scope:artifact.creator.culture }
     |                            ^^^^^^^^^^^^^^ <-- here
    --> [MOD] common/scripted_effects/00_ep1_artifact_creation_effects.txt
9412 |                 scope:smith ?= { artifact_should_use_gfx_type_trigger = { TYPE = iranian_building } }
     |                                  ^ <-- from here
    --> [CK3] history/characters/eastereggs.txt
4992 |             create_artifact_weapon_effect = {
     |             ^ <-- from here
```

```
warning(duplicate-field): `weight_multiplier` is redefined in a following line
    --> [MOD] events/activities/tournaments/tournament_events.txt
4540 |     weight_multiplier = {
     |     ^ 
4576 |     weight_multiplier = {
     |     ^ <-- the other one is here

warning(scopes): `tournament_1270_versus_effect` expects scope to be activity but scope seems to be character
    --> [MOD] events/activities/tournaments/tournament_events.txt
6655 |                 tournament_1270_versus_effect = { CONTEST = joust }
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
6571 |         random_guest_subset = {
     |         ^^^^^^^^^^^^^^^^^^^ <-- expected scope was deduced from `random_guest_subset` here
6655 |                 tournament_1270_versus_effect = { CONTEST = joust }
     |                 ^ <-- from here
6580 | tournament_events.1270 = {
     | ^^^^^^^^^^^^^^^^^^^^^^ <-- actual scope was supplied by the game engine

warning(scopes): `tournament_1270_versus_effect` expects scope to be activity but scope seems to be character
    --> [MOD] events/activities/tournaments/tournament_events.txt
6661 |                 tournament_1270_versus_effect = { CONTEST = wrestling }
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
6571 |         random_guest_subset = {
     |         ^^^^^^^^^^^^^^^^^^^ <-- expected scope was deduced from `random_guest_subset` here
6661 |                 tournament_1270_versus_effect = { CONTEST = wrestling }
     |                 ^ <-- from here
6580 | tournament_events.1270 = {
     | ^^^^^^^^^^^^^^^^^^^^^^ <-- actual scope was supplied by the game engine

warning(scopes): `tournament_1270_versus_effect` expects scope to be activity but scope seems to be character
    --> [MOD] events/activities/tournaments/tournament_events.txt
6667 |                 tournament_1270_versus_effect = { CONTEST = duel }
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
6571 |         random_guest_subset = {
     |         ^^^^^^^^^^^^^^^^^^^ <-- expected scope was deduced from `random_guest_subset` here
6667 |                 tournament_1270_versus_effect = { CONTEST = duel }
     |                 ^ <-- from here
6580 | tournament_events.1270 = {
     | ^^^^^^^^^^^^^^^^^^^^^^ <-- actual scope was supplied by the game engine

warning(scopes): `tournament_1270_versus_effect` expects scope to be activity but scope seems to be character
    --> [MOD] events/activities/tournaments/tournament_events.txt
6673 |                 tournament_1270_versus_effect = { CONTEST = board_game }
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
6571 |         random_guest_subset = {
     |         ^^^^^^^^^^^^^^^^^^^ <-- expected scope was deduced from `random_guest_subset` here
6673 |                 tournament_1270_versus_effect = { CONTEST = board_game }
     |                 ^ <-- from here
6580 | tournament_events.1270 = {
     | ^^^^^^^^^^^^^^^^^^^^^^ <-- actual scope was supplied by the game engine
```