### PR TITLE
Adapt to ck3 1.16.1

### DIFF
--- a/common/character_interactions/00_tributary_interactions.txt
+++ b/common/character_interactions/00_tributary_interactions.txt
@@ -590,6 +590,7 @@ demand_tributary_interaction = {
 		
 		modifier = {
 			scope:actor = { is_gurkhan = yes }
+			scope:recipient = { government_has_flag = government_is_nomadic }
 			add = 20
 			desc = gurkhan_interaction_reason
 		}
@@ -605,6 +606,7 @@ demand_tributary_interaction = {
 					}
 				}
 			}
+			scope:recipient = { government_has_flag = government_is_nomadic }
 			add = 25
 			desc = zud_season_reason
 		}
@@ -621,7 +623,7 @@ demand_tributary_interaction = {
 			trigger = {
 				scope:recipient = { highest_held_title_tier = tier_kingdom }
 			}
-			add = -20
+			add = -100
 		}
 
 		modifier = { # They are an Emperor or greater
@@ -629,7 +631,7 @@ demand_tributary_interaction = {
 			trigger = {
 				scope:recipient = { highest_held_title_tier >= tier_empire }
 			}
-			add = -50
+			add = -200
 		}
 
 		modifier = { # Recipient has higher Dominance than the actor
@@ -643,6 +645,7 @@ demand_tributary_interaction = {
 		modifier = { # Actor has higher Dominance than the recipient
 			desc = demand_tributary_interaction_aibehavior_dominance_tt
 			trigger = {
+				scope:recipient = { government_has_flag = government_is_nomadic }
 				scope:actor.dominance_value > scope:recipient.dominance_value
 			}
 			add = 20
@@ -678,6 +681,26 @@ demand_tributary_interaction = {
 			add = 25
 		}
 
+		# Non-nomadic
+		modifier = {
+			desc = AI_FILTHY_HORSE_LORD_REASON
+			trigger = {
+				scope:actor = { government_has_flag = government_is_nomadic }
+				scope:recipient = {
+					NOT = { government_has_flag = government_is_nomadic }
+				}
+			}
+			add = {
+				value = -50
+				if = {
+					limit = {
+						scope:recipient = { government_has_flag = government_is_tribal }
+					}
+					multiply = 0.5
+				}
+			}
+		}
+
 		# MINOR
 		modifier = { # Rivalry modifier.
 			desc = offer_vassalization_interaction_aibehavior_rival_tt
@@ -687,7 +710,7 @@ demand_tributary_interaction = {
 					NOT = { has_relation_nemesis = scope:actor }
 				}
 			}
-			add = -10
+			add = -100
 		}
 		modifier = { # Nemesis modifier.
 			desc = offer_vassalization_interaction_aibehavior_nemesis_tt
@@ -696,7 +719,7 @@ demand_tributary_interaction = {
 					has_relation_nemesis = scope:actor
 				}
 			}
-			add = -30
+			add = -200
 		}
 		modifier = { # Same Dynasty modifier.
 			desc = offer_vassalization_interaction_aibehavior_dynasty_tt

--- a/common/script_values/07_ep3_values.txt
+++ b/common/script_values/07_ep3_values.txt
@@ -4110,7 +4110,7 @@ gold_refill_value = {
 				government_has_flag = government_is_nomadic
 			}
 		}
-		multiply = 4
+		multiply = 1.5
 	}
 	if = {
 		limit = {
@@ -4148,7 +4148,7 @@ gold_refill_value_tt = {
 		limit = {
 			government_has_flag = government_is_nomadic
 		}
-		multiply = 4
+		multiply = 1.5
 	}
 	if = {
 		limit = {

--- a/common/scripted_effects/00_scheme_scripted_effects.txt
+++ b/common/scripted_effects/00_scheme_scripted_effects.txt
@@ -16471,4 +16471,8 @@ steal_herd_failure_effect = {
 			modifier = attempted_to_steal_herd_crime
 		}
 	}
+	#Lose some prestige
+	scope:owner = {
+		add_prestige = minor_prestige_loss
+	}
 }

--- a/gfx/portraits/portrait_modifiers/00_custom_special.txt
+++ b/gfx/portraits/portrait_modifiers/00_custom_special.txt
@@ -31,7 +31,8 @@ custom_special_crowns_crests = {
 	add_accessory_modifiers = {
 		gene = additive_headgear
 		template = no_additive
-	} #Unop ck3-tiger Split into two add_accessory_modifiers
+	}
+
 	add_accessory_modifiers = {
 		gene = secondary_headgears
 		template = no_headgear


### PR DESCRIPTION
Adapt to changes in CK3 1.16.1. I am doing it by using a script to generate the list of all Unop files, then comparing it against the list of changed files published in Steam (see e.g. https://steamdb.info/patchnotes/18358489/) after making sure both are uniformly sorted to identify all changed files. Then I diff all files in the list against the base game files and merge in all changes that are not marked with `#Unop`.

This method should be reliable, but it won't identify relevant localization changes due to the way Unop manages localization.