### PR TITLE
Fix request_court_position and grant_court_position interaction UI

### DIFF
--- a/gui/interaction_court_task.gui
+++ b/gui/interaction_court_task.gui
@@ -1,0 +1,344 @@
+﻿window = {
+	name = "court_task_interaction_window"
+	size = { 650 700 }
+	datacontext = "[CourtTaskInteractionWindow.GetCharacterInteractionConfirmationWindow]"
+	parentanchor = center
+	layer = middle
+
+	using = Window_Movable
+	using = Window_Background
+	using = Window_Decoration_Spike
+
+	state = {
+		name = _show
+		using = Animation_FadeIn_Quick
+		using = Sound_WindowShow_Standard
+	}
+
+	state = {
+		name = _hide
+		using = Animation_FadeOut_Quick
+		using = Sound_WindowHide_Standard
+	}
+
+	vbox = {
+		using = Window_Margins
+
+
+		hbox = {
+			margin_bottom = -10
+			layoutpolicy_horizontal = expanding
+
+			header_pattern_interaction = {
+				layoutpolicy_horizontal = expanding
+
+				blockoverride "header_text"
+				{
+					text = "[CourtTaskInteractionWindow.GetSelectedPositionHeader]"
+				}
+
+				blockoverride "button_close"
+				{
+					onclick = "[CourtTaskInteractionWindow.Close]"
+				}
+
+				icon_character_interaction = {}
+			}
+		}
+
+		vbox = {
+			layoutpolicy_horizontal = expanding
+
+			hbox = {
+				name = "portraits"
+				layoutpolicy_horizontal = expanding
+				size = { 0 160 }
+				margin = { 25 5 }
+				margin_top = 10
+
+				background = {
+					texture = "gfx/interface/illustrations/event_scenes/councilchamber.dds"
+					alpha = 0.5
+					fittype = centercrop
+					using = Mask_Rough_Edges
+				}
+
+				### LEFT ACTOR
+				portrait_shoulders = {
+					name = "left_background_portrait"
+					datacontext = "[CharacterInteractionConfirmationWindow.GetActor]"
+					visible = "[Character.IsValid]"
+					tooltip_visible = "[Character.IsValid]"
+				}
+
+				vbox = {
+					layoutpolicy_horizontal = expanding
+					layoutpolicy_vertical = expanding
+					size = { 330 160 }
+
+					text_multi = {
+						name = "select_position_label"
+						visible = "[Not( CourtTaskInteractionWindow.HasSelectedPosition )]"
+						layoutpolicy_horizontal = expanding
+						text = "COURT_TASK_INTERACTION_WINDOW_SELECT_TASK"
+						autoresize = yes
+						max_width = 260
+						default_format = "#instruction"
+						align = center|nobaseline
+
+						background = {
+							using = Text_Label_Background
+							margin = { 0 3 }
+							margin_bottom = 5
+						}
+					}
+
+					text_multi = {
+						name = "selected_position_label"
+						visible = "[CourtTaskInteractionWindow.HasSelectedPosition]"
+						layoutpolicy_horizontal = expanding
+						autoresize = yes
+						max_width = 260
+						align = center|nobaseline
+						text = "COURT_TASK_INTERACTION_WINDOW_SELECTED_TASK"
+
+						background = {
+							using = Text_Label_Background
+							margin = { 0 3 }
+							margin_bottom = 5
+						}
+					}
+					expand = {}
+				}
+
+				### RIGHT RECIPIENT
+				portrait_shoulders = {
+					name = "right_background_portrait"
+					datacontext = "[CharacterInteractionConfirmationWindow.GetRecipient]"
+					visible = "[Character.IsValid]"
+					tooltip_visible = "[Character.IsValid]"
+
+					blockoverride "portrait_transformation"
+					{
+						portrait_scale = { -1 1 }
+						portrait_offset = { 1 0 }
+					}
+				}
+			}
+		}
+
+		scrollbox = {
+			name = "court_positions"
+			layoutpolicy_horizontal = expanding
+			layoutpolicy_vertical = expanding
+
+			blockoverride "scrollbox_content" {
+				vbox = {
+					margin = { 5 5 }
+				
+					layoutpolicy_horizontal = expanding
+					layoutpolicy_vertical = expanding
+
+					vbox = {
+						datamodel = "[CourtTaskInteractionWindow.AccessPositions]"
+						layoutpolicy_horizontal = expanding
+						spacing = 5
+						
+						item = {
+							select_court_position_button = {}
+						}
+					}
+					expand = {}
+				}
+			}
+		}
+		vbox = {
+			margin = { 0 10 }
+			margin_bottom = 15
+			
+			vbox_interaction_options = {
+				layoutpolicy_horizontal = expanding
+			}
+
+			hbox_character_interaction_acceptance = {
+				layoutpolicy_horizontal = expanding
+				margin = { 0 4 }
+			}
+
+			### SEND OFFER BUTTON
+			button_primary = {
+				name = "send_offer_button"
+				size = { 400 42 }
+				onclick = "[CourtTaskInteractionWindow.Send]"
+				enabled = "[CourtTaskInteractionWindow.CanSendOffer]"
+
+				text = "[CharacterInteractionConfirmationWindow.GetSendName]"
+				using = Font_Size_Medium
+
+				tooltip = "[CourtTaskInteractionWindow.GetSendOfferTooltip]"
+			}
+			expand = {}
+		}
+	}
+}
+
+types CourtPositionButton
+{
+	type select_court_position_button = button_standard_clean {
+		layoutpolicy_horizontal = expanding
+		datacontext = "[CourtTaskInteractionItem.GetCourtPosition]"
+		onclick = "[CourtTaskInteractionItem.Select]"
+		down = "[ObjectsEqual( CourtPositionType.Self, CourtTaskInteractionWindow.GetSelectedPosition )]"
+
+		vbox = {
+			name = "position"
+			margin = { 10 0 }
+			spacing = 4
+			set_parent_size_to_minimum = yes
+
+			spacer = {
+				size = { 510 0 }
+			}
+
+			vbox = {
+				layoutpolicy_horizontal = expanding
+				spacing = 4
+
+				hbox = {
+					margin_bottom = 4
+					layoutpolicy_horizontal = expanding
+					icon = {
+						texture = "[CourtPositionType.GetIcon]"
+						size = { 40 40 }
+					}
+					vbox = {
+						text_single = {
+							layoutpolicy_horizontal = expanding
+							margin_left = 8
+
+							name = "position_label"
+							alwaystransparent = yes
+							text = "[CourtPositionType.GetName]"
+							using = Font_Size_Medium
+							align = nobaseline
+						}
+						text_single = {
+							visible = "[Not(ObjectsEqual( GetPlayer.Self, CharacterInteractionConfirmationWindow.GetActor.Self ))]"
+							datacontext = "[CharacterInteractionConfirmationWindow.GetRecipient]"
+							layoutpolicy_horizontal = expanding
+							margin_top = -2
+							margin_left = 2
+
+							name = "aptitude_label_1"
+							alwaystransparent = yes
+							text = "[Character.GetCourtPositionAptitude( CourtPositionType.Self )]"
+							align = nobaseline
+						}
+						text_single = {
+							visible = "[ObjectsEqual( GetPlayer.Self, CharacterInteractionConfirmationWindow.GetActor.Self )]"
+							datacontext = "[CharacterInteractionConfirmationWindow.GetActor]"
+							layoutpolicy_horizontal = expanding
+							margin_top = -2
+							margin_left = 2
+
+							name = "aptitude_label_2"
+							alwaystransparent = yes
+							text = "[Character.GetCourtPositionAptitude( CourtPositionType.Self )]"
+							align = nobaseline
+						}
+					}
+					expand = {}
+					text_single = {
+						margin_top = -4
+						default_format = "#high"
+						using = tooltip_ne
+						text = "[CourtPositionType.GetSalaryTextFor( GetPlayer )]"
+						tooltip = "[CourtPositionType.GetSalaryBreakdownFor( GetPlayer )]"
+						alwaystransparent = yes
+					}
+				}
+			}
+
+			#divider_light = {
+			#	layoutpolicy_horizontal = growing
+			#}
+			#
+			#text_multi = {
+			#	name = "employer_modifier_header"
+			#	layoutpolicy_horizontal = expanding
+			#	layoutpolicy_vertical = expanding
+			#	margin = { 8 4 }
+			#	alwaystransparent = yes
+			#
+			#	minimumsize = { 340 50 }
+			#	maximumsize = { 440 150 }
+			#	autoresize = yes
+			#	default_format = "#S"
+			#
+			#	align = bottom|left|nobaseline
+			#	text = "COURT_POSITION_TOOLTIP_EFFECT_ON_LIEGE"
+			#}
+			#
+			#text_multi = {
+			#	name = "employer_modifier_description"
+			#	layoutpolicy_horizontal = expanding
+			#	layoutpolicy_vertical = expanding
+			#	margin = { 8 4 }
+			#	alwaystransparent = yes
+			#
+			#	minimumsize = { 340 50 }
+			#	maximumsize = { 440 150 }
+			#	autoresize = yes
+			#
+			#	align = top|left|nobaseline
+			#	text = "[CourtPositionType.GetEmployerModifierDescription]"
+			#}
+			#
+			#text_multi = {
+			#	name = "employee_modifier_header"
+			#	layoutpolicy_horizontal = expanding
+			#	layoutpolicy_vertical = expanding
+			#	margin = { 8 4 }
+			#	alwaystransparent = yes
+			#
+			#	minimumsize = { 340 50 }
+			#	maximumsize = { 440 150 }
+			#	autoresize = yes
+			#	default_format = "#S"
+			#
+			#	align = bottom|left|nobaseline
+			#	text = "COURT_POSITION_TOOLTIP_EFFECT_ON_HOLDER"
+			#}
+			#
+			#text_multi = {
+			#	name = "employee_modifier_description"
+			#	layoutpolicy_horizontal = expanding
+			#	layoutpolicy_vertical = expanding
+			#	margin = { 8 4 }
+			#	alwaystransparent = yes
+			#
+			#	minimumsize = { 340 50 }
+			#	maximumsize = { 440 150 }
+			#	autoresize = yes
+			#
+			#	align = top|left|nobaseline
+			#	text = "[CourtPositionType.GetEmployeeModifierDescription]"
+			#}
+			#
+			#text_multi = {
+			#	name = "liege_court_modifiers"
+			#	visible = "[CourtPositionType.HasLiegeCourtModifiers]"
+			#	layoutpolicy_horizontal = expanding
+			#	layoutpolicy_vertical = expanding
+			#	margin = { 8 4 }
+			#
+			#	minimumsize = { 340 50 }
+			#	maximumsize = { 440 150 }
+			#	autoresize = yes
+			#
+			#	align = top|left|nobaseline
+			#	text = "COURT_POSITION_TYPE_EMPLOYER_COURT_EFFECTS"
+			#}
+		}
+	}
+}

--- a/gui/interaction_court_task.gui
+++ b/gui/interaction_court_task.gui
@@ -224,7 +224,7 @@ types CourtPositionButton
 						}
 						text_single = {
 							visible = "[Not(ObjectsEqual( GetPlayer.Self, CharacterInteractionConfirmationWindow.GetActor.Self ))]"
-							datacontext = "[CharacterInteractionConfirmationWindow.GetRecipient]"
+							datacontext = "[CharacterInteractionConfirmationWindow.GetActor]" #Unop Use correct character
 							layoutpolicy_horizontal = expanding
 							margin_top = -2
 							margin_left = 2
@@ -236,7 +236,7 @@ types CourtPositionButton
 						}
 						text_single = {
 							visible = "[ObjectsEqual( GetPlayer.Self, CharacterInteractionConfirmationWindow.GetActor.Self )]"
-							datacontext = "[CharacterInteractionConfirmationWindow.GetActor]"
+							datacontext = "[CharacterInteractionConfirmationWindow.GetRecipient]" #Unop Use correct character
 							layoutpolicy_horizontal = expanding
 							margin_top = -2
 							margin_left = 2


### PR DESCRIPTION
The aptitude shown in the UI of `request_court_position` and `grant_court_position` interaction UIs is bugged - it is incorrect and always the same for all characters. This is because it's the player character aptitude for the position, not the other character that should be evaluated.

This change fixes it.