### PR TITLE
Fix opinions when offering or demanding courtiers or concubines

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -62,8 +62,13 @@ filter = {
 			OR = {
 				text = "`break_grand_wedding_betrothal_effect` expects root to be any except none scope but root seems to be none"
 				text = "`elope_success_effect` expects root to be any except none scope but root seems to be none"
+				text = "`send_child_to_clergy_effect` expects root to be any except none scope but root seems to be none"
+				text = "`send_child_to_holy_order_tooltip_effect` expects root to be any except none scope but root seems to be none"
 			}
-			file = common/character_interactions/00_marriage_interactions.txt
+			OR = {
+				file = common/character_interactions/00_marriage_interactions.txt
+				file = common/scripted_effects/00_marriage_interaction_effects.txt
+			}
 		}
 		NAND = { # list changed_obligations is never created and so is likely hardcoded
 			key = strict-scopes
@@ -312,7 +317,10 @@ filter = {
 				text = "unknown token `tier_difference`"
 				text = "unexpected comparator >"
 			}
-			file = events/interaction_events/character_interaction_events.txt
+			OR = {
+				file = events/interaction_events/character_interaction_events.txt
+				file = common/character_interactions/00_tributary_interactions.txt
+			}
 		}
 		NAND = { # migration is likely a valid title change type
 			key = choice

--- a/common/character_interactions/00_tributary_interactions.txt
+++ b/common/character_interactions/00_tributary_interactions.txt
@@ -1541,6 +1541,19 @@ offer_courtier_interaction = {
 	}
 	
 	on_accept = {
+		#Unop Warning for multiple courtier offers
+		if = {
+			limit = {
+				scope:recipient = {
+					has_opinion_modifier = {
+						target = scope:actor
+						modifier = unop_offer_courtier_opinion
+					}
+				}
+			}
+			custom_tooltip = ALREADY_OFFERED_COURTIER_WARNING
+		}
+
 		scope:secondary_actor = {
 			add_opinion = {
 				#Unop Make consistent with demand_courtier interaction

--- a/common/character_interactions/00_tributary_interactions.txt
+++ b/common/character_interactions/00_tributary_interactions.txt
@@ -1,0 +1,2293 @@
+﻿#Interactions relating to tributary relationship management
+
+### Become Tributary - bilateral
+# actor = offerer / potential tributary
+# recipient = receiver / potential suzerain
+
+become_tributary_interaction = {
+	category = interaction_category_diplomacy
+	common_interaction = no
+	icon = become_tributary_interaction
+
+	desc = become_tributary_interaction_desc
+
+	is_shown = {
+		scope:actor = {
+			NOT = { government_has_flag = cannot_be_vassal_or_liege }
+			is_independent_ruler = yes # You have to be independent - This check exists to prevent a lot of edge-cases where you can change liege
+			is_tributary = no
+			highest_held_title_tier >= tier_county
+			trigger_if = {
+				limit = {
+					is_ai = yes
+				}
+				current_military_strength < scope:recipient.one_and_a_half_times_current_military_strength
+				primary_title.tier < scope:recipient.primary_title.tier
+			}
+		}
+		scope:recipient = {
+			is_independent_ruler = yes # while it's possible for tributaries to have their own tributaries, it should not be possible to create a tributary relationship with a non-independent ruler
+			NOT = { 
+				this = scope:actor
+				top_suzerain = scope:actor
+			}
+			can_have_tributaries_trigger = yes
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			is_physically_able = yes
+			is_travelling = no
+			NOT = { exists = involved_activity }
+			is_confederation_member = no
+			is_at_war = no
+		}
+	}
+
+	greeting = positive
+	notification_text = BECOME_TRIBUTARY_INTERACTION_NOTIFICATION
+
+	# Low starting obligations
+	send_option = {
+		flag = low_obligations
+		localization = low_tributary_obligations
+	}
+
+	# Medium starting obligations
+	send_option = {
+		flag = normal_obligations
+		localization = normal_tributary_obligations
+		starts_enabled = { always = yes	}
+
+	}
+
+	# High starting obligations
+	send_option = {
+		flag = high_obligations
+		localization = high_tributary_obligations
+	}
+
+	send_options_exclusive = yes
+
+	on_accept = {
+		start_tributary_interaction_effect = {
+			TRIBUTARY = scope:actor
+			SUZERAIN = scope:recipient
+		}
+		scope:actor = {
+			trigger_event = char_interaction.0360
+		}
+		scope:recipient = {
+			if = {
+				limit = { scope:high_obligations = yes }
+				add_opinion = {
+					modifier = tributary_volunteered_opinion
+					target = scope:actor
+					opinion = 20
+				}
+			}
+			else_if = {
+				limit = { scope:normal_obligations = yes }
+				add_opinion = {
+					modifier = tributary_volunteered_opinion
+					target = scope:actor
+				}
+			}
+
+			consume_all_criminal_reasons_effect = {
+				LIEGE = scope:recipient
+				CRIMINAL = scope:actor
+			}
+		}
+	}
+
+	on_decline = {
+		scope:actor = {
+			trigger_event = char_interaction.0361
+		}
+	}
+	
+	ai_potential = {
+		highest_held_title_tier >= tier_county
+		is_independent_ruler = yes
+	}
+
+	ai_targets = {
+		ai_recipients = neighboring_rulers_including_tributary_borders
+	}
+
+	ai_frequency = 6 # this might appear fairly frequent but is necessary in order to ensure AI can respond to sudden threats on their borders
+
+	force_notification = yes
+
+	ai_will_do = {
+		base = -50
+		ai_military_threat_modifier_with_cbs = { 
+			SENDER = scope:actor 
+			RECEIVER = scope:recipient
+			MULTIPLIER = -1 
+		}
+
+		modifier = {
+			is_obedient_to = scope:recipient
+			add = 40
+			desc = obedient_interaction_reason
+		}	
+
+		modifier = { # Rivalry modifier.
+			desc = offer_vassalization_interaction_aibehavior_rival_tt
+			trigger = {
+				scope:actor = {
+					has_relation_rival = scope:recipient
+					NOT = { has_relation_nemesis = scope:recipient }
+				}
+			}
+			add = -10
+		}
+		modifier = { # Nemesis modifier.
+			desc = offer_vassalization_interaction_aibehavior_nemesis_tt
+			trigger = {
+				scope:actor = {
+					has_relation_nemesis = scope:recipient
+				}
+			}
+			add = -30
+		}
+		modifier = { # Different faith, no pluralism.
+			desc = offer_vassalization_interaction_aibehavior_differentfaith_tt
+			trigger = {
+				scope:actor = {
+					NOR = { # Of two different faiths AND the potential vassal's faith is not pluralistic.
+						faith = scope:recipient.faith
+						faith = { has_doctrine = doctrine_pluralism_pluralistic }
+					}
+				}
+			}
+			add = {
+				value = -25
+				if = {
+					limit = {
+						scope:actor.faith = {
+							faith_hostility_level = {
+								target = scope:recipient.faith
+								value >= faith_hostile_level
+							}
+						}
+					}
+					add = -10
+				}
+				if = {
+					limit = {
+						scope:actor.faith = {
+							faith_hostility_level = {
+								target = scope:recipient.faith
+								value >= faith_evil_level
+							}
+						}
+					}
+					add = -25
+				}
+			}
+		}
+		modifier = { # I am a King!
+			desc = offer_fealty_interaction_aibehavior_amkingtier_tt
+			trigger = {
+				highest_held_title_tier >= tier_kingdom
+			}
+			add = -20
+		}
+
+		modifier = { # Cultural Acceptance
+			add = -5
+			desc = cultural_acceptance_interaction_reason
+			trigger = {
+				scope:actor = {
+					NOT = { has_same_culture_as = scope:recipient }
+					culture = {
+						cultural_acceptance = { target = scope:recipient.culture value < 50 }
+					}
+				}
+			}
+		}
+
+		modifier = { # Same language
+			add = 5
+			desc = speaks_same_language_interaction_reason
+			trigger = {
+				scope:actor = {
+					knows_language_of_culture = scope:recipient.culture
+				}
+			}
+		}
+	}
+
+	ai_min_reply_days = 5
+	ai_max_reply_days = 10
+
+	ai_accept = {
+		base = -50
+
+		modifier = {
+			desc = interaction_is_nomadic
+			scope:recipient = {
+				government_has_flag = government_is_nomadic
+			}
+			add = 100
+		}
+		
+		modifier = { # Wide difference in rank
+			desc = offer_vassalization_interaction_aibehavior_widetitletier_tt
+			trigger = {
+				scope:actor = {
+					tier_difference = {
+						target = scope:recipient
+						value > 1
+					}
+				}
+			}
+			add = 20
+		}
+		modifier = { # Distant Realm.
+			desc = offer_vassalization_interaction_aibehavior_distantrealm_tt
+			trigger = {
+				scope:actor = {
+					NOT = {
+						any_neighboring_top_liege_realm_owner = { this = scope:recipient }
+					}
+				}
+				scope:actor.capital_province = { squared_distance = { target = scope:recipient.capital_province value < 200000 } }
+			}
+			add = -15
+		}
+		modifier = { # Remote Realm.
+			desc = offer_vassalization_interaction_aibehavior_remoterealm_tt
+			trigger = {
+				scope:actor = {
+					NOT = {
+						any_neighboring_top_liege_realm_owner = { this = scope:recipient }
+					}
+				}
+				scope:actor.capital_province = { squared_distance = { target = scope:recipient.capital_province value >= 200000 } }
+			}
+			add = -25
+		}
+
+		# MINOR
+		modifier = { # Rivalry modifier.
+			desc = offer_vassalization_interaction_aibehavior_rival_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_rival = scope:actor
+					NOT = { has_relation_nemesis = scope:actor }
+				}
+			}
+			add = -10
+		}
+		modifier = { # Nemesis modifier.
+			desc = offer_vassalization_interaction_aibehavior_nemesis_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_nemesis = scope:actor
+				}
+			}
+			add = -30
+		}
+		modifier = { # Same Dynasty modifier.
+			desc = offer_vassalization_interaction_aibehavior_dynasty_tt
+			trigger = {
+				scope:recipient = {
+					dynasty = scope:actor.dynasty
+				}
+			}
+			add = 10
+		}
+
+		# PERSONALITY
+		ai_value_modifier = {
+			ai_greed = 0.75
+			min = 0
+		}
+
+		# OPINION INFLUENCE
+		opinion_modifier = { # Compare Opinion modifier.
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 1
+		}
+
+		# CONTRACT OPTIONS
+		modifier = {
+			add = -25
+			scope:low_obligations = yes
+			desc = CONTRACT_LOW_TAXES_REASON
+		}
+		modifier = {
+			add = 25
+			scope:high_obligations = yes
+			desc = CONTRACT_HIGH_TAXES_REASON
+		}
+	}
+}
+
+### Demand Tributary - bilateral
+# actor = offerer / potential suzerain
+# recipient = receiver / potential tributary
+
+demand_tributary_interaction = {
+	category = interaction_category_diplomacy
+	common_interaction = yes
+	icon = demand_tributary_interaction
+
+	desc = demand_tributary_interaction_desc
+
+	is_shown = {
+		scope:actor = {
+			NOT = { 
+				this = scope:recipient
+				top_suzerain = scope:recipient.top_suzerain # ensures the actor and recipient is not already in the same "suzerain bloc"
+			}
+			can_get_tributaries_peacefully_trigger = yes
+			
+			trigger_if = {
+				limit = {
+					is_ai = yes
+				}
+				current_military_strength >= scope:recipient.one_and_a_half_times_current_military_strength
+				primary_title.tier >= scope:recipient.primary_title.tier
+			}
+		}
+		scope:recipient = {
+			highest_held_title_tier >= tier_county
+			is_independent_ruler = yes # target cannot be a vassal
+			NOT = { government_has_flag = cannot_be_vassal_or_liege }
+		}
+		# Temujin cannot make Jamukha his subject once he leaves him
+		NOT = {
+			scope:actor = {
+				has_variable = had_mpo_temujin_flavor_0010
+				var:had_mpo_temujin_flavor_0010 ?= scope:recipient
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			NOT = { has_truce = scope:actor }
+			is_physically_able = yes
+			is_travelling = no
+			NOT = { exists = involved_activity }
+		}
+		scope:recipient = {
+			is_tributary = no
+			is_at_war = no
+			custom_tooltip = {
+				text = demand_tributary_interaction_cooldown_active_tt
+				NOT = {
+					has_opinion_modifier = {
+						modifier = tributary_demanded_opinion
+						target = scope:actor
+					}
+				}
+			}
+			is_confederation_member = no
+		}
+		scope:actor = {
+			custom_tooltip = {
+				text = mpo_interaction_not_neighbouring_tt
+				any_land_neighboring_realm_with_tributaries_owner = { 
+					this = scope:recipient
+				}
+			}
+		}
+	}
+
+	cost = {
+		prestige = minor_prestige_value	
+	}
+
+	greeting = positive
+	notification_text = DEMAND_TRIBUTARY_INTERACTION_NOTIFICATION
+
+	on_accept = {
+		start_tributary_interaction_effect = {
+			TRIBUTARY = scope:recipient
+			SUZERAIN = scope:actor
+		}
+		scope:actor = {
+			trigger_event = char_interaction.0362
+		}
+		scope:recipient = {
+			add_opinion = {
+				modifier = tributary_demanded_opinion # this opinion also acts as a built-in cooldown
+				target = scope:actor
+			}
+		}
+		consume_all_criminal_reasons_effect = {
+			LIEGE = scope:actor
+			CRIMINAL = scope:recipient
+		}
+	}
+
+	on_decline = {
+		scope:actor = {
+			trigger_event = char_interaction.0363
+		}
+		scope:recipient = {
+			add_opinion = {
+				modifier = tributary_demanded_opinion # this opinion also acts as a built-in cooldown
+				target = scope:actor
+			}
+			custom_tooltip = demand_tributary_interaction_cooldown_tt
+		}
+	}
+	
+	ai_maybe = yes
+
+	ai_potential = {
+		highest_held_title_tier > 1 # at least a count-level ruler
+		is_independent_ruler = yes
+	}
+
+	ai_targets = {
+		ai_recipients = neighboring_rulers_including_tributary_borders
+		max = 5
+	}
+
+	ai_frequency = 4
+
+	force_notification = yes
+
+	ai_will_do = {	# AI will often do this to valid targets that aren't a military threat to them, especially if they're rich
+		base = 0
+		
+		modifier = {
+			add = {
+				add = scope:recipient.gold
+				divide = 10
+				max = 100
+			}
+			desc = accumulated_wealth_reason
+		}
+
+		ai_military_threat_modifier_with_cbs = { 
+			SENDER = scope:actor 
+			RECEIVER = scope:recipient
+			MULTIPLIER = -1 
+		}
+
+		modifier = {
+			scope:recipient = { is_obedient_to = scope:actor }
+			add = 40
+			desc = obedient_interaction_reason
+		}
+
+		modifier = { # Generally don't try to tributarize those of higher rank than you
+			trigger = {
+				"scope:recipient.tier_difference(scope:actor)" > 1
+			}
+			add = -20
+		}
+
+		modifier = { # Generally don't try to tributarize those of higher dominance than you
+			trigger = {
+				scope:recipient.dominance_value > scope:actor.dominance_value
+			}
+			add = -30
+		}
+
+		modifier = { # Remote Realm.
+			trigger = {
+				scope:actor = {
+					NOT = {
+						any_neighboring_top_liege_realm_owner = { this = scope:recipient }
+					}
+				}
+				scope:actor.capital_province = { squared_distance = { target = scope:recipient.capital_province value >= 200000 } }
+			}
+			add = -25
+		}
+
+		modifier = {
+			trigger = {
+				scope:recipient = { government_has_flag = government_is_herder }
+			}
+			add = 1000
+		}
+	}
+
+	ai_min_reply_days = 5
+	ai_max_reply_days = 10
+	
+	auto_accept = {
+		custom_tooltip = {
+			text = scheme_agent_aptitude.is_herder
+			scope:recipient = { government_has_flag = government_is_herder }
+		}
+	}
+
+	ai_accept = {
+		base = -60
+		
+		modifier = { # Perk boost
+			desc = offer_vassalization_true_ruler_perk_tt
+			trigger = {
+				scope:actor = { has_perk = true_ruler_perk }
+			}
+			add = true_ruler_value
+		}
+
+		#Yurt bonuses
+		modifier = {
+			desc = tributary_yurt_02_domicile_building
+			trigger = {
+				scope:actor.domicile ?= { has_domicile_parameter = nomad_yurt_increased_tributary_acceptance_lvl_1 }
+			}
+			add = 5
+		}
+
+		modifier = {
+			desc = tributary_yurt_02_domicile_building
+			trigger = {
+				scope:actor.domicile ?= { has_domicile_parameter = nomad_yurt_increased_tributary_acceptance_lvl_2 }
+			}
+			add = 10
+		}
+
+		modifier = {
+			desc = tributary_yurt_02_domicile_building
+			trigger = {
+				scope:actor.domicile ?= { has_domicile_parameter = nomad_yurt_increased_tributary_acceptance_lvl_3 }
+			}
+			add = 15
+		}
+ 
+		modifier = { # the bolder they are, the less likely they will agree to this and vice versa
+			NOT = { ai_boldness = 0 }
+			add = {
+				value = ai_boldness
+				multiply = -1
+				divide = 2
+			}
+			desc = TRIBUTARY_BOLDNESS_REASON
+		}
+
+		modifier = { # the greedier they are, the less likely they will agree to this
+			ai_greed > 0
+			add = {
+				value = ai_greed
+				multiply = -1
+				divide = 4
+			}
+			desc = TRIBUTARY_GREED_REASON
+		}
+
+		modifier = {
+			is_obedient_to = scope:actor
+			add = 40
+			desc = obedient_interaction_reason
+		}
+		
+		modifier = {
+			scope:actor = { is_gurkhan = yes }
+			add = 20
+			desc = gurkhan_interaction_reason
+		}
+		
+		# Easier to make Tributaries during the Zud season
+		modifier = {
+			any_character_situation = {
+				any_situation_sub_region = {
+					has_sub_region_phase_parameter = the_great_steppe_easier_tributaries
+					any_situation_sub_region_participant_group = {
+						participant_group_type = nomad_rulers_capital
+						participant_group_has_character = scope:actor
+					}
+				}
+			}
+			add = 25
+			desc = zud_season_reason
+		}
+  		
+  		# if the actor is a major threat to the recipient they're more likely to accept
+		ai_military_threat_modifier_with_cbs = {
+			SENDER = scope:recipient 
+			RECEIVER = scope:actor
+			MULTIPLIER = 1 
+		}
+
+		modifier = { # They are a King
+			desc = demand_tributary_interaction_aibehavior_hightier_tt
+			trigger = {
+				scope:recipient = { highest_held_title_tier = tier_kingdom }
+			}
+			add = -20
+		}
+
+		modifier = { # They are an Emperor or greater
+			desc = demand_tributary_interaction_aibehavior_hightier_tt
+			trigger = {
+				scope:recipient = { highest_held_title_tier >= tier_empire }
+			}
+			add = -50
+		}
+
+		modifier = { # Recipient has higher Dominance than the actor
+			desc = demand_tributary_interaction_aibehavior_dominance_tt
+			trigger = {
+				scope:recipient.dominance_value > scope:actor.dominance_value
+			}
+			add = -20
+		}
+
+		modifier = { # Actor has higher Dominance than the recipient
+			desc = demand_tributary_interaction_aibehavior_dominance_tt
+			trigger = {
+				scope:actor.dominance_value > scope:recipient.dominance_value
+			}
+			add = 20
+		}
+		
+		# Legitimacy
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			scope:actor = {
+				has_legitimacy_flag = very_reduced_tributarization_acceptance
+			}
+			add = -25
+		}
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			scope:actor = {
+				has_legitimacy_flag = reduced_tributarization_acceptance
+			}
+			add = -10
+		}
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			scope:actor = {
+				has_legitimacy_flag = increased_tributarization_acceptance
+			}
+			add = 10
+		}
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			scope:actor = {
+				has_legitimacy_flag = very_increased_tributarization_acceptance
+			}
+			add = 25
+		}
+
+		# MINOR
+		modifier = { # Rivalry modifier.
+			desc = offer_vassalization_interaction_aibehavior_rival_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_rival = scope:actor
+					NOT = { has_relation_nemesis = scope:actor }
+				}
+			}
+			add = -10
+		}
+		modifier = { # Nemesis modifier.
+			desc = offer_vassalization_interaction_aibehavior_nemesis_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_nemesis = scope:actor
+				}
+			}
+			add = -30
+		}
+		modifier = { # Same Dynasty modifier.
+			desc = offer_vassalization_interaction_aibehavior_dynasty_tt
+			trigger = {
+				scope:recipient = {
+					dynasty = scope:actor.dynasty
+				}
+			}
+			add = 10
+		}
+		modifier = { # Different faith, no pluralism.
+			desc = offer_vassalization_interaction_aibehavior_differentfaith_tt
+			trigger = {
+				scope:actor = {
+					NOT = { # faith condition below doesn't have to apply if both actor and recipient have nomadic_philosophy
+						has_trait = nomadic_philosophy
+						scope:recipient = { has_trait = nomadic_philosophy }
+					}
+					faith = {
+						NOR = { # Of two different faiths AND the potential vassal's faith is not pluralistic
+							this = scope:recipient.faith
+							has_doctrine = doctrine_pluralism_pluralistic
+						}
+					}
+				}
+			}
+			add = {
+				value = -25
+				if = {
+					limit = {
+						scope:actor.faith = {
+							faith_hostility_level = {
+								target = scope:recipient.faith
+								value >= faith_hostile_level
+							}
+						}
+					}
+					add = -10
+				}
+				if = {
+					limit = {
+						scope:actor.faith = {
+							faith_hostility_level = {
+								target = scope:recipient.faith
+								value >= faith_evil_level
+							}
+						}
+					}
+					add = -25
+				}
+			}
+		}
+
+		modifier = { # Encircled
+			desc = offer_vassalization_interaction_aibehavior_encircled_tt
+			trigger = {
+				scope:recipient = {
+					NOT = {
+						any_neighboring_top_suzerain_realm_owner = {
+							NOT = {
+								this = scope:actor
+							}
+						}
+					}
+					NOT = {
+						any_realm_county = {
+							is_coastal_county = yes
+						}
+					}
+				}
+			}
+			add = 30
+		}
+
+		modifier = { # Cultural Acceptance
+			add = -5
+			desc = cultural_acceptance_interaction_reason
+			trigger = {
+				scope:actor = {
+					NOT = { # cultural condition below doesn't have to apply if both actor and recipient have nomadic_philosophy
+						has_trait = nomadic_philosophy
+						scope:recipient = { has_trait = nomadic_philosophy }
+					}
+					NOT = { has_same_culture_as = scope:recipient }
+					culture = {
+						cultural_acceptance = { target = scope:recipient.culture value < 50 }
+					}
+				}
+			}
+		}
+
+		modifier = { # Same language
+			add = 5
+			desc = speaks_same_language_interaction_reason
+			trigger = {
+				scope:actor = {
+					knows_language_of_culture = scope:recipient.culture
+				}
+			}
+		}
+
+		# OPINION INFLUENCE
+		opinion_modifier = { # Compare Opinion modifier.
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 1
+		}
+
+		#Severed head acceptance
+		modifier = {
+			add = 200
+			scope:actor = {
+				has_variable = severed_head_vassalization
+				var:severed_head_vassalization = {
+					this = scope:recipient
+				}
+			}
+		}
+	}
+}
+
+
+
+### Cease Paying Tribute - unilateral
+### Name referenced in code! Don't change it without an adult present!
+# actor = tributary
+# recipient = suzerain
+
+cease_paying_tribute_interaction = {
+	category = interaction_category_diplomacy
+	common_interaction = yes
+	use_diplomatic_range = no
+	icon = cease_paying_tributary_interaction
+
+	desc = cease_paying_tribute_interaction_desc
+
+	is_shown = {
+		scope:actor = {
+			this != scope:recipient
+			suzerain = scope:recipient
+			subject_can_break_tributary = yes
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			is_physically_able = yes
+			is_travelling = no
+			NOT = { exists = involved_activity }
+			trigger_if = {
+				limit = {
+					OR = {
+						any_land_neighboring_realm_with_tributaries_owner = {
+							this = scope:recipient
+						}
+						scope:recipient = {
+							is_landed = no
+						}
+					}
+				}
+				NOT = { has_truce = scope:recipient }
+			}
+		}
+	}
+
+	cost = {
+		prestige = {
+			value = 0
+			if = {
+				limit = {
+					scope:actor = {
+						OR = {
+							any_land_neighboring_realm_with_tributaries_owner = {
+								this = scope:recipient
+							}
+							scope:recipient = {
+								is_landed = no
+							}
+						}
+					}
+				}
+				add = minor_prestige_value
+			}
+		}
+	}
+
+	auto_accept = yes
+	on_accept = {
+		scope:actor = {
+			end_tributary = yes
+		}
+		scope:recipient = {
+			if = {
+				limit = { is_ai = yes }
+				trigger_event = {
+					id = char_interaction.0370
+					days = 14 # we delay the response from the AI for 2 weeks to make it feel more like a "diplomacy response"
+				}
+			}
+			else = {
+				trigger_event = char_interaction.0370
+			}
+			add_opinion = {
+				modifier = tributary_ceased_payments_opinion
+				target = scope:actor
+			}
+		}
+	}
+
+	ai_potential = {
+		is_at_war = no
+		is_migrating = no
+		suzerain ?= {
+			is_migrating = no
+
+			OR = {
+				is_landed = no
+				NOT = { # disconnected tributaries can always do this, even herders
+					any_land_neighboring_realm_with_tributaries_owner = {
+						this = root
+					}
+				}
+				AND = {
+					NOT = { root = { government_has_flag = government_is_herder } }
+					trigger_if = { # Obedience is a hard blocker, but only if suzerain is landed
+						limit = { 
+							is_landed = yes
+						}
+						root = { is_obedient = no }
+					}
+				}
+			}
+		}
+	}
+
+	ai_targets = {
+		ai_recipients = suzerain
+	}
+
+	ai_frequency = 12 # this must be 12 (1 year) in order to ensure the integrity of the UI-visualized chance the tributary will break the contract
+
+	# visualized in the UI as the annual chance the tributary will break the contract, based on a percentage chance per year
+	ai_will_do = { 
+		base = -25
+
+		modifier = {
+			add = {
+				add = obedience_value
+				subtract = obedience_threshold
+				multiply = -1
+				max = obedience_threshold
+				min = {
+					value = obedience_threshold
+					multiply = -1
+				}
+			}
+			desc = obedience_value_reason
+		}
+
+		modifier = {
+			scope:recipient = {
+				has_variable = temp_tributary_protection
+			}
+			add = -150
+			desc = temp_tributary_protection_reason
+		}
+
+		modifier = {
+			dominance_value > suzerain.dominance_value
+			add = 30
+			desc = cease_tribute_higher_dominance_reason
+		}
+
+		modifier = {
+			suzerain = { 
+				any_memory = { 
+					has_memory_type = nomad_showed_weakness_in_war
+					memory_age_years < 5
+				}
+			}
+			add = 30
+			desc = cease_tribute_showed_weakness_in_war_reason
+		}
+
+		modifier = {
+			any_memory = { 
+				has_memory_type = suzerain_defended_me_in_war
+				has_memory_participant = root.suzerain
+				memory_age_years < 10
+			}
+			add = -100
+			desc = cease_tribute_defended_me_in_war_reason
+		}
+
+		modifier = {
+			suzerain = { 
+				any_memory = { 
+					has_memory_type = had_chaotic_kurultai_succession
+					memory_age_years < 5
+				}
+			}
+			add = 30
+			desc = cease_tribute_had_chaotic_kurultai_succession_reason
+		}
+
+		# if the actor is sufficiently scared of the recipient they're way less likely to do this
+		ai_military_threat_modifier = {  
+			SENDER = scope:actor
+			RECEIVER = scope:recipient
+			MULTIPLIER = -2.5
+		}
+
+		modifier = {
+			scope:actor = {
+				is_migrating = no
+			}
+			scope:recipient = {
+				NOT = { 
+					any_land_neighboring_realm_with_tributaries_owner = {
+						this = scope:actor
+					}
+				}
+			}
+			add = 1000
+			desc = cease_tribute_disconnected_suzerain
+		}
+
+		modifier = {
+			scope:recipient = {
+				is_landed = no
+				is_migrating = no
+				is_at_war = no
+			}
+			add = 10000
+			desc = cease_tribute_landless_suzerain
+		}
+	}
+}
+
+### Release Tributary - unilateral
+# actor = suzerain
+# recipient = tributary
+
+release_tributary_interaction = {
+	category = interaction_category_diplomacy
+	common_interaction = no
+	icon = release_tributary_interaction
+
+	desc = release_tributary_interaction_desc
+
+	is_shown = {
+		scope:recipient = {
+			this != scope:actor
+			suzerain = scope:actor
+			OR = { # AI should only ever consider releasing unruly subjects
+				scope:actor = { is_ai = no }
+				NOT = { is_obedient_to = scope:actor }
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {}
+
+	cost = {
+		prestige = minor_prestige_value
+	}
+
+	auto_accept = yes
+	on_accept = {
+		add_truce_one_way = {
+			character = scope:recipient
+			years = 5
+			name = TRUCE_TRIBUTARY_RELEASED
+		}
+		scope:recipient = {
+			end_tributary = yes
+			save_scope_as = tributary_loc
+			scope:actor = { save_scope_as = suzerain_loc }
+			add_truce_both_ways = {
+				character = scope:actor
+				years = 5
+				name = TRUCE_TRIBUTARY_STOPPED
+			}
+			add_opinion = {
+                target = scope:actor
+                modifier = tributary_released_opinion
+                opinion = 25
+            }
+			trigger_event = char_interaction.0380
+		}
+		scope:actor = {
+			#TODO_CD_MPO some sort of message here
+		}
+	}
+}
+
+### Release as Tributary - unilateral
+# actor = suzerain
+# recipient = tributary
+
+release_as_tributary_interaction = {
+	category = interaction_category_vassal
+	common_interaction = no
+	icon = release_as_tributary
+	interface_priority = 4
+
+	desc = release_as_tributary_interaction_desc
+
+	is_shown = {
+		scope:actor = {
+			government_has_flag = government_is_nomadic
+		}
+		scope:recipient = {
+			is_vassal_of = scope:actor
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			is_independent_ruler = yes
+			is_at_war = no
+		}
+	}
+
+	auto_accept = yes
+	
+	on_accept = {
+		scope:actor = {
+			hidden_effect = {
+				send_interface_toast = {
+					type = event_toast_effect_neutral
+					title = release_as_tributary_interaction_toast
+					left_icon = scope:actor
+					right_icon = scope:recipient
+
+					custom_tooltip = release_as_tributary_interaction_toast_desc
+				}
+			}
+		}
+		scope:recipient = {
+			add_opinion = {
+				target = scope:actor
+				modifier = granted_independence_opinion
+				opinion = 10
+			}
+			create_title_and_vassal_change = {
+				type = independency
+				save_scope_as = change
+				add_claim_on_loss = yes
+			}
+			becomes_independent = {
+				change = scope:change
+			}
+
+			resolve_title_and_vassal_change = scope:change
+		}
+		start_tributary_interaction_effect = {
+			SUZERAIN = scope:actor
+			TRIBUTARY = scope:recipient
+		}
+	}
+
+	ai_potential = {
+		government_has_flag = government_is_nomadic
+		this = top_liege
+		vassal_count > vassal_limit
+	}
+
+	ai_targets = {
+		ai_recipients = vassals
+	}
+
+	ai_frequency = 12
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			scope:recipient = { # Only on your borders
+				any_held_title = {
+					tier = tier_county
+					any_neighboring_county = {
+						OR = {
+							is_coastal_county = yes
+							holder.top_liege != scope:recipient.top_liege
+						}
+					}
+				}
+			}
+			add = 100
+		}
+	}
+}
+
+# Offer Courtier
+offer_courtier_interaction = {
+	category = interaction_category_diplomacy
+	common_interaction = no
+	icon = courtier_interaction
+	interface_priority = 40
+
+	desc = offer_courtier_interaction_desc
+
+	ai_targets = {
+		ai_recipients = suzerain
+		ai_recipients = liege
+		ai_recipients = scripted_relations
+		max = 5
+	}
+	ai_target_quick_trigger = {
+		adult = yes
+	}
+	ai_frequency = 36
+
+	greeting = positive
+	notification_text = OFFER_COURTIER_NOTIFICATION
+
+	needs_recipient_to_open = yes
+
+	populate_actor_list = {
+		scope:actor = {
+			every_courtier = {
+				limit = {
+					is_available_healthy_ai_adult = yes
+					NOR = {
+						is_consort_of = scope:actor
+						is_heir_of = scope:actor
+						AND = {
+							is_female = yes
+							patrilinear_marriage = yes
+						}
+						AND = {
+							is_male = yes
+							matrilinear_marriage = yes
+						}
+						is_diarch = yes
+						is_designated_diarch = yes
+						has_character_flag = has_been_offered_as_concubine
+					}
+				}
+				add_to_list = characters
+			}
+		}
+	}
+
+	is_shown = {
+		scope:actor != scope:recipient
+		scope:recipient = {
+			is_ruler = yes
+			NOT = { government_has_flag = government_is_herder }
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		custom_tooltip = {
+			text = offer_courtier_valid_courtier_tt
+			scope:actor = {
+				any_courtier = {
+					is_available_healthy_ai_adult = yes
+					NOR = {
+						is_consort_of = scope:actor
+						is_heir_of = scope:actor
+						AND = {
+							is_female = yes
+							patrilinear_marriage = yes
+						}
+						AND = {
+							is_male = yes
+							matrilinear_marriage = yes
+						}
+					}
+				}
+			}
+		}
+	}
+
+	can_be_picked = {
+		is_adult = yes
+	}
+
+	can_send = {
+		custom_tooltip = {
+			text = no_heirs_can_be_sent_tt
+			scope:secondary_actor = {
+				NOT = {
+					is_heir_of = scope:actor
+				}
+			}
+		}
+		custom_tooltip = {
+			text = no_spouses_can_be_sent_tt
+			scope:secondary_actor = {
+				NOT = {
+					is_consort_of = scope:actor
+				}
+			}
+		}
+	}
+
+	auto_accept = no
+
+	ai_accept = {
+		base = -10
+		
+		modifier = {
+			add = 100
+			scope:secondary_actor = {
+				OR = {
+					sum_of_all_skills_value >= sum_of_all_skills_threshold_good
+					martial >= monumentally_high_skill_rating
+					prowess >= extremely_high_skill_rating
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_chancellor ?= { diplomacy < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_steward ?= { stewardship < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_spymaster ?= { intrigue < monumentally_high_skill_rating }
+					}
+					has_relation_lover = scope:recipient # Shhh, don't tell anyone, of course you're 'skilled'!
+					trigger_if = {
+						limit = {
+							scope:recipient = {
+								government_has_flag = government_is_nomadic
+							}
+						}
+						OR = {
+							AND = {
+								sum_of_all_skills_value >= sum_of_all_skills_threshold_average
+								scope:recipient = {
+									any_courtier = {
+										count < 10
+									}
+								}
+							}
+							aptitude:master_of_hunt_court_position >= 4
+							aptitude:keeper_of_the_horses_court_position >= 4
+							aptitude:boyan_court_position >= 4
+							aptitude:siege_engineer_court_position >= 4
+							aptitude:yurtchi_court_position >= 4
+							aptitude:cherbi_court_position >= 4
+							aptitude:yeke_jarquchi_court_position >= 4
+							aptitude:foreign_emissary_court_position >= 4
+						}
+					}
+				}
+			}
+			desc = AI_INTERESTING_COURTIER_REASON
+		}
+		
+		modifier = {
+			add = 100
+			scope:secondary_actor.prowess >= decent_skill_rating
+			scope:recipient.number_of_knights < scope:recipient.max_number_of_knights
+			desc = AI_KNIGHT_REASON
+		}
+		
+		modifier = {
+			add = 100
+			exists = scope:secondary_actor.inspiration
+			desc = AI_INSPIRED_REASON
+		}
+		
+		modifier = {
+			add = 100
+			scope:secondary_actor = {
+				is_close_or_extended_family_of = scope:recipient
+			}
+			desc = AI_FAMILY_REASON
+		}
+		
+		modifier = {
+			add = 100
+			scope:secondary_actor = {
+				is_consort_of = scope:recipient
+			}
+			desc = AI_SPOUSE_REASON
+		}
+		
+		modifier = {
+			add = 100
+			scope:secondary_actor = {
+				has_relation_friend = scope:recipient
+			}
+			desc = AI_FRIEND_REASON
+		}
+		
+		modifier = {
+			add = -200
+			scope:secondary_actor = {
+				has_relation_rival = scope:recipient
+			}
+			desc = AI_RIVAL_REASON
+		}
+		
+		modifier = {
+			add = 100
+			scope:recipient = {
+				any_courtier = {
+					is_consort_of = scope:secondary_actor
+				}
+			}
+			desc = AI_SPOUSE_OF_COURTIER_REASON
+		}
+		
+		modifier = {
+			add = 100
+			scope:recipient = {
+				any_courtier = {
+					count < 5
+				}
+			}
+			desc = AI_LACK_COURTIERS_REASON
+		}
+	}
+
+	ai_potential = {
+		OR = {
+			ai_greed <= 25
+			is_obedient = yes
+		}
+		OR = {
+			is_tributary = yes
+			num_of_relation_friend > 0
+			num_of_relation_lover > 0
+		}
+	}
+
+	ai_will_do = {
+		base = 0
+		
+		modifier = {
+			add = 100
+			scope:recipient = {
+				OR = {
+					has_relation_friend = scope:actor
+					has_relation_lover = scope:actor
+				}
+			}
+		}
+		
+		modifier = {
+			add = 100
+			scope:recipient = {
+				is_tributary_of = scope:actor
+				OR = {
+					ai_greed <= -50
+					is_obedient_to = scope:actor
+					opinion = {
+						target = scope:actor
+						value >= 50
+					}
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			scope:secondary_actor = {
+				OR = {
+					has_relation_friend = scope:actor
+					has_relation_lover = scope:actor
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			scope:actor = {
+				NOR = {
+					government_has_flag = government_is_nomadic
+					government_has_flag = government_is_herder
+				}
+			}
+			scope:secondary_actor = {
+				is_close_or_extended_family_of = scope:actor
+			}
+		}
+		
+		modifier = { # The AI only offers really good characters
+			factor = 0
+			scope:secondary_actor = {
+				NOR = {
+					sum_of_all_skills_value >= sum_of_all_skills_threshold_good
+					martial >= monumentally_high_skill_rating
+					prowess >= extremely_high_skill_rating
+					exists = inspiration
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_chancellor ?= { diplomacy < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_steward ?= { stewardship < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_spymaster ?= { intrigue < monumentally_high_skill_rating }
+					}
+					trigger_if = {
+						limit = {
+							scope:recipient = {
+								government_has_flag = government_is_nomadic
+							}
+						}
+						OR = {
+							AND = {
+								sum_of_all_skills_value >= sum_of_all_skills_threshold_average
+								scope:recipient = {
+									any_courtier = {
+										count < 10
+									}
+								}
+							}
+							aptitude:master_of_hunt_court_position >= 4
+							aptitude:keeper_of_the_horses_court_position >= 4
+							aptitude:boyan_court_position >= 4
+							aptitude:siege_engineer_court_position >= 4
+							aptitude:yurtchi_court_position >= 4
+							aptitude:cherbi_court_position >= 4
+							aptitude:yeke_jarquchi_court_position >= 4
+							aptitude:foreign_emissary_court_position >= 4
+						}
+					}
+				}
+			}
+		}
+	}
+
+	on_send = {
+		scope:secondary_actor = { # to block the same character from being offered twice
+			add_character_flag = {
+				flag = has_been_offered_as_concubine
+				days = 5
+			}
+		}
+	}
+	
+	on_accept = {
+		scope:secondary_actor = {
+			add_opinion = {
+				target = scope:recipient
+				modifier = piqued_opinion
+				opinion = 10
+			}
+		}
+		scope:recipient = {
+			add_courtier = scope:secondary_actor
+			scope:secondary_actor = {
+				every_consort = {
+					limit = {
+						is_courtier_of = scope:actor
+					}
+					scope:recipient = {
+						add_courtier = prev
+					}
+				}
+				every_child = {
+					limit = {
+						is_adult = no
+						is_courtier_of = scope:recipient
+					}
+					scope:actor = {
+						add_courtier = prev
+					}
+				}
+			}
+			add_opinion = {
+				target = scope:actor
+				modifier = grateful_opinion
+				opinion = 10
+			}
+		}
+	}
+
+	on_decline = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_bad
+				title = msg_courtier_offer_rejected_title
+				right_icon = scope:recipient
+				left_icon = scope:secondary_actor
+				custom_tooltip = msg_courtier_offer_rejected
+			}
+		}
+	}
+}
+
+# Demand Courtier
+demand_courtier_interaction = {
+	category = interaction_category_vassal
+	common_interaction = yes
+	icon = request_courtier_interaction
+	interface_priority = 45
+
+	desc = demand_courtier_interaction_desc
+
+	ai_targets = {
+		ai_recipients = tributaries
+		ai_recipients = vassals
+	}
+	ai_target_quick_trigger = {
+		adult = yes
+	}
+	ai_frequency = 12
+	cooldown_against_recipient = { years = 3 }
+
+	greeting = positive
+	notification_text = DEMAND_COURTIER_NOTIFICATION
+	
+	highlighted_reason = HIGHLIGHTED_SKILLED_COURTIER
+	is_highlighted = {
+		scope:recipient = {
+			any_courtier = {
+				is_available_healthy_ai_adult = yes
+				NOR = {
+					is_consort_of = scope:recipient
+					is_heir_of = scope:recipient
+					AND = {
+						is_female = yes
+						patrilinear_marriage = yes
+					}
+					AND = {
+						is_male = yes
+						matrilinear_marriage = yes
+					}
+					is_diarch = yes
+					is_designated_diarch = yes
+					has_character_flag = has_been_offered_as_concubine
+				}
+				OR = {
+					sum_of_all_skills_value >= sum_of_all_skills_threshold_good
+					martial >= monumentally_high_skill_rating
+					prowess >= extremely_high_skill_rating
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_chancellor ?= { diplomacy < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_steward ?= { stewardship < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_spymaster ?= { intrigue < monumentally_high_skill_rating }
+					}
+					trigger_if = {
+						limit = {
+							scope:actor = {
+								government_has_flag = government_is_nomadic
+							}
+						}
+						OR = {
+							aptitude:master_of_hunt_court_position >= 4
+							aptitude:keeper_of_the_horses_court_position >= 4
+							aptitude:boyan_court_position >= 4
+							aptitude:siege_engineer_court_position >= 4
+							aptitude:yurtchi_court_position >= 4
+							aptitude:cherbi_court_position >= 4
+							aptitude:yeke_jarquchi_court_position >= 4
+							aptitude:foreign_emissary_court_position >= 4
+						}
+					}
+				}
+			}
+		}
+	}
+
+	needs_recipient_to_open = yes
+
+	populate_actor_list = {
+		scope:recipient = {
+			every_courtier = {
+				limit = {
+					is_available_healthy_ai_adult = yes
+					NOR = {
+						is_consort_of = scope:recipient
+						is_heir_of = scope:recipient
+						AND = {
+							is_female = yes
+							patrilinear_marriage = yes
+						}
+						AND = {
+							is_male = yes
+							matrilinear_marriage = yes
+						}
+						is_diarch = yes
+						is_designated_diarch = yes
+						has_character_flag = has_been_offered_as_concubine
+					}
+				}
+				add_to_list = characters
+			}
+		}
+	}
+
+	is_shown = {
+		scope:actor != scope:recipient
+		scope:recipient = {
+			OR = {
+				trigger_if = {
+					limit = {
+						scope:actor = {
+							government_has_flag = government_is_nomadic
+						}
+					}
+					is_vassal_of = scope:actor
+				}
+				is_tributary_of = scope:actor
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		custom_tooltip = {
+			text = demand_courtier_valid_courtier_tt
+			scope:recipient = {
+				any_courtier = {
+					is_available_healthy_ai_adult = yes
+					NOR = {
+						is_consort_of = scope:recipient
+						is_heir_of = scope:recipient
+						AND = {
+							is_female = yes
+							patrilinear_marriage = yes
+						}
+						AND = {
+							is_male = yes
+							matrilinear_marriage = yes
+						}
+					}
+				}
+			}
+		}
+	}
+
+	can_be_picked = {
+		is_adult = yes
+	}
+
+	can_send = {
+	}
+
+	auto_accept = no
+
+	ai_accept = {
+		base = 0
+		
+		modifier = {
+			add = 1000
+			scope:recipient = {
+				is_obedient_to = scope:actor
+			}
+			desc = AI_OBEDIENT_REASON
+		}
+		
+		modifier = {
+			add = 25
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 1
+				}
+			}
+			desc = INTIMIDATED_REASON
+		}
+		
+		modifier = {
+			add = 50
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 2
+				}
+			}
+			desc = COWED_REASON
+		}
+		
+		opinion_modifier = { # Opinion Factor
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 1.0
+			desc = AI_OPINION_REASON
+		}
+		
+		modifier = {
+			add = -25
+			scope:secondary_actor = {
+				OR = {
+					is_councillor = yes
+					has_any_court_position = yes
+				}
+			}
+			desc = AI_EMPLOYED_COURTIER_REASON
+		}
+		
+		modifier = {
+			add = -15
+			scope:secondary_actor = {
+				is_knight = yes
+			}
+			desc = AI_IS_KNIGHT_REASON
+		}
+		
+		modifier = {
+			add = -50
+			exists = scope:secondary_actor.inspiration
+			desc = AI_INSPIRED_REASON
+		}
+		
+		modifier = {
+			add = -25
+			scope:secondary_actor = {
+				is_close_or_extended_family_of = scope:recipient
+			}
+			desc = AI_FAMILY_REASON
+		}
+		
+		modifier = {
+			add = -50
+			scope:secondary_actor = {
+				has_relation_friend = scope:recipient
+			}
+			desc = AI_FRIEND_REASON
+		}
+		
+		modifier = {
+			add = 1000
+			scope:secondary_actor = {
+				has_relation_rival = scope:recipient
+			}
+			desc = AI_RIVAL_REASON
+		}
+	}
+
+	ai_potential = {
+		ai_greed >= 0
+		any_tributary = { }
+	}
+
+	ai_will_do = {
+		base = 0
+		
+		modifier = {
+			add = 100
+			scope:secondary_actor = {
+				OR = {
+					has_relation_friend = scope:actor
+					has_relation_lover = scope:actor
+					sum_of_all_skills_value >= sum_of_all_skills_threshold_good
+					martial >= monumentally_high_skill_rating
+					prowess >= extremely_high_skill_rating
+					exists = inspiration
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_chancellor ?= { diplomacy < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_steward ?= { stewardship < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_spymaster ?= { intrigue < monumentally_high_skill_rating }
+					}
+					trigger_if = {
+						limit = {
+							scope:actor = {
+								government_has_flag = government_is_nomadic
+							}
+						}
+						OR = {
+							AND = {
+								sum_of_all_skills_value >= sum_of_all_skills_threshold_average
+								scope:actor = {
+									any_courtier = {
+										count < 10
+									}
+								}
+							}
+							aptitude:master_of_hunt_court_position >= 4
+							aptitude:keeper_of_the_horses_court_position >= 4
+							aptitude:boyan_court_position >= 4
+							aptitude:siege_engineer_court_position >= 4
+							aptitude:yurtchi_court_position >= 4
+							aptitude:cherbi_court_position >= 4
+							aptitude:yeke_jarquchi_court_position >= 4
+							aptitude:foreign_emissary_court_position >= 4
+						}
+					}
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			scope:recipient = {
+				OR = {
+					has_relation_friend = scope:actor
+					has_relation_lover = scope:actor
+				}
+			}
+		}
+	}
+
+	on_send = {
+		scope:secondary_actor = { # to block the same character from being offered twice
+			add_character_flag = {
+				flag = has_been_offered_as_concubine
+				days = 5
+			}
+		}
+	}
+	
+	on_accept = {
+		scope:secondary_actor = {
+			add_opinion = {
+				target = scope:recipient
+				modifier = annoyed_opinion
+				opinion = -10
+			}
+		}
+		scope:actor = {
+			add_courtier = scope:secondary_actor
+			scope:secondary_actor = {
+				every_consort = {
+					limit = {
+						is_courtier_of = scope:recipient
+					}
+					scope:actor = {
+						add_courtier = prev
+					}
+				}
+				every_child = {
+					limit = {
+						is_adult = no
+						is_courtier_of = scope:recipient
+					}
+					scope:actor = {
+						add_courtier = prev
+					}
+				}
+			}
+			add_opinion = {
+				target = scope:recipient
+				modifier = pleased_opinion
+				opinion = 20
+			}
+		}
+		scope:recipient = {
+			add_opinion = {
+				target = scope:actor
+				modifier = upset_opinion
+				opinion = -15
+			}
+		}
+	}
+
+	on_decline = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_bad
+				title = msg_courtier_demand_rejected_title
+				right_icon = scope:recipient
+				left_icon = scope:secondary_actor
+				custom_tooltip = msg_courtier_demand_rejected
+			}
+		}
+		scope:actor = {
+			add_opinion = {
+				target = scope:recipient
+				modifier = upset_opinion
+				opinion = -15
+			}
+		}
+	}
+}
+
+# Demand Concubine
+demand_concubine_interaction = {
+	category = interaction_category_vassal
+	common_interaction = yes
+	icon = request_concubine_interaction
+	interface_priority = 44
+
+	desc = demand_concubine_interaction_desc
+
+	ai_targets = {
+		ai_recipients = tributaries
+		ai_recipients = vassals
+	}
+	ai_target_quick_trigger = {
+		adult = yes
+	}
+	ai_frequency = 12
+	cooldown_against_recipient = { years = 3 }
+
+	greeting = positive
+	notification_text = DEMAND_CONCUBINE_NOTIFICATION
+
+	needs_recipient_to_open = yes
+
+	populate_actor_list = {
+		scope:recipient = {
+			every_courtier = {
+				limit = {
+					is_physically_able_adult = yes
+					is_ruler = no
+					could_marry_character_trigger = { CHARACTER = scope:actor }
+				}
+				add_to_list = characters
+			}
+		}
+	}
+
+	is_shown = {
+		scope:actor != scope:recipient
+		scope:actor = {
+			allowed_concubines = yes
+		}
+		scope:recipient = {
+			OR = {
+				trigger_if = {
+					limit = {
+						scope:actor = {
+							government_has_flag = government_is_nomadic
+						}
+					}
+					is_vassal_of = scope:actor
+				}
+				is_tributary_of = scope:actor
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			allowed_more_concubines = yes
+			is_physically_able_adult = yes
+		}
+		custom_tooltip = {
+			text = must_have_valid_concubine_tt
+			scope:recipient = {
+				any_courtier = {
+					is_physically_able_adult = yes
+					is_ruler = no
+					could_marry_character_trigger = { CHARACTER = scope:actor }
+				}
+			}
+		}
+	}
+
+	can_be_picked = {
+		is_adult = yes
+	}
+
+	can_send = {
+	}
+
+	auto_accept = no
+
+	ai_accept = {
+		base = 0
+		
+		modifier = {
+			add = 1000
+			scope:recipient = {
+				is_obedient_to = scope:actor
+			}
+			desc = AI_OBEDIENT_REASON
+		}
+		
+		modifier = {
+			add = 25
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 1
+				}
+			}
+			desc = INTIMIDATED_REASON
+		}
+		
+		modifier = {
+			add = 50
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 2
+				}
+			}
+			desc = COWED_REASON
+		}
+		
+		opinion_modifier = { # Opinion Factor
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 1.0
+			desc = AI_OPINION_REASON
+		}
+		
+		modifier = {
+			add = -25
+			scope:secondary_actor = {
+				OR = {
+					is_councillor = yes
+					has_any_court_position = yes
+				}
+			}
+			desc = AI_EMPLOYED_COURTIER_REASON
+		}
+		
+		modifier = {
+			add = -15
+			scope:secondary_actor = {
+				is_knight = yes
+			}
+			desc = AI_IS_KNIGHT_REASON
+		}
+		
+		modifier = {
+			add = -50
+			exists = scope:secondary_actor.inspiration
+			desc = AI_INSPIRED_REASON
+		}
+		
+		modifier = {
+			add = -25
+			scope:secondary_actor = {
+				is_close_or_extended_family_of = scope:recipient
+			}
+			desc = AI_FAMILY_REASON
+		}
+		
+		modifier = {
+			add = -50
+			scope:secondary_actor = {
+				has_relation_friend = scope:recipient
+			}
+			desc = AI_FRIEND_REASON
+		}
+		
+		modifier = {
+			add = -50
+			scope:secondary_actor = {
+				is_consort_of = scope:recipient
+			}
+			desc = AI_SPOUSE_REASON
+		}
+		
+		modifier = {
+			add = -50
+			scope:secondary_actor = {
+				is_child_of = scope:recipient
+			}
+			desc = AI_CHILD_REASON
+		}
+		
+		modifier = {
+			add = 1000
+			scope:secondary_actor = {
+				has_relation_rival = scope:recipient
+			}
+			desc = AI_RIVAL_REASON
+		}
+	}
+
+	ai_potential = {
+		OR = {
+			has_trait = lustful
+			ai_honor <= 0
+		}
+		any_tributary = { }
+	}
+
+	ai_will_do = {
+		base = 0
+		
+		modifier = {
+			add = 100
+			scope:secondary_actor = {
+				OR = {
+					has_relation_friend = scope:actor
+					has_relation_lover = scope:actor
+					sum_of_all_skills_value >= sum_of_all_skills_threshold_good
+					martial >= monumentally_high_skill_rating
+					prowess >= extremely_high_skill_rating
+					exists = inspiration
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_chancellor ?= { diplomacy < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_steward ?= { stewardship < monumentally_high_skill_rating }
+					}
+					AND = {
+						diplomacy >= monumentally_high_skill_rating
+						scope:actor.cp:councillor_spymaster ?= { intrigue < monumentally_high_skill_rating }
+					}
+					has_conventionally_attractive_trigger = yes
+					num_of_good_genetic_traits > 1
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			scope:recipient = {
+				OR = {
+					has_relation_friend = scope:actor
+					has_relation_lover = scope:actor
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0
+			scope:secondary_actor = {
+				OR = {
+					has_conventionally_ugly_trigger = yes
+					age >= 30
+					is_visibly_fertile = no
+				}
+			}
+		}
+	}
+
+	on_send = {
+		scope:secondary_actor = { # to block the same character from being offered twice
+			add_character_flag = {
+				flag = has_been_offered_as_concubine
+				days = 5
+			}
+		}
+	}
+	
+	on_accept = {
+		scope:recipient = {
+			if = {
+				limit = {
+					scope:secondary_actor = {
+						NOR = {
+							is_consort_of = scope:recipient
+							is_close_or_extended_family_of = scope:recipient
+						}
+					}
+				}
+				add_opinion = {
+					target = scope:actor
+					modifier = upset_opinion
+					opinion = -15
+				}
+			}
+			else = {
+				scope:secondary_actor = { save_scope_as = relationship_reason_involved_character }
+				progress_towards_rival_effect = {
+					REASON = rival_demanded_concubine
+					CHARACTER = scope:actor
+					OPINION = 0
+				}
+				add_opinion = {
+					target = scope:actor
+					modifier = upset_opinion
+					opinion = -50
+				}
+				clear_saved_scope = secondary_actor
+			}
+		}
+		demand_concubine_interaction_on_accept_effect = yes
+	}
+
+	on_decline = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_bad
+				title = msg_concubine_demand_rejected_title
+				right_icon = scope:recipient
+				left_icon = scope:secondary_actor
+				custom_tooltip = msg_courtier_demand_rejected
+			}
+		}
+		scope:actor = {
+			add_opinion = {
+				target = scope:recipient
+				modifier = upset_opinion
+				opinion = -15
+			}
+		}
+	}
+}

--- a/common/character_interactions/00_tributary_interactions.txt
+++ b/common/character_interactions/00_tributary_interactions.txt
@@ -1066,10 +1066,12 @@ release_tributary_interaction = {
 
 	auto_accept = yes
 	on_accept = {
-		add_truce_one_way = {
-			character = scope:recipient
-			years = 5
-			name = TRUCE_TRIBUTARY_RELEASED
+		scope:actor = { #Unop ck3-tiger Fix scope
+			add_truce_one_way = {
+				character = scope:recipient
+				years = 5
+				name = TRUCE_TRIBUTARY_RELEASED
+			}
 		}
 		scope:recipient = {
 			end_tributary = yes
@@ -1541,9 +1543,10 @@ offer_courtier_interaction = {
 	on_accept = {
 		scope:secondary_actor = {
 			add_opinion = {
-				target = scope:recipient
-				modifier = piqued_opinion
-				opinion = 10
+				#Unop Make consistent with demand_courtier interaction
+				target = scope:actor
+				modifier = annoyed_opinion
+				opinion = -10
 			}
 		}
 		scope:recipient = {
@@ -1569,7 +1572,7 @@ offer_courtier_interaction = {
 			}
 			add_opinion = {
 				target = scope:actor
-				modifier = grateful_opinion
+				modifier = unop_offer_courtier_opinion #Unop Use custom non-stacking opinion, as for other gifts
 				opinion = 10
 			}
 		}

--- a/common/opinion_modifiers/00_unop_opinion_modifiers.txt
+++ b/common/opinion_modifiers/00_unop_opinion_modifiers.txt
@@ -1,0 +1,9 @@
+﻿unop_offer_concubine_opinion = {
+	monthly_change = 0.25
+	decaying = yes
+}
+
+unop_offer_courtier_opinion = {
+	monthly_change = 0.25
+	decaying = yes
+}

--- a/common/scripted_effects/00_marriage_interaction_effects.txt
+++ b/common/scripted_effects/00_marriage_interaction_effects.txt
@@ -1,0 +1,1864 @@
+﻿marriage_interaction_on_accept_effect = {
+	#Use hook
+	if = {
+		limit = { always = scope:hook }
+		scope:actor = {
+			use_hook = scope:recipient
+		}
+		#To make sure betrothals can't be broken if a hook was used
+		if = {
+			limit = {
+				OR = {
+					scope:secondary_actor = { is_adult = no }
+					scope:secondary_recipient = { is_adult = no }
+				}
+			}
+			scope:secondary_actor = {
+				set_variable = {
+					name = hook_used_for_betrothal
+					value = scope:secondary_recipient
+				}
+			}
+		}
+	}
+	
+	#Penalties for marrying a lowborn
+	scope:actor = {
+		if = {
+			limit = {
+				this = scope:secondary_actor # We check that you're marrying them yourself
+				scope:secondary_recipient = { is_lowborn = yes }
+			}
+			# Vassal dispositions get aggy.
+			## Actual effect applied in the on_marriage on_action.
+			show_as_tooltip = {
+				vassals_dislike_marry_lowborn_effect = {
+					SPOUSE = scope:secondary_recipient
+					RULER = scope:actor
+				}
+			}
+			#Legitimacy loss for marrying a lowborn
+			if = {
+				limit = {
+					is_valid_for_legitimacy_change = yes
+					NOT = { has_variable = lowborn_legitimacy_cooldown }
+					OR = {
+						NOT = { exists = primary_spouse }
+						primary_spouse ?= scope:secondary_recipient
+					}
+				}
+				if = {
+					limit = { is_ai = no }
+					send_interface_toast = {
+						type = event_toast_effect_good
+						title = married_lowborn_toast
+						left_icon = scope:actor
+						add_legitimacy = {
+							value = medium_legitimacy_loss
+							multiply = scope:actor.primary_title.tier
+						}
+					}
+				}
+				else = { # To avoid destroying polygamy AIs
+					send_interface_toast = {
+						type = event_toast_effect_good
+						title = married_lowborn_toast
+						left_icon = scope:actor
+						add_legitimacy = { value = minor_legitimacy_loss }
+					}
+					hidden_effect = {
+						set_variable = {
+							name = lowborn_legitimacy_cooldown
+							years = 10
+						}
+					}
+				}
+			}
+		}
+		if = {
+			limit = {
+				this = scope:secondary_recipient # We check that you're marrying them yourself
+				scope:secondary_actor = { is_lowborn = yes }
+			}
+			# Vassal dispositions get aggy.
+			## Actual effect applied in the on_marriage on_action.
+			show_as_tooltip = {
+				vassals_dislike_marry_lowborn_effect = {
+					SPOUSE = scope:secondary_actor
+					RULER = scope:actor
+				}
+			}
+			#Legitimacy loss for marrying a lowborn
+			if = {
+				limit = {
+					is_valid_for_legitimacy_change = yes
+					NOT = { has_variable = lowborn_legitimacy_cooldown }
+					OR = {
+						NOT = { exists = primary_spouse }
+						primary_spouse ?= scope:secondary_actor
+					}
+				}
+				if = {
+					limit = { is_ai = no }
+					send_interface_toast = {
+						type = event_toast_effect_good
+						title = married_lowborn_toast
+						left_icon = scope:actor
+						add_legitimacy = {
+							value = medium_legitimacy_loss
+							multiply = scope:actor.primary_title.tier
+						}
+					}
+				}
+				else = { # To avoid destroying polygamy AIs
+					send_interface_toast = {
+						type = event_toast_effect_good
+						title = married_lowborn_toast
+						left_icon = scope:actor
+						add_legitimacy = { value = minor_legitimacy_loss }
+					}
+					hidden_effect = {
+						set_variable = {
+							name = lowborn_legitimacy_cooldown
+							years = 10
+						}
+					}
+				}
+			}
+		}
+		else = { # If they're not a lowborn AND you and the recipient are both Nomad we may give you some Legitimacy
+			if = {
+				limit = {
+					is_valid_for_nomadic_legitimacy_change = yes
+					scope:recipient = { government_has_flag = government_is_nomadic }
+					mpo_lower_nomad_authority_trigger = { CHARACTER = scope:recipient } # Only if recipient has higher Dominance than you
+				}
+				add_legitimacy = medium_legitimacy_gain
+			}
+		}
+	}
+	
+	#No longer Herder
+	if = {
+		limit = {
+			scope:secondary_recipient = {
+				is_landed = yes
+				government_has_flag = government_is_herder
+			}
+		}
+		scope:actor = {
+			switch = {
+				trigger = has_government
+				feudal_government = {
+					scope:secondary_recipient = { change_government = feudal_government }
+				}
+				tribal_government = {
+					scope:secondary_recipient = { change_government = tribal_government }
+				}
+				clan_government = {
+					scope:secondary_recipient = { change_government = clan_government }
+				}
+				nomad_government = {
+					scope:secondary_recipient = { change_government = nomad_government }
+				}
+				administrative_government = {
+					scope:secondary_recipient = { change_government = administrative_government }
+				}
+				landless_adventurer_government = {
+					scope:secondary_recipient = { change_government = landless_adventurer_government }
+				}
+			}
+		}
+	}
+
+	#No longer concubine
+	if = {
+		limit = {
+			scope:secondary_recipient = { is_concubine = yes }
+		}
+		scope:secondary_recipient = {
+			random_consort = {
+				limit = {
+					any_concubine = { this = scope:secondary_recipient }
+				}
+				remove_concubine = scope:secondary_recipient
+			}
+		}
+	}
+	if = {
+		limit = {
+			scope:secondary_actor = { is_concubine = yes }
+		}
+		scope:secondary_actor = {
+			random_consort = {
+				limit = {
+					any_concubine = { this = scope:secondary_actor }
+				}
+				remove_concubine = scope:secondary_actor
+			}
+		}
+	}
+	# A Grand Wedding was promised
+	if = {
+		limit = {
+			scope:grand_wedding_promise = yes
+		}
+		set_grand_wedding_betrothal_variables = {
+			SPOUSE_1 = scope:secondary_actor
+			SPOUSE_2 = scope:secondary_recipient
+			HOST = scope:actor
+			PROMISEE = scope:recipient
+		}
+	}
+
+	#Marriage notification events
+	hidden_effect = {
+		scope:actor = {
+			if = {
+				limit = { NOT = { this = scope:recipient } }
+				trigger_event = marriage_interaction.0010
+			}
+			else = { #In my own court
+				if = {
+					limit = { #Betrothal?
+						OR = {
+							scope:secondary_actor = { is_adult = no }
+							scope:secondary_recipient = { is_adult = no }
+							scope:secondary_actor = { has_been_promised_grand_wedding = yes }
+							scope:secondary_recipient = { has_been_promised_grand_wedding = yes }
+						}
+					}
+					send_interface_toast = {
+						type = event_toast_effect_good
+						title = arrange_marriage_interaction_accept_betrothal_toast
+						left_icon = scope:secondary_actor
+						right_icon = scope:secondary_recipient
+						custom_tooltip  = arrange_marriage_interaction_accept_betrothal_toast_desc
+					}
+				}
+				else = {
+					send_interface_toast = {
+						type = event_toast_effect_good
+						title = arrange_marriage_interaction_accept_toast
+						left_icon = scope:secondary_actor
+						right_icon = scope:secondary_recipient
+						custom_tooltip  = arrange_marriage_interaction_accept_toast_desc
+					}
+				}
+			}
+		}
+
+		# Apply any relevant opinion penalties for relatives of spouse.
+		scope:secondary_actor = {
+			if = { # Polygamy
+				limit = {
+					any_consort = {
+						count >= 2
+					}
+				}
+				every_consort = {
+					# If the spouse themselves does not believe in polygamy...
+					limit = {
+						NOR = {
+							culture = { has_cultural_tradition = tradition_polygamous }
+							faith = { has_doctrine = doctrine_polygamy }
+							faith = { has_doctrine = doctrine_concubines }
+						}
+					}
+
+					#... then family members who also do not believe in polygamy aren't happy about having a relative forced into polygamous union with you.
+					every_close_family_member = {
+						if = {
+							limit = { 
+								NOR = {
+									culture = { has_cultural_tradition = tradition_polygamous }
+									faith = { has_doctrine = doctrine_polygamy }
+									faith = { has_doctrine = doctrine_concubines }
+								}
+							}
+							add_opinion = {
+								target = scope:secondary_actor
+								modifier = relative_in_blasphemous_union_opinion
+							}
+						}
+					}
+
+					# NOTE: Spouse's own opinions handled in the 'on_marriage' code on_action inside of marriage_concubinage.txt, and are not included here.
+				}
+			}
+		}
+		scope:secondary_recipient = {
+			if = { #Same-sex relations
+				limit = {
+					allowed_to_marry_same_sex_trigger = no
+					sex_same_as = scope:secondary_actor
+				}
+				every_close_family_member = {
+					if = {
+						limit = { 
+							allowed_to_marry_same_sex_trigger = no
+						}
+						add_opinion = {
+							target = scope:secondary_actor
+							modifier = relative_in_blasphemous_union_opinion
+						}
+					}
+				}
+			}
+		}
+		# Courtly vassals like grand weddings
+		scope:secondary_actor = {
+			if = {
+				limit = {
+					any_vassal = {
+						has_vassal_stance = courtly
+					}
+				}
+				if = {
+					limit = {
+						has_been_promised_grand_wedding = yes
+					}
+					every_vassal = {
+						limit = {
+							has_vassal_stance = courtly
+						}
+						add_opinion = {
+							target = scope:secondary_actor
+							modifier = prestigious_wedding_opinion
+						}
+					}
+				}
+			}
+		}
+		scope:secondary_recipient = {
+			if = {
+				limit = {
+					any_vassal = {
+						has_vassal_stance = courtly
+					}
+				}
+				if = {
+					limit = {
+						has_been_promised_grand_wedding = yes
+					}
+					every_vassal = {
+						limit = {
+							has_vassal_stance = courtly
+						}
+						add_opinion = {
+							target = scope:secondary_recipient
+							modifier = prestigious_wedding_opinion
+						}
+					}
+				}
+			}
+		}
+	}
+
+	###MANAGEMENT SCRIPT FOR VARIOUS EVENTS/CONTENT###
+	
+	#If your spouse councillor had boosted the chance of marriage, remove modifier
+	if = {
+		limit = {
+			scope:secondary_actor = {
+				has_character_modifier = heir_easier_to_marry_off_modifier
+			}
+			scope:actor = { player_heir = scope:secondary_actor }
+		}
+		scope:secondary_actor = {
+			remove_character_modifier = heir_easier_to_marry_off_modifier
+		}
+	}
+	if = {
+		limit = {
+			scope:secondary_actor = {
+				is_child_of = scope:actor
+				has_character_modifier = child_easier_to_marry_off_modifier
+			}
+		}
+		scope:secondary_actor = {
+			remove_character_modifier = child_easier_to_marry_off_modifier
+		}
+	}
+
+	#AI Break up consideration after marriage
+	scope:secondary_recipient = { 
+		if = {
+			limit = {
+				is_adult = yes
+				is_ai = yes
+			}
+			scope:secondary_actor = { save_scope_as = new_spouse_secondary_actor }
+			trigger_event = lover.0205
+		}
+	}
+	scope:secondary_actor = {
+		if = {
+			limit = {
+				is_adult = yes
+				is_ai = yes
+			}
+			scope:secondary_recipient = { save_scope_as = new_spouse_secondary_recipient }
+			trigger_event = lover.0205
+		}
+	}
+
+	# Struggle parameters
+
+	#interfaith wedding costs piety
+	if = {
+		limit = {
+			scope:secondary_actor = {
+				NOT = { faith = scope:secondary_recipient.faith }
+			}
+			scope:actor ={
+				any_character_struggle = {
+					has_struggle_phase_parameter = interfaith_marriages_between_involved_characters_costs_piety
+				}
+			}
+		}
+		scope:actor = {
+			add_piety = major_piety_loss
+		}
+	}
+	#interfaith wedding provides piety
+	if = {
+		limit = {
+			scope:secondary_actor = {
+				NOT = { faith = scope:secondary_recipient.faith }
+			}
+			scope:actor ={
+				any_character_struggle = {
+					has_struggle_phase_parameter = interfaith_marriages_between_involved_characters_gives_piety
+				}
+			}
+		}
+		scope:actor = {
+			add_piety = medium_piety_gain
+		}
+	}
+
+	#other stuff 
+	#Khurramites and Mazdakists gain piety from marrying lowborn
+	if = {
+		limit = {
+			scope:secondary_recipient = {
+				is_lowborn = yes 
+			}
+			scope:actor.faith = {
+				has_doctrine = tenet_communal_possessions 
+			}
+		}
+		scope:actor = {
+			add_piety = medium_piety_gain
+		}
+	}
+}
+
+concubine_on_accept_effect = {
+	scope:recipient = {
+		trigger_event = marriage_interaction.0040
+		if = {
+			# Victim is angry for being forced into concubinage.
+			limit = {
+				OR = {
+					has_trait = celibate
+					is_imprisoned = yes
+				}
+			}
+			release_from_prison = yes
+			add_opinion = {
+				target = scope:actor
+				modifier = forced_me_concubine_marriage_opinion
+			}
+
+			# Family members of victim are also angry that you've forced them into concubinage.
+			every_close_family_member = {
+				if = {
+					limit = { 
+						NOT = { this = scope:actor } # Don't hate yourself.
+					}
+					add_opinion = {
+						target = scope:actor
+						modifier = forced_family_concubine_marriage_opinion
+					}
+					hidden_effect = {
+						send_interface_message = {
+							type = msg_family_became_concubine
+							title = msg_close_family_member_taken_as_concubine_title
+							right_icon = scope:actor
+							left_icon = scope:secondary_actor
+							show_as_tooltip = { scope:actor = { make_concubine = scope:secondary_actor } }
+						}
+					}
+
+					# Family members are even *more* angry if they don't believe in concubines/polyamory (different from polygamy). Also if they don't accept same-sex relationships
+					if = {
+						limit = { 
+							OR = {
+								NOT = { faith = { has_doctrine = doctrine_concubines } }
+								NOT = { faith = { has_doctrine = tenet_polyamory } }
+								AND = {
+									allowed_to_marry_same_sex_trigger = no
+									scope:recipient = { sex_same_as = scope:secondary_actor }
+								}
+							}
+						}
+						add_opinion = {
+							target = scope:actor
+							modifier = relative_in_blasphemous_union_opinion
+						}
+					}
+				}
+			}	
+
+			# Not up to them anymore...
+			if = {
+				limit = { has_trait = celibate }
+				remove_trait = celibate
+			}			
+					
+			# Spouses, if any exist, are also furious.
+			if = {
+				limit = {
+					is_married = yes
+				}
+				every_spouse = {
+					show_as_tooltip = {
+						add_opinion = {
+							target = scope:actor
+							modifier = forced_spouse_concubine_marriage_opinion
+						}
+						divorce = scope:recipient # no additional opinion hit, no scripted effect
+					}
+					trigger_event = marriage_interaction.0041
+				}
+			}
+					
+			# Stealing concubines pisses the former concubinist off.
+			if = {
+				limit = {
+					is_concubine = yes
+				}
+				this.concubinist = {
+					show_as_tooltip = {
+						add_opinion = {
+							target = scope:secondary_actor
+							modifier = stole_concubine_opinion
+						}
+						remove_concubine = scope:recipient # no additional opinion hit, no scripted effect
+					}
+					trigger_event = marriage_interaction.0041
+				}
+			}
+
+			# Break any betrothals which may exist (without additional opinion penalties).
+			if = {
+				limit = { exists = betrothed }
+				betrothed = { trigger_event = marriage_interaction.0041 }
+				break_betrothal = betrothed
+			}
+
+			# Having concubines means they're now no longer yours.
+			if = {
+				limit = { number_of_concubines > 0	}
+				every_concubine = {
+					scope:recipient = {
+						remove_concubine = prev
+					}
+				}
+			}
+		}
+	}
+
+	# Send us a notification about what we just did.
+	scope:secondary_actor = {
+		hidden_effect = {
+			send_interface_toast = {
+				type = event_toast_effect_neutral
+				title = msg_concubine_taken_title
+				right_icon = scope:recipient
+				make_concubine = scope:recipient
+			}
+		}
+	}
+}
+
+
+#This effect has some small differences to the previous one since this one involves one extra person (the one you give a concubine to)
+concubine_offer_on_accept_effect = {
+	scope:secondary_actor = {
+		trigger_event = marriage_interaction.0040
+		if = {
+			# Victim is angry for being forced into concubinage.
+			limit = {
+				is_imprisoned = yes
+			}
+			add_character_flag = {
+				flag = block_release_from_prison_event
+				days = 3
+			}
+			release_from_prison = yes
+			add_opinion = {
+				target = scope:actor
+				modifier = forced_me_concubine_marriage_opinion
+			}
+
+			# Family members of victim are also angry that you've forced them into concubinage.
+			every_close_family_member = {
+				if = {
+					limit = { 
+						NOT = { this = scope:actor } # Don't hate yourself.
+					}
+					add_opinion = {
+						target = scope:actor
+						modifier = forced_family_concubine_marriage_opinion
+					}
+					hidden_effect = {
+						send_interface_message = {
+							type = msg_family_became_concubine
+							title = msg_close_family_member_taken_as_concubine_title
+							right_icon = scope:actor
+							left_icon = scope:secondary_actor
+							show_as_tooltip = { scope:actor = { make_concubine = scope:secondary_actor } }
+						}
+					}
+
+					# Family members are even *more* angry if they don't believe in concubines/polyamory (different from polygamy). Also if they don't accept same-sex relationships
+					if = {
+						limit = { 
+							OR = {
+								NOT = { faith = { has_doctrine = doctrine_concubines } }
+								NOT = { faith = { has_doctrine = tenet_polyamory } }
+								AND = {
+									allowed_to_marry_same_sex_trigger = no
+									scope:recipient = { sex_same_as = scope:secondary_actor }
+								}
+							}
+						}
+						add_opinion = {
+							target = scope:actor
+							modifier = relative_in_blasphemous_union_opinion
+						}
+					}
+				}
+			}
+					
+			# Spouses, if any exist, are also furious.
+			if = {
+				limit = {
+					is_married = yes
+					#A check to make sure you haven't somehow married them during the consideration time
+					NOT = { any_spouse = { this = scope:recipient } }
+				}
+				every_spouse = {
+					add_opinion = {
+						target = scope:actor
+						modifier = forced_spouse_concubine_marriage_opinion
+					}
+					divorce = scope:secondary_actor # no additional opinion hit, no scripted effect
+					save_scope_value_as = { # For tooltips in the coming event
+						name = was_spouse
+						value = yes
+					}
+					trigger_event = marriage_interaction.0043
+				}
+			}
+					
+			# Stealing concubines pisses the former concubinist off.
+			if = {
+				limit = {
+					is_concubine = yes
+					#A check to make sure you haven't somehow gotten them as concubine during the consideration time
+					NOT = { any_consort = { this = scope:recipient } }
+				}
+				this.concubinist = {
+					if = {
+						limit = {
+							NOT = {
+								this = scope:actor
+							}
+						}
+						add_opinion = {
+							target = scope:actor
+							modifier = stole_concubine_opinion
+						}
+						remove_concubine = scope:secondary_actor # no additional opinion hit, no scripted effect
+						save_scope_value_as = { # For tooltips in the coming event
+							name = was_concubine
+							value = yes
+						}
+						trigger_event = marriage_interaction.0043
+					}
+					else = {
+						remove_concubine = scope:secondary_actor # no additional opinion hit, no scripted effect
+					}
+				}
+			}
+
+			# Break any betrothals which may exist (without additional opinion penalties).
+			if = {
+				limit = {
+					exists = betrothed
+					#A check to make sure you haven't somehow gotten betrothed to them during the consideration time
+					NOT = { betrothed = scope:recipient }
+				}
+				betrothed = { trigger_event = marriage_interaction.0043 }
+				break_betrothal = betrothed
+			}
+
+			# Having concubines means they're now no longer yours.
+			if = {
+				limit = { number_of_concubines > 0	}
+				every_concubine = {
+					scope:secondary_actor = {
+						remove_concubine = prev
+					}
+				}
+			}
+		}
+		if = {
+			limit = {
+				is_concubine_of = scope:actor
+			}
+			scope:actor = {
+				remove_concubine = scope:secondary_actor
+			}
+		}
+		remove_character_flag = has_been_offered_as_concubine
+	}
+
+	# Send us a notification about what we just did. If the secondary_actor somehow ended up as a consort (spouse/concubine) or betrothed to recipient during the consideration time of this request we'll send a message about that instead (should only happen to AI tho)
+	if = {
+		limit = { #Invalidation message
+			scope:secondary_actor = {
+				OR = {
+					any_consort = { count >= 1 }
+					exists = betrothed
+				}
+			}
+		}
+		scope:secondary_actor = {
+			# If they've somehow already become entangled with the recipient we tell this
+			if = {
+				limit = {
+					OR = {
+						is_consort_of = scope:recipient
+						AND = {
+							exists = betrothed
+							betrothed = scope:recipient
+						}
+					}
+				}
+				scope:recipient = {
+					save_scope_as = spouse
+				}
+			}
+			# Else, if they've married or gotten betrothed to someone else, we say this
+			else_if = {
+				limit = {
+					exists = betrothed
+				}
+				betrothed = {
+					save_scope_as = spouse
+				}
+			}
+			else = {
+				random_consort = {
+					limit = {
+						this = scope:secondary_actor.primary_spouse
+					}
+					alternative_limit = {
+						always = yes
+					}
+					save_scope_as = spouse
+				}
+			}
+		}
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_neutral
+				title = msg_concubine_offered_invalidated_title
+				right_icon = scope:recipient
+				left_icon = scope:secondary_actor
+				if = {
+					limit = {
+						scope:secondary_actor = { is_consort_of = scope:spouse }
+					}
+					custom_tooltip = msg_concubine_offered_invalidated_consort
+				}
+				else = {
+					custom_tooltip = msg_concubine_offered_invalidated_betrothed
+				}
+			}
+		}
+		scope:recipient = {
+			send_interface_toast = {
+				type = event_toast_effect_neutral
+				title = msg_concubine_offered_invalidated_recipient_title
+				right_icon = scope:actor
+				left_icon = scope:secondary_actor
+				if = {
+					limit = {
+						scope:secondary_actor = { is_consort_of = scope:spouse }
+					}
+					custom_tooltip = msg_concubine_offered_invalidated_consort
+				}
+				else = {
+					custom_tooltip = msg_concubine_offered_invalidated_betrothed
+				}
+			}
+		}
+	}
+	else = { #Proper notification
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_neutral
+				title = msg_concubine_offered_title
+				right_icon = scope:recipient
+				left_icon = scope:secondary_actor
+				scope:recipient = {
+					make_concubine = scope:secondary_actor
+					if = { #Scale opinion gain a bit depending on how cool the concubine is
+						limit = {
+							scope:secondary_actor = {
+								OR = {
+									has_trait = beauty_good_2
+									has_trait = beauty_good_3
+									num_of_good_genetic_traits > 1
+									has_relation_lover = scope:recipient
+									has_relation_soulmate = scope:recipient
+								}
+								trigger_if = {
+									limit = {
+										is_female = yes
+									}
+									age < define:NChildbirth|MAX_FEMALE_REPRODUCTION_AGE
+								}
+							}
+						}
+						add_opinion = {
+							target = scope:actor
+							modifier = grateful_opinion
+							opinion = 40
+						}
+					}
+					else_if = {
+						limit = {
+							scope:secondary_actor = {
+								OR = {
+									is_lowborn = no
+									has_trait = beauty_good_1
+									num_of_good_genetic_traits > 0
+									has_relation_friend = scope:recipient
+									has_relation_best_friend = scope:recipient
+								}
+								trigger_if = {
+									limit = {
+										is_female = yes
+									}
+									age < define:NChildbirth|MAX_FEMALE_REPRODUCTION_AGE
+								}
+							}
+						}
+						add_opinion = {
+							target = scope:actor
+							modifier = grateful_opinion
+							opinion = 30
+						}
+					}
+					else = {
+						add_opinion = {
+							target = scope:actor
+							modifier = grateful_opinion
+							opinion = 20
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+#This effect has some small differences AGAIN to the previous one since this one has some roles reversed
+demand_concubine_interaction_on_accept_effect = {
+	scope:secondary_actor = {
+		trigger_event = marriage_interaction.0040
+		if = {
+			# Victim is angry for being forced into concubinage.
+			limit = {
+				is_imprisoned = yes
+			}
+			add_character_flag = {
+				flag = block_release_from_prison_event
+				days = 3
+			}
+			release_from_prison = yes
+			add_opinion = {
+				target = scope:actor
+				modifier = forced_me_concubine_marriage_opinion
+			}
+		}
+		
+		# Family members of victim are also angry that you've forced them into concubinage.
+		every_close_family_member = {
+			if = {
+				limit = { 
+					NOT = { this = scope:actor } # Don't hate yourself.
+				}
+				add_opinion = {
+					target = scope:actor
+					modifier = forced_family_concubine_marriage_opinion
+				}
+				hidden_effect = {
+					send_interface_message = {
+						type = msg_family_became_concubine
+						title = msg_close_family_member_taken_as_concubine_title
+						right_icon = scope:actor
+						left_icon = scope:secondary_actor
+						show_as_tooltip = { scope:actor = { make_concubine = scope:secondary_actor } }
+					}
+				}
+
+				# Family members are even *more* angry if they don't believe in concubines/polyamory (different from polygamy). Also if they don't accept same-sex relationships
+				if = {
+					limit = { 
+						OR = {
+							NOT = { faith = { has_doctrine = doctrine_concubines } }
+							NOT = { faith = { has_doctrine = tenet_polyamory } }
+							AND = {
+								allowed_to_marry_same_sex_trigger = no
+								scope:recipient = { sex_same_as = scope:secondary_actor }
+							}
+						}
+					}
+					add_opinion = {
+						target = scope:actor
+						modifier = relative_in_blasphemous_union_opinion
+					}
+				}
+			}
+		}
+				
+		# Spouses, if any exist, are also furious.
+		if = {
+			limit = {
+				is_married = yes
+				#A check to make sure you haven't somehow married them during the consideration time
+				NOT = { any_spouse = { this = scope:actor } }
+			}
+			every_spouse = {
+				if = {
+					limit = {
+						NOT = {
+							this = scope:recipient
+						}
+					}
+					add_opinion = {
+						target = scope:actor
+						modifier = forced_spouse_concubine_marriage_opinion
+					}
+				}
+				divorce = scope:secondary_actor # no additional opinion hit, no scripted effect
+				save_scope_value_as = { # For tooltips in the coming event
+					name = was_spouse
+					value = yes
+				}
+			}
+		}
+				
+		# Stealing concubines pisses the former concubinist off.
+		if = {
+			limit = {
+				is_concubine = yes
+				#A check to make sure you haven't somehow gotten them as concubine during the consideration time
+				NOT = { any_consort = { this = scope:actor } }
+			}
+			this.concubinist = {
+				if = {
+					limit = {
+						NOT = {
+							this = scope:recipient
+						}
+					}
+					add_opinion = {
+						target = scope:actor
+						modifier = stole_concubine_opinion
+					}
+				}
+				remove_concubine = scope:secondary_actor # no additional opinion hit, no scripted effect
+			}
+		}
+
+		# Break any betrothals which may exist (without additional opinion penalties).
+		if = {
+			limit = {
+				exists = betrothed
+				#A check to make sure you haven't somehow gotten betrothed to them during the consideration time
+				NOT = { betrothed = scope:actor }
+			}
+			break_betrothal = betrothed
+		}
+
+		# Having concubines means they're now no longer yours.
+		if = {
+			limit = { number_of_concubines > 0	}
+			every_concubine = {
+				scope:secondary_actor = {
+					remove_concubine = prev
+				}
+			}
+		}
+		
+		if = {
+			limit = {
+				is_concubine_of = scope:recipient
+			}
+			scope:recipient = {
+				remove_concubine = scope:secondary_actor
+			}
+		}
+		remove_character_flag = has_been_offered_as_concubine
+	}
+
+	# Send us a notification about what we just did.
+	scope:actor = {
+		send_interface_toast = {
+			type = event_toast_effect_neutral
+			title = msg_concubine_offered_reversed_title
+			right_icon = scope:recipient
+			left_icon = scope:secondary_actor
+			scope:actor = {
+				make_concubine = scope:secondary_actor
+				if = { #Scale opinion gain a bit depending on how cool the concubine is
+					limit = {
+						scope:secondary_actor = {
+							OR = {
+								has_trait = beauty_good_2
+								has_trait = beauty_good_3
+								num_of_good_genetic_traits > 1
+								has_relation_lover = scope:actor
+								has_relation_soulmate = scope:actor
+							}
+							trigger_if = {
+								limit = {
+									is_female = yes
+								}
+								age < define:NChildbirth|MAX_FEMALE_REPRODUCTION_AGE
+							}
+						}
+					}
+					add_opinion = {
+						target = scope:recipient
+						modifier = grateful_opinion
+						opinion = 40
+					}
+				}
+				else_if = {
+					limit = {
+						scope:secondary_actor = {
+							OR = {
+								is_lowborn = no
+								has_trait = beauty_good_1
+								num_of_good_genetic_traits > 0
+								has_relation_friend = scope:actor
+								has_relation_best_friend = scope:actor
+							}
+							trigger_if = {
+								limit = {
+									is_female = yes
+								}
+								age < define:NChildbirth|MAX_FEMALE_REPRODUCTION_AGE
+							}
+						}
+					}
+					add_opinion = {
+						target = scope:recipient
+						modifier = grateful_opinion
+						opinion = 30
+					}
+				}
+				else = {
+					add_opinion = {
+						target = scope:recipient
+						modifier = grateful_opinion
+						opinion = 20
+					}
+				}
+			}
+		}
+	}
+}
+
+divorce_effect = {
+	$DIVORCER$ = {
+		if = {
+			limit = {
+				any_spouse = {
+					this = $DIVORCEE$
+				}
+			}
+			divorce = $DIVORCEE$
+		}
+		
+		reverse_add_opinion = {
+			modifier = divorced_me_opinion
+			target = $DIVORCEE$
+		}
+	}
+	# Opinion hit
+	$DIVORCEE$ = {
+		every_close_or_extended_family_member = {
+			limit = { NOT = { this = $DIVORCER$ } } # don't hate yourself just because of some incest
+			custom = all_family_members
+			add_opinion = {
+				modifier = divorced_close_kin
+				target = $DIVORCER$
+			}
+		}
+	}
+
+	if = {
+		limit = {
+			$DIVORCER$ = {
+				has_character_modifier = rejected_from_marriage_bed_modifier
+			}
+		}
+		$DIVORCER$ = { remove_character_modifier = rejected_from_marriage_bed_modifier }
+	}
+	if = {
+		limit = {
+			$DIVORCEE$ = {
+				has_character_modifier = rejected_from_marriage_bed_modifier
+			}
+		}
+		$DIVORCEE$ = { remove_character_modifier = rejected_from_marriage_bed_modifier }
+	}
+	
+	if = {
+		limit = { $DIVORCER$ = { has_relation_lover = $DIVORCEE$ } }
+		lover_breakup_effect = {
+			BREAKER = $DIVORCER$
+			LOVER = $DIVORCEE$
+		}			
+	}
+}
+
+less_verbose_divorce_effect = {
+	$DIVORCER$ = {
+		if = {
+			limit = {
+				any_spouse = {
+					this = $DIVORCEE$
+				}
+			}
+			divorce = $DIVORCEE$
+		}
+		
+		hidden_effect = {
+			reverse_add_opinion = {
+				modifier = divorced_me_opinion
+				target = $DIVORCEE$
+			}
+		}
+	}
+	hidden_effect = {
+		# Opinion hit
+		$DIVORCEE$ = {
+			every_close_or_extended_family_member = {
+				limit = { NOT = { this = $DIVORCER$ } } # don't hate yourself just because of some incest
+				custom = all_family_members
+				add_opinion = {
+					modifier = divorced_close_kin
+					target = $DIVORCER$
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				$DIVORCER$ = {
+					has_character_modifier = rejected_from_marriage_bed_modifier
+				}
+			}
+			$DIVORCER$ = { remove_character_modifier = rejected_from_marriage_bed_modifier }
+		}
+		if = {
+			limit = {
+				$DIVORCEE$ = {
+					has_character_modifier = rejected_from_marriage_bed_modifier
+				}
+			}
+			$DIVORCEE$ = { remove_character_modifier = rejected_from_marriage_bed_modifier }
+		}
+	}
+	
+	if = {
+		limit = { $DIVORCER$ = { has_relation_lover = $DIVORCEE$ } }
+		lover_breakup_effect = {
+			BREAKER = $DIVORCER$
+			LOVER = $DIVORCEE$
+		}			
+	}	
+}
+
+marriage_soulmate_exclusivity_confrontation_effect = {
+	$SPOUSE_1$ = { add_to_temporary_list = new_spouses }
+	$SPOUSE_2$ = { add_to_temporary_list = new_spouses }
+
+	every_in_list = {
+		list = new_spouses
+		limit = {
+			any_relation = {
+				type = soulmate
+				NOT = { is_in_list = new_spouses }
+			}
+		}
+		add_character_flag = {
+			flag = can_be_confronted_about_lover_exclusivity
+			days = 1825
+		}
+	}
+}
+
+# CHARACTER = character we check for if they should send a message
+# SPOUSE = the spouse in this divorce
+# scope:reason = flag:script or flag:faith
+send_divorce_notifications_effect = {
+	$CHARACTER$ = {
+		if = {
+			limit = {
+				is_ai = no
+			}
+			switch = {
+				trigger = scope:reason
+				flag:script = {
+					send_interface_message = {
+						type = msg_divorce
+						left_icon = $SPOUSE$
+					}
+				}
+				flag:faith = {
+					send_interface_message = {
+						type = msg_spouse_invalidated
+						left_icon = $SPOUSE$
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_heir_title = {
+					exists = holder
+					holder = { is_ai = no }
+				}
+			}
+			every_heir_title = {
+				limit = {
+					exists = holder
+					holder = { is_ai = no }
+				}
+				holder = {
+					if = {
+						limit = {
+							NOT = { is_in_list = had_notification_sent } 
+						}
+						add_to_list = had_notification_sent
+						switch = {
+							trigger = scope:reason
+							flag:script = {
+								send_interface_message = {
+									type = msg_divorce_player_heir
+									left_icon = $CHARACTER$
+									right_icon = $SPOUSE$
+								}
+							}
+							flag:faith = {
+								send_interface_message = {
+									type = msg_spouse_invalidated_player_heir
+									left_icon = $CHARACTER$
+									right_icon = $SPOUSE$
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+# CHARACTER = character we check for if they should send a message
+# BETROTHED = the other person in the betrothal
+# scope:reason = flag:timeout, flag:death, flag:faith, or flag:script
+send_break_betrothal_notifications_effect = {
+	$CHARACTER$ = {
+		if = {
+			limit = {
+				is_ai = no
+			}
+			switch = {
+				trigger = scope:reason
+				flag:script = {
+					send_interface_message = {
+						type = msg_break_betrothal
+						left_icon = $BETROTHED$
+					}
+				}
+				flag:faith = {
+					send_interface_message = {
+						type = msg_betrothal_invalidated
+						left_icon = $BETROTHED$
+					}
+				}
+				# flag:death is hanlded by normal death management events
+				# flag:timeout is hanlded by caller separately
+			}
+		}
+		else_if = {
+			limit = {
+				any_heir_title = {
+					exists = holder
+					holder = { is_ai = no }
+				}
+			}
+			every_heir_title = {
+				limit = {
+					holder = { is_ai = no }
+				}
+				holder = {
+					if = {
+						limit = {
+							NOT = { is_in_list = had_notification_sent }
+						}
+						add_to_list = had_notification_sent
+						switch = {
+							trigger = scope:reason
+							flag:script = {
+								send_interface_message = {
+									type = msg_break_betrothal_player_heir
+									left_icon = $CHARACTER$
+									right_icon = $BETROTHED$
+								}
+							}
+							flag:faith = {
+								send_interface_message = {
+									type = msg_betrothal_invalidated_player_heir
+									left_icon = $CHARACTER$
+									right_icon = $BETROTHED$
+								}
+							}
+							# flag:death is hanlded by normal death management events
+							# flag:timeout is hanlded by caller separately
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+
+
+# When you take spouses/concubines whose Faith does not permit that union, they will gain opinion penalties.
+# This effect adds/updates/replaces/removes those opinion penalties, as approprite to the current situation.
+update_active_consort_opinion_effect = {
+
+	# If we currently have any existing consort opinion modifiers, check if they should be downgraded from permanent modifiers to decaying modifiers.
+	downgrade_invalid_consort_opinions_effect = { PARTNER = $PARTNER$ }
+
+	if = {
+		# If this opinion change was triggered by being divorced/set-aside, we may still technically be married/joined to PARTNER at this moment, but we won't be very shortly and should skip this step.
+		limit = {
+			NOR = {
+				exists = scope:is_being_divorced
+				exists = scope:is_being_set_aside
+			}
+		}
+
+		# Oterwise, apply any new consort opinion effects that are applicable.
+		if = {
+			# Characters who do not believe in concubinage, but are forced into it, have the harshest opinion penalties.
+			limit = {
+				is_concubine_of = $PARTNER$
+				NOT = { faith = { has_doctrine = doctrine_concubines }}
+				NOT = { culture = { has_cultural_tradition = tradition_concubines } }
+			}
+			if = {
+				# Harshest opinion penalty if they are a concubine but believe in monogamy
+				limit = { faith = { has_doctrine = doctrine_monogamy }}
+				add_opinion = {
+					target = $PARTNER$
+					modifier = concubine_with_monogamous_faith_opinion
+				}
+			}
+			else_if = {
+				# Lesser-but-still-harsh opinion penalty if they are a concubine but believe in polygamy
+				limit = {
+					OR = {
+						culture = { has_cultural_tradition = tradition_polygamous }
+						faith = { has_doctrine = doctrine_polygamy }
+					}
+				}
+				add_opinion = {
+					target = $PARTNER$
+					modifier = concubine_with_polygamous_faith_opinion
+				}
+			}
+		}
+		else_if = {
+			# Characters who are legitimate spouses of their partner, but do not approve of their partner's other spouses/concubines, will have milder opinion penalties.
+			limit = {
+				is_spouse_of = $PARTNER$
+				$PARTNER$ = { any_consort = { count >= 2 }}
+				NOT = { faith = { has_doctrine = doctrine_concubines }}
+				NOT = { faith = { has_doctrine = tenet_polyamory }}
+				NOT = { culture = { has_cultural_tradition = tradition_concubines } }
+			}
+			if = {
+				limit = {
+					$PARTNER$ = { any_concubine = { count >= 1 }}
+				}
+				add_opinion = {
+					target = $PARTNER$
+					modifier = spouse_does_not_believe_in_concubines_opinion
+				}
+				#Remove the opinion modifier if you flip-flop and go get concubines after getting rid of them all...
+				remove_opinion = {
+					target = $PARTNER$
+					modifier = spouse_does_not_believe_in_former_concubines_opinion
+				}
+			}
+			else_if = {
+				limit = {
+					NOR = { 
+						culture = { has_cultural_tradition = tradition_polygamous }
+						faith = { has_doctrine = doctrine_polygamy }
+					}
+				}
+				add_opinion = {
+					target = $PARTNER$
+					modifier = polygamous_marriage_opinion
+				}
+			}
+		}
+		#Same-sex not accepted penalty
+		if = {
+			limit = {
+				allowed_to_marry_same_sex_trigger = no
+				sex_same_as = $PARTNER$
+			}
+			add_opinion = {
+				target = $PARTNER$
+				modifier = same_sex_with_no_acceptance_opinion
+			}
+		}
+	}
+}
+
+# Checks if we have any permanent opinion modifiers which are no longer applicable. If so, downgrade them to decaying opinion modifiers.
+downgrade_invalid_consort_opinions_effect = {
+	if = {
+		limit = {
+			has_opinion_modifier = {
+				modifier = concubine_with_monogamous_faith_opinion
+				target = $PARTNER$
+			}
+			OR = {
+				# We are no longer a concubine of PARTNER...
+				NOT = { is_concubine_of = $PARTNER$ }
+				# ...or will no longer be a concubine of them.
+				trigger_if = {
+					limit = { exists = scope:is_being_set_aside}
+					scope:is_being_set_aside = this
+				}
+
+				# Or, our Faith has changed to permit us being a concubine.
+				faith = { has_doctrine = doctrine_concubines }
+			}
+		}
+		remove_opinion = {
+			modifier = concubine_with_monogamous_faith_opinion
+			target = $PARTNER$
+		}
+		add_opinion = {
+			modifier = formerly_concubine_with_monogamous_faith_opinion
+			target = $PARTNER$
+		}
+	}
+
+	if = {
+		limit = {
+			has_opinion_modifier = {
+				modifier = concubine_with_polygamous_faith_opinion
+				target = $PARTNER$
+			}
+			OR = {
+				# We are no longer a concubine of PARTNER...
+				NOT = { is_concubine_of = $PARTNER$ }
+				# ...or will no longer be a concubine of them.
+				trigger_if = {
+					limit = { exists = scope:is_being_set_aside}
+					scope:is_being_set_aside = this
+				}
+
+				# Or, our Faith has changed to permit us being a concubine.
+				faith = { has_doctrine = doctrine_concubines }
+			}
+		}
+		remove_opinion = {
+			modifier = concubine_with_polygamous_faith_opinion
+			target = $PARTNER$
+		}
+		add_opinion = {
+			modifier = formerly_concubine_with_polygamous_faith_opinion
+			target = $PARTNER$
+		}
+	}
+
+	if = {
+		limit = {
+			has_opinion_modifier = {
+				modifier = spouse_does_not_believe_in_concubines_opinion
+				target = $PARTNER$
+			}
+			OR = {
+				# We are no longer married to PARTNER...
+				NOT = { is_spouse_of = $PARTNER$ }
+				# ...or will no longer be married to them.
+				trigger_if = {
+					limit = { exists = scope:is_being_divorced}
+					scope:is_being_divorced = this
+				}
+
+				# Or, the offending relationship no longer exists.
+				$PARTNER$ = { any_concubine = {	count = 0 }}
+				AND = {
+					# The last remaining concubine is being set aside, leaving none.
+					exists = scope:is_being_set_aside
+					$PARTNER$ = { any_concubine = { count = 1 }}
+				}
+
+				# Or, our Faith has changed to permit the relationship.
+				faith = { has_doctrine = doctrine_concubines }
+				faith = { has_doctrine = tenet_polyamory }
+			}
+		}
+		remove_opinion = {
+			modifier = spouse_does_not_believe_in_concubines_opinion
+			target = $PARTNER$
+		}
+		add_opinion = {
+			modifier = spouse_does_not_believe_in_former_concubines_opinion
+			target = $PARTNER$
+		}
+	}
+
+	if = {
+		limit = {
+			has_opinion_modifier = {
+				modifier = polygamous_marriage_opinion
+				target = $PARTNER$
+			}
+			OR = {
+				# We are no longer married to PARTNER...
+				NOT = { is_spouse_of = $PARTNER$ }
+				# ...or will no longer be married to them.
+				trigger_if = {
+					limit = { exists = scope:is_being_divorced}
+					scope:is_being_divorced = this
+				}
+
+				# Or, the offending relationship no longer exists.
+				$PARTNER$ = { any_spouse = { count = 1 }}
+				AND = {
+					# One of the 2 remaining spouses will be divorced next tick, leaving only 1.
+					exists = scope:is_being_divorced 
+					$PARTNER$ = { any_spouse = { count = 2 }}
+				}
+
+				# Or, our Faith has changed to permit the relationship.
+				faith = { has_doctrine = doctrine_concubines }
+				culture = { has_cultural_tradition = tradition_polygamous }
+				faith = { has_doctrine = doctrine_polygamy }
+				faith = { has_doctrine = tenet_polyamory }
+			}
+		}
+		remove_opinion = {
+			modifier = polygamous_marriage_opinion
+			target = $PARTNER$
+		}
+		add_opinion = {
+			modifier = former_polygamous_marriage_opinion
+			target = $PARTNER$
+		}
+	}
+
+	if = {
+		limit = {
+			has_opinion_modifier = {
+				modifier = same_sex_with_no_acceptance_opinion
+				target = $PARTNER$
+			}
+			OR = {
+				# We are no partner of PARTNER...
+				NOT = { is_consort_of = $PARTNER$ }
+				# ...or will no longer be married to them
+				trigger_if = {
+					limit = { exists = scope:is_being_divorced}
+					scope:is_being_divorced = this
+				}
+				# ...or will no longer be a concubine of them
+				trigger_if = {
+					limit = { exists = scope:is_being_set_aside}
+					scope:is_being_set_aside = this
+				}
+
+				# Or, the offending relationship no longer exists.
+				sex_opposite_of = $PARTNER$
+
+				# Or, our Faith has changed to permit the relationship.
+				allowed_to_marry_same_sex_trigger = yes
+			}
+		}
+		remove_opinion = {
+			modifier = same_sex_with_no_acceptance_opinion
+			target = $PARTNER$
+		}
+		add_opinion = {
+			modifier = former_same_sex_with_no_acceptance_opinion
+			target = $PARTNER$
+		}
+	}
+}
+
+##### EP2 - You promised a Grand Wedding and failed to deliver it
+break_grand_wedding_betrothal_effect = {
+	# Uniform the scopes between breaking a betrothal with the interaction and saying no at the altar
+	if = {
+		limit = {
+			exists = scope:spouse_1
+			exists = scope:spouse_2
+		}
+		scope:spouse_1 = { save_scope_as = rejecting_betrothed }
+		scope:spouse_2 = { save_scope_as = rejected_betrothed }
+		root = { save_scope_as = actor }
+	}
+	scope:rejecting_betrothed.var:promised_grand_wedding_by ?= {
+		save_scope_as = promising_host
+	}
+	# Save the offended party
+	scope:rejected_betrothed = {
+		if = {
+			limit = {
+				matchmaker = {
+					NOT = { this = scope:rejected_betrothed }
+				}
+			}
+			matchmaker = { save_scope_as = rejected_betrothal_owner }
+		}
+		else = { #The betrothed accepted the wedding for themselves
+			save_scope_as = rejected_betrothal_owner
+		}
+	}
+	# First of all, the betrothal is broken
+	scope:rejecting_betrothed = {
+		break_betrothal = scope:rejected_betrothed
+	}
+	# If an alliance was connected to this, the alliance is broken
+	if = {
+		limit = {
+			yields_alliance = {
+				candidate = scope:rejecting_betrothed
+				target = scope:rejected_betrothal_owner
+				target_candidate = scope:rejected_betrothed
+			}
+		}
+		break_alliance = scope:rejected_betrothal_owner
+	}
+	# Opinion hit if there were no legitimate reason
+	scope:rejected_betrothed = {
+		if = {
+			limit = {
+				is_eunuch_trigger = no
+				scope:rejecting_betrothed = { is_eunuch_trigger = no }
+				NOR = {
+					scope:rejecting_betrothed = {
+						allowed_to_marry_same_sex_trigger = no
+						sex_same_as = scope:rejected_betrothed
+					}
+					AND = {
+						allowed_to_marry_same_sex_trigger = no
+						sex_same_as = scope:rejecting_betrothed
+					}
+				}
+			}
+			add_opinion = {
+				target = scope:actor
+				modifier = broke_betrothal_grand_wedding_opinion
+				opinion = -50
+			}
+			
+			if = {
+				limit = {
+					scope:rejecting_betrothed = {
+						NOT = { this = scope:actor }
+					}
+				}
+				
+				add_opinion = {
+					target = scope:rejecting_betrothed
+					modifier = broke_betrothal_grand_wedding_opinion
+					opinion = -50
+				}
+			}
+			if = {
+				limit = {
+					NOT = { this = scope:rejected_betrothal_owner }
+				}
+				scope:rejected_betrothal_owner = {
+					add_opinion = {
+						target = scope:actor
+						modifier = broke_betrothal_grand_wedding_opinion
+						opinion = -50
+					}
+						
+					if = {
+						limit = {
+							scope:rejecting_betrothed = {
+								NOT = { this = scope:actor }
+							}
+						}
+						
+						add_opinion = {
+							target = scope:rejecting_betrothed
+							modifier = broke_betrothal_grand_wedding_opinion
+							opinion = -50
+						}
+					}
+				}
+			}
+		}
+	}
+	# Regular Break Betrothal has a standard loss of prestige, but we need more
+	add_prestige_level = -1
+	if = {
+		limit = {
+			OR = {
+				scope:rejected_betrothed = { highest_held_title_tier = tier_empire }
+				scope:rejected_betrothal_owner = { highest_held_title_tier = tier_empire }
+			}
+			
+		}
+		add_prestige = monumental_prestige_loss
+	}
+
+	else_if = {
+		limit = {
+			OR = {
+				scope:rejected_betrothed = { highest_held_title_tier = tier_kingdom }
+				scope:rejected_betrothal_owner = { highest_held_title_tier = tier_kingdom }
+			}
+		}
+		add_prestige = massive_prestige_loss
+	}
+
+	else_if = {
+		limit = {
+			OR = {
+				scope:rejected_betrothed = { highest_held_title_tier = tier_duchy }
+				scope:rejected_betrothal_owner = { highest_held_title_tier = tier_duchy }
+			}
+		}
+		add_prestige = major_prestige_loss
+	}
+
+	else_if = {
+		limit = {
+			OR = {
+				scope:rejected_betrothed = { highest_held_title_tier = tier_county }
+				scope:rejected_betrothal_owner = { highest_held_title_tier = tier_county }
+			}
+		}
+		add_prestige = medium_prestige_loss
+	}
+
+	else_if = {
+		limit = {
+			OR = {
+				scope:rejected_betrothed = { highest_held_title_tier = tier_barony }
+				scope:rejected_betrothal_owner = { highest_held_title_tier = tier_barony }
+			}
+		}
+		add_prestige = minor_prestige_loss
+	}
+	else = { add_prestige = miniscule_prestige_loss }
+	# Start a Feud, if possible!
+	if = {
+		limit = {
+			has_dlc_feature = friends_and_foes
+			exists = scope:rejected_betrothal_owner.house.house_head
+			exists = scope:rejecting_betrothed.house.house_head
+			NOT = { scope:rejected_betrothal_owner.house = scope:rejecting_betrothed.house }
+		}
+		scope:rejected_betrothal_owner.house.house_head = {
+			if = { 
+				limit = { this = scope:rejected_betrothed } # Rejected betrothed is also House Head
+				house_feud_start_effect = {
+					# Feuding House Head
+					ACTOR = scope:rejected_betrothal_owner.house.house_head
+					# Target House Head
+					TARGET = scope:rejecting_betrothed.house.house_head
+					# Feud Reason
+					REASON = head_broke_gw_betrothal
+					# House Member attacker if relevant 
+					ATTACKER = scope:rejecting_betrothed
+					# House Member victim if relevant
+					VICTIM = scope:rejected_betrothed
+				}
+			}
+			else = {
+				house_feud_start_effect = {
+					# Feuding House Head
+					ACTOR = scope:rejected_betrothal_owner.house.house_head
+					# Target House Head
+					TARGET = scope:rejecting_betrothed.house.house_head
+					# Feud Reason
+					REASON = family_broke_gw_betrothal
+					# House Member attacker if relevant 
+					ATTACKER = scope:rejecting_betrothed
+					# House Member victim if relevant
+					VICTIM = scope:rejected_betrothed
+				}
+			}
+		}
+	}
+	# If you say no at the altar, there are some extra consequences
+	if = {
+		limit = {
+			scope:rejecting_betrothed = { has_character_flag = grand_wedding_said_no }
+		}
+		scope:rejecting_betrothed = {
+			give_nickname = nick_the_naysayer
+			if = {
+				limit = {
+					NOT = { this = scope:actor }
+				}
+				reverse_add_opinion = {
+					target = scope:actor
+					modifier = challenged_authority_opinion
+				}
+			}
+		}
+	}
+	# Finally, the promise is wiped off
+	scope:rejecting_betrothed = {
+		var:promised_grand_wedding_by = {
+			remove_variable = promised_grand_wedding_marriage_countdown
+		}
+		remove_variable = promised_grand_wedding_by
+	}
+	scope:rejected_betrothed = {
+		remove_variable = promised_grand_wedding_by
+	}
+}

--- a/common/scripted_effects/00_marriage_interaction_effects.txt
+++ b/common/scripted_effects/00_marriage_interaction_effects.txt
@@ -587,6 +587,19 @@ concubine_on_accept_effect = {
 
 #This effect has some small differences to the previous one since this one involves one extra person (the one you give a concubine to)
 concubine_offer_on_accept_effect = {
+	#Unop Warning for multiple concubine offers
+	if = {
+		limit = {
+			scope:recipient = {
+				has_opinion_modifier = {
+					target = scope:actor
+					modifier = unop_offer_concubine_opinion
+				}
+			}
+		}
+		custom_tooltip = ALREADY_OFFERED_CONCUBINE_WARNING
+	}
+
 	scope:secondary_actor = {
 		trigger_event = marriage_interaction.0040
 		if = {

--- a/common/scripted_effects/00_marriage_interaction_effects.txt
+++ b/common/scripted_effects/00_marriage_interaction_effects.txt
@@ -839,7 +839,7 @@ concubine_offer_on_accept_effect = {
 						}
 						add_opinion = {
 							target = scope:actor
-							modifier = grateful_opinion
+							modifier = unop_offer_concubine_opinion #Unop Use custom non-stacking opinion, as for other gifts
 							opinion = 40
 						}
 					}
@@ -863,14 +863,14 @@ concubine_offer_on_accept_effect = {
 						}
 						add_opinion = {
 							target = scope:actor
-							modifier = grateful_opinion
+							modifier = unop_offer_concubine_opinion #Unop Use custom non-stacking opinion, as for other gifts
 							opinion = 30
 						}
 					}
 					else = {
 						add_opinion = {
 							target = scope:actor
-							modifier = grateful_opinion
+							modifier = unop_offer_concubine_opinion #Unop Use custom non-stacking opinion, as for other gifts
 							opinion = 20
 						}
 					}
@@ -1050,7 +1050,7 @@ demand_concubine_interaction_on_accept_effect = {
 					}
 					add_opinion = {
 						target = scope:recipient
-						modifier = grateful_opinion
+						modifier = pleased_opinion #Unop Same opinion as in demand_courtier_interaction
 						opinion = 40
 					}
 				}
@@ -1074,14 +1074,14 @@ demand_concubine_interaction_on_accept_effect = {
 					}
 					add_opinion = {
 						target = scope:recipient
-						modifier = grateful_opinion
+						modifier = pleased_opinion #Unop Same opinion as in demand_courtier_interaction
 						opinion = 30
 					}
 				}
 				else = {
 					add_opinion = {
 						target = scope:recipient
-						modifier = grateful_opinion
+						modifier = pleased_opinion #Unop Same opinion as in demand_courtier_interaction
 						opinion = 20
 					}
 				}

--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -185,3 +185,6 @@
  local_holding_type_capitalized_herder_holding: "$game_concept_herder_holding$"
 
  ATTACKING_TRIBUTARY: "\n#S Attacking a [tributary|E] will break the [tributary_contract|E]#!"
+
+ unop_offer_concubine_opinion:0 "Received Concubine"
+ unop_offer_courtier_opinion:0 "Received Courtier"

--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -188,3 +188,6 @@
 
  unop_offer_concubine_opinion:0 "Received Concubine"
  unop_offer_courtier_opinion:0 "Received Courtier"
+
+ ALREADY_OFFERED_CONCUBINE_WARNING:0 "@warning_icon! #X You have already offered a [concubine|E] to [recipient.GetShortUIName], sending another one will #underline override#! the existing [opinion|E] modifier!#!"
+ ALREADY_OFFERED_COURTIER_WARNING:0 "@warning_icon! #X You have already offered a [courtier|E] to [recipient.GetShortUIName], sending another one will #underline override#! the existing [opinion|E] modifier!#!"


### PR DESCRIPTION
* Make opinions types when offering or demanding courtiers and concubines consistent (e.g. `annoyed_opinion`, `pleased_opinion`, etc.)
* Make sure that opinion gains from repeatedly offering courtiers or concubines don't stack by using a custom opinion type, similarly to gifts. I regard this as a bug fix, since without it the player can gain unlimited opinion with particular rulers, especially since you can often get the courtier back via "invite to court".
* Fix a few ck3-tiger errors in the newly added files