### PR TITLE
Fix pool characters marriage malus for nomadic rulers

### DIFF
--- a/common/scripted_modifiers/00_marriage_scripted_modifiers.txt
+++ b/common/scripted_modifiers/00_marriage_scripted_modifiers.txt
@@ -2044,6 +2044,7 @@
 			government_has_flag = government_is_nomadic
 		}
 		scope:recipient = {
+			is_ruler = yes #Unop prevent this malus for pool characters
 			NOR = { 
 				government_has_flag = government_is_nomadic
 				government_has_flag = government_is_tribal
@@ -2066,6 +2067,7 @@
 			government_has_flag = government_is_nomadic
 		}
 		scope:recipient = {
+			is_ruler = yes #Unop prevent this malus for pool characters
 			NOT = { government_has_flag = government_is_nomadic }
 			OR = {
 				government_has_flag = government_is_tribal


### PR DESCRIPTION
Fixes the following bug:

* Try to marry one of your courtiers to a pool character of your religion and culture living nearby.
* They get -100 malus because "you are a filthy horse lord". What?

I believe this malus is intended for rulers only, hence the government check. The check however also fails for pool characters, so an explicit `is_ruler = yes` check is needed.