### PR TITLE
Fix accolade inc hunt danger

### DIFF
--- a/common/script_values/04_ep2_accolade_values.txt
+++ b/common/script_values/04_ep2_accolade_values.txt
@@ -155,8 +155,8 @@ accolade_hostile_knight_death_in_battle_actual_high_value = {
 # EMINENT ATTRIBUTES
 ###############
 
-acclaimed_knight_hunt_danger_value = 10
-acclaimed_knight_hunt_danger_value_high = 15
+acclaimed_knight_hunt_danger_value = -10 #Unop: Was 10 but this need to be reversed (since it's adding danger in hunt_melee_danger_value & hunt_bow_danger_value)
+acclaimed_knight_hunt_danger_value_high = -15 #Unop: Was 15 but this need to be reversed (since it's adding danger in hunt_melee_danger_value & hunt_bow_danger_value)
 accolade_tournament_invite_acceptance_value = 20
 accolade_feast_wedding_invite_acceptance_value = 20
 acclaimed_knight_prestige_from_victory_value = miniscule_prestige_value


### PR DESCRIPTION
Seen from https://forum.paradoxplaza.com/forum/threads/accolades-knight-huntsmaster-not-reduced-chance-for-negative-hunt-events.1725993/

And indeed if we check hunt_melee_danger_value & hunt_bow_danger_value we can see that it's adding danger instead of decreasing it)