### PR TITLE
Consume hooks properly in MPO interactions

### DIFF
--- a/common/character_interactions/00_tributary_interactions.txt
+++ b/common/character_interactions/00_tributary_interactions.txt
@@ -1291,6 +1291,10 @@ offer_courtier_interaction = {
 							is_male = yes
 							matrilinear_marriage = yes
 						}
+						#Unop Match conditions in populate_actor_list
+						is_diarch = yes
+						is_designated_diarch = yes
+						has_character_flag = has_been_offered_as_concubine
 					}
 				}
 			}
@@ -1769,6 +1773,10 @@ demand_courtier_interaction = {
 							is_male = yes
 							matrilinear_marriage = yes
 						}
+						#Unop Match conditions in populate_actor_list
+						is_diarch = yes
+						is_designated_diarch = yes
+						has_character_flag = has_been_offered_as_concubine
 					}
 				}
 			}

--- a/common/character_interactions/09_mpo_interactions.txt
+++ b/common/character_interactions/09_mpo_interactions.txt
@@ -1,0 +1,9286 @@
+﻿offer_confederation_interaction = {
+	category = interaction_category_diplomacy
+	icon = offer_confederation_interaction
+
+	desc = offer_confederation_interaction_desc
+
+	ai_targets = {
+		ai_recipients = neighboring_rulers_including_tributary_borders
+	}
+	ai_frequency = 8
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	common_interaction = yes
+	
+	cooldown_against_recipient = { years = 3 }
+
+	is_shown = {
+		scope:actor = {
+			OR = {
+				government_has_flag = government_is_tribal
+				government_has_flag = government_is_nomadic
+			}
+			is_playable_character = yes
+			OR = {
+				is_independent_ruler = yes
+				is_confederation_member = yes
+			}
+		}
+		scope:recipient = {
+			is_playable_character = yes
+			is_independent_ruler = yes
+			NOR = {
+				government_has_flag = government_is_herder
+				this = scope:actor
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		trigger_if = {
+			limit = {
+				scope:actor = { is_confederation_member = no }
+			}
+			custom_tooltip = {
+				text = forming_confederation_tt
+				scope:actor = {
+					has_character_flag = forming_confederation
+				}
+			}
+		}
+		scope:actor = {
+			is_imprisoned = no
+		}
+		scope:recipient = {
+			valid_confederation_member_trigger = { CHARACTER = scope:actor }
+			is_imprisoned = no
+			is_at_war = no
+		}
+	}
+
+	cost = {
+		prestige = {
+			value = 0
+			if = {
+				limit = { scope:prestige_send_option = yes }
+				add = scope:actor.minor_prestige_value
+				desc = PRESTIGE_INTERACTION_ACCEPTANCE_SEND_OPTION
+			}
+		}
+	}
+
+	greeting = positive
+	notification_text = OFFER_CONFEDERATION_INTERACTION_NOTIFICATION
+
+	ai_accept = {
+		base = -50
+		# MAIN
+		# Heretic/Infidel modifier.
+		# Tier difference modifier.
+		# Dejure modifier.
+		# Distant/Remote Realm modifier.
+		# Military power difference modifier.
+
+		# MINOR
+		# Rivalry modifier.
+		# Same Dynasty modifier.
+		# Cultural/Cultural Group modifiers.
+		# Ageism modifier vs kids.
+		# Ruler Legitimacy modifier.
+		# Claimant modifier.
+		# FP3 Piety Level modifier.
+
+		# OPINION SCALES
+		# Dread
+		# Compare Opinion modifier.
+
+		#WHEN UPDATING ANYTHING HERE, PLEASE DO THE SAME (BUT INVERTED) IN LEAVE CONFEDERATION DECISION
+
+		# PERKS
+		modifier = { # Perk boost
+			desc = offer_vassalization_true_ruler_perk_tt
+			trigger = {
+				scope:actor = { has_perk = true_ruler_perk }
+			}
+			add = true_ruler_value
+		}
+		modifier = { # Education 5 boost
+			desc = offer_vassalization_education_diplomacy_5_tt
+			trigger = {
+				scope:actor = { has_trait_with_flag = offer_vassalisation_25 }
+			}
+			add = 25
+		}
+
+		# EVENTS - temporary bonuses gained by events
+		modifier = {
+			desc = event_bonus_to_vassal_accept_tt
+			trigger = {
+				scope:actor = { has_character_modifier = event_bonus_to_vassal_accept }
+			}
+			add = 20
+		}
+
+
+		# STRUGGLES - bonus gained by successful Sway scheme during the Persian Struggle
+		modifier = {
+			desc = fp3_persian_struggle_previously_swayed_tt
+			trigger = {
+				scope:recipient = {
+					has_opinion_modifier = {
+						modifier = scheme_sway_and_compelled_to_submit_opinion
+						target = scope:actor
+					}
+				}
+			}
+			add = 20
+		}
+
+		modifier = {
+			desc = fp3_rekindler_of_iran_modifier_reason
+			trigger = {
+				AND = {
+					scope:actor = { dynasty ?={ has_dynasty_modifier = fp3_rekindler_of_iran_modifier } }
+					scope:recipient = { culture = { has_cultural_pillar = heritage_iranian } }
+				}
+			}
+			add = 20
+		}
+
+
+		modifier = { # Cultural Acceptance
+			add = offer_vassalage_acceptance_value
+			desc = cultural_acceptance_interaction_reason
+			trigger = {
+				scope:actor = {
+					NOT = { has_same_culture_as = scope:recipient }
+					culture = {
+						cultural_acceptance = { target = scope:recipient.culture value <= 90 }
+					}
+				}
+			}
+		}
+
+		# MAIN
+		modifier = { #Different faith, no pluralism.
+			desc = offer_vassalization_interaction_aibehavior_differentfaith_tt
+			trigger = {
+				scope:recipient = {
+					NOR = { #Of two different faiths AND the potential vassal's faith is not pluralistic.
+						faith = scope:actor.faith
+						faith = { has_doctrine = doctrine_pluralism_pluralistic }
+						government_has_flag = government_is_nomadic
+						government_has_flag = government_is_herder
+					}
+				}
+			}
+			add = {
+				value = -30
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_hostile_level
+							}
+						}
+					}
+					add = -30
+				}
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_evil_level
+							}
+						}
+					}
+					add = -30
+				}
+			}
+		}
+
+		modifier = { #Different faith, pluralism.
+			desc = offer_vassalization_interaction_aibehavior_differentfaith_tt
+			trigger = {
+				scope:recipient = {
+					NOR = {
+						faith = scope:actor.faith
+						scope:actor.faith = { has_doctrine = doctrine_pluralism_pluralistic }
+						government_has_flag = government_is_nomadic
+						government_has_flag = government_is_herder
+					}
+					faith = { has_doctrine = doctrine_pluralism_pluralistic }
+				}
+			}
+			add = {
+				value = -15
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_hostile_level
+							}
+						}
+					}
+					add = -15
+				}
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_evil_level
+							}
+						}
+					}
+					add = -15
+				}
+			}
+		}
+
+		modifier = { #Different faith, both have pluralism.
+			desc = offer_vassalization_interaction_aibehavior_differentfaith_tt
+			trigger = {
+				scope:recipient = {
+					NOR = {
+						faith = scope:actor.faith
+						government_has_flag = government_is_nomadic
+						government_has_flag = government_is_herder
+					}
+					scope:actor.faith = { has_doctrine = doctrine_pluralism_pluralistic }
+					faith = { has_doctrine = doctrine_pluralism_pluralistic }
+				}
+			}
+			add = {
+				value = -10
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_hostile_level
+							}
+						}
+					}
+					add = -10
+				}
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_evil_level
+							}
+						}
+					}
+					add = -10
+				}
+			}
+		}
+		modifier = { #We just fought against each other.
+			desc = offer_vassalization_interaction_aibehavior_recent_war_tt
+			trigger = {
+				scope:recipient = {
+					any_truce_holder = {
+						this = scope:actor
+					}
+				}
+				# Ensure the truce wasn't purchased and is indeed from a war
+				scope:actor = {
+					NOT = {
+						has_purchased_truce_with_char = { TARGET = scope:recipient }
+					}
+				}
+			}
+			add = -40
+		}
+		modifier = { #I fought an independence war against you.
+			desc = offer_confederation_independence_war_tt
+			trigger = {
+				scope:recipient = {
+					exists = var:independence_war_former_liege
+					var:independence_war_former_liege = scope:actor.top_liege
+				}
+			}
+			add = -100
+		}
+		modifier = { # Isolationist tradition
+			desc = isolationist_reason
+			trigger = {
+				NOT = {
+					scope:actor.culture = scope:recipient.culture
+				}
+				scope:recipient.culture = {
+					has_cultural_tradition = tradition_isolationist
+				}
+			}
+			add = -50
+		}
+		modifier = { #Bankrupt
+			desc = bankrupt_reason
+			trigger = {
+				scope:actor.gold <= -1
+			}
+			add = -30
+		}
+		modifier = { #Wide difference in rank
+			desc = offer_vassalization_interaction_aibehavior_widetitletier_tt
+			trigger = {
+				scope:actor = {
+					tier_difference = {
+						target = scope:recipient
+						value > 1
+					}
+				}
+			}
+			add = 10
+		}
+		modifier = { # Allied
+			desc = offer_vassalization_interaction_aibehavior_allied_tt
+			trigger = {
+				scope:recipient = {
+					is_allied_to = scope:actor
+				}
+			}
+			add = 50
+		}
+		modifier = { # Is the Rightful Liege of recipient
+			desc = offer_vassalization_interaction_aibehavior_rightfulliegetitleholder_tt
+			trigger = {
+				scope:actor = { is_rightful_liege_of = scope:recipient }
+			}
+			add = 20
+		}
+		modifier = { # Encircled
+			desc = offer_vassalization_interaction_aibehavior_encircled_tt
+			trigger = {
+				scope:recipient = {
+					NOT = {
+						any_land_neighboring_realm_with_tributaries_owner = {
+							NOT = {
+								this = scope:actor
+							}
+						}
+					}
+					NOT = {
+						any_realm_county = {
+							is_coastal_county = yes
+						}
+					}
+				}
+			}
+			add = 40
+		}
+		modifier = { #No adjacency
+			desc = offer_vassalization_interaction_aibehavior_unconnectedrealm_tt
+			trigger = {
+				scope:recipient = {
+					NOT = {
+						any_land_neighboring_realm_with_tributaries_owner = {
+							OR = {
+								this = scope:actor
+								AND = {
+									exists = scope:actor.confederation
+									is_member_of_confederation = scope:actor.confederation
+								}
+								AND = {
+									exists = scope:actor.confederation
+									suzerain ?= {
+										is_member_of_confederation = scope:actor.confederation
+									}
+								}
+								suzerain ?= {
+									this = scope:actor
+								}
+							}
+						}
+					}
+				}
+				scope:recipient.capital_province = { squared_distance = { target = scope:actor.capital_province value < 100000 } }
+			}
+			add = -25
+		}
+		modifier = { #Distant Realm
+			desc = offer_vassalization_interaction_aibehavior_distantrealm_tt
+			trigger = {
+				scope:recipient = {
+					NOT = {
+						any_land_neighboring_realm_with_tributaries_owner = {
+							OR = {
+								this = scope:actor
+								AND = {
+									exists = scope:actor.confederation
+									is_member_of_confederation = scope:actor.confederation
+								}
+								AND = {
+									exists = scope:actor.confederation
+									suzerain ?= {
+										is_member_of_confederation = scope:actor.confederation
+									}
+								}
+								suzerain ?= {
+									this = scope:actor
+								}
+							}
+						}
+					}
+				}
+				scope:recipient.capital_province = { squared_distance = { target = scope:actor.capital_province value >= 100000 } }
+			}
+			add = -75
+		}
+		modifier = { #Remote Realm.
+			desc = offer_vassalization_interaction_aibehavior_remoterealm_tt
+			trigger = {
+				scope:recipient = {
+					NOT = {
+						any_land_neighboring_realm_with_tributaries_owner = {
+							OR = {
+								this = scope:actor
+								AND = {
+									exists = scope:actor.confederation
+									is_member_of_confederation = scope:actor.confederation
+								}
+								AND = {
+									exists = scope:actor.confederation
+									suzerain ?= {
+										is_member_of_confederation = scope:actor.confederation
+									}
+								}
+								suzerain ?= {
+									this = scope:actor
+								}
+							}
+						}
+					}
+				}
+				scope:recipient.capital_province = { squared_distance = { target = scope:actor.capital_province value >= 200000 } }
+			}
+			add = -175
+		}
+		modifier = {
+			desc = offer_vassalization_interaction_aibehavior_power_tt
+	  	  	add = {
+				value = 1
+				subtract = {
+					value = scope:recipient.max_military_strength # Intended for recipient to use max, to avoid having vassalizations become too easy for weakened realms
+					divide = { value = scope:actor.top_liege.current_military_strength min = 1 }
+				}
+				multiply = 5
+				ceiling = yes
+				min = -100
+	  		}
+		}
+		modifier = {
+			desc = offer_confederation_offerer_vassal_opinion_tt
+			trigger = {
+				scope:actor.top_liege = {
+				number_of_powerful_vassals >= 1
+				}
+			}
+
+	  	  	add = {
+				value = 0
+				scope:actor.top_liege = {
+					every_powerful_vassal = {
+						if = {
+							limit = {
+								save_temporary_opinion_value_as = {
+									name = vassal_opinion
+									target = scope:actor.top_liege
+								}
+							}
+							add = scope:vassal_opinion
+						}
+					}
+
+					if = {
+						limit = {
+							number_of_powerful_vassals > 0
+						}
+						divide = number_of_powerful_vassals
+					}
+					else = {
+						divide = 5
+					}
+				}
+
+				divide = 10
+	  		}
+		}
+		
+		# Legitimacy 
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			scope:actor = {
+				has_legitimacy_flag = very_reduced_tributarization_acceptance
+			}
+			add = -20
+		}
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			scope:actor = {
+				has_legitimacy_flag = reduced_tributarization_acceptance
+			}
+			add = -10
+		}
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			scope:actor = {
+				has_legitimacy_flag = increased_tributarization_acceptance
+			}
+			add = 10
+		}
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			scope:actor = {
+				has_legitimacy_flag = very_increased_tributarization_acceptance
+			}
+			add = 20
+		}
+
+		# MINOR
+		modifier = { #Friend modifier.
+			desc = offer_vassalization_interaction_aibehavior_friend_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_friend = scope:actor
+					NOT = { has_relation_best_friend = scope:actor }
+				}
+			}
+			add = 25
+		}
+		modifier = { #Best Friend modifier.
+			desc = offer_vassalization_interaction_aibehavior_best_friend_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_best_friend = scope:actor
+				}
+			}
+			add = 50
+		}
+		modifier = { #Lover modifier.
+			desc = interaction_lover
+			trigger = {
+				scope:recipient = {
+					has_relation_lover = scope:actor
+					NOT = { has_relation_soulmate = scope:actor }
+				}
+			}
+			add = 25
+		}
+		modifier = { #Soulmate modifier.
+			desc = interaction_soulmate
+			trigger = {
+				scope:recipient = {
+					has_relation_soulmate = scope:actor
+				}
+			}
+			add = 50
+		}
+		modifier = { #Rivalry modifier.
+			desc = offer_vassalization_interaction_aibehavior_rival_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_rival = scope:actor
+					NOT = { has_relation_nemesis = scope:actor }
+				}
+			}
+			add = -200
+		}
+		modifier = { #Nemesis modifier.
+			desc = offer_vassalization_interaction_aibehavior_nemesis_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_nemesis = scope:actor
+				}
+			}
+			add = -1000
+		}
+		modifier = { #Same Dynasty modifier.
+			desc = offer_vassalization_interaction_aibehavior_dynasty_tt
+			trigger = {
+				exists = scope:actor.dynasty
+				exists = scope:recipient.dynasty
+				scope:recipient = {
+					dynasty = scope:actor.dynasty
+				}
+			}
+			add = 25
+		}
+		modifier = { #Same House modifier.
+			desc = offer_vassalization_interaction_aibehavior_house_tt
+			trigger = {
+				exists = scope:actor.house
+				exists = scope:recipient.house
+				scope:recipient = {
+					house = scope:actor.house
+				}
+			}
+			add = 50
+		}
+
+		modifier = { # Same language
+			add = 20
+			desc = speaks_same_language_interaction_reason
+			trigger = {
+				scope:actor = {
+					knows_language_of_culture = scope:recipient.culture
+				}
+			}
+		}
+
+		modifier = { # Iberian Struggle, less likely for outsiders to vassalize inside
+			add = -35
+			desc = iberian_struggle_reason_reason
+			trigger = {
+				scope:actor = {
+					NOT = {
+						any_character_struggle = { is_struggle_type = iberian_struggle }
+					}
+				}
+				scope:recipient = {
+					any_character_struggle = { is_struggle_type = iberian_struggle }
+				}
+			}
+		}
+
+		modifier = { #Ageism modifier vs kids.
+			desc = offer_vassalization_interaction_aibehavior_child_tt
+			trigger = {
+				scope:actor = {
+					age < 12
+				}
+				scope:recipient = {
+					age > 16
+				}
+			}
+			add = -5
+		}
+		modifier = { #Illegitimacy modifier.
+			desc = confederation_offerer_illegitimate_tt
+			trigger = {
+				scope:actor.top_liege = {
+					OR = {
+						AND = {
+							has_trait = bastard
+							scope:recipient = {
+								faith = { NOT = { has_doctrine = doctrine_bastardry_none } }
+							}
+						}
+						has_trait = denounced
+						has_trait = disinherited
+					}
+				}
+			}
+			add = -20
+		}
+
+		modifier = { #Claimant modifier.
+			desc = confederation_interaction_aibehavior_claimant_tt
+			trigger = {
+				scope:actor.top_liege.primary_title = {
+					scope:recipient = {
+						has_claim_on = prev
+					}
+				}
+			}
+			add = -20
+		}
+
+		modifier = { # Ambitious
+			desc = TAKE_THE_VOWS_AMBITIOUS
+			trigger = {
+				scope:recipient = {
+					has_trait = ambitious
+				}
+			}
+			add = -25
+		}
+
+		modifier = { # Paranoid
+			desc = INTERACTION_PARANOID
+			trigger = {
+				scope:recipient = {
+					has_trait = paranoid
+				}
+			}
+			add = -25
+		}
+
+		modifier = { # Arrogant
+			desc = INTERACTION_ARROGANT
+			trigger = {
+				scope:recipient = {
+					has_trait = arrogant
+				}
+			}
+			add = -25
+		}
+
+		modifier = { # Fickle
+			desc = INTERACTION_FICKLE
+			trigger = {
+				scope:recipient = {
+					has_trait = fickle
+				}
+			}
+			add = -15
+		}
+
+		modifier = { # Stubborn
+			desc = INTERACTION_STUBBORN
+			trigger = {
+				scope:recipient = {
+					has_trait = stubborn
+				}
+			}
+			add = -15
+		}
+
+		modifier = { # Greedy
+			desc = INTERACTION_GREEDY
+			trigger = {
+				scope:recipient = {
+					has_trait = greedy
+				}
+			}
+			add = -15
+		}
+
+		modifier = { # Trusting
+			desc = TAKE_THE_VOWS_TRUSTING
+			trigger = {
+				scope:recipient = {
+					has_trait = trusting
+				}
+			}
+			add = 15
+		}
+
+		modifier = { # Content
+			desc = INTERACTION_CONTENT
+			trigger = {
+				scope:recipient = {
+					has_trait = content
+				}
+			}
+			add = 15
+		}
+
+		modifier = { # Craven
+			desc = INTERACTION_CRAVEN
+			trigger = {
+				scope:recipient = {
+					has_trait = craven
+				}
+			}
+			add = 25
+		}
+
+		modifier = { # FP3 modifier.
+			desc = GENERIC_YOUR_PIETY_LEVEL_MODIFIER
+			trigger = { scope:actor = { any_character_struggle = { has_struggle_phase_parameter = piety_level_affects_vassalage_acceptance } } }
+			add = {
+				value = {
+					value = scope:actor.piety_level
+					subtract = low_piety_level
+				}
+				multiply = 10
+			}
+		}
+
+		# OPINION INFLUENCE
+		modifier = {
+			add = intimidated_external_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 1
+				}
+			}
+			desc = INTIMIDATED_REASON
+		}
+		modifier = {
+			add = cowed_external_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 2
+				}
+			}
+			desc = COWED_REASON
+		}
+		modifier = {
+			add = intimidated_external_reason_value
+			scope:actor = {
+				is_independent_ruler = no
+			}
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor.top_liege
+					level = 1
+				}
+			}
+			desc = LIEGE_INTIMIDATED_REASON
+		}
+		modifier = {
+			add = cowed_external_reason_value
+			scope:actor = {
+				is_independent_ruler = no
+			}
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor.top_liege
+					level = 2
+				}
+			}
+			desc = LIEGE_COWED_REASON
+		}
+		opinion_modifier = { #Compare Opinion modifier.
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 0.35
+		}
+		opinion_modifier = { #Compare Opinion modifier.
+			trigger = {
+				scope:actor = {
+					is_independent_ruler = no
+				}
+			}
+			who = scope:recipient
+			opinion_target = scope:actor.top_liege
+			multiplier = 0.35
+		}
+
+		# DIPLOMATIC COURT GRANDEUR BONUS
+		modifier = {
+			trigger = {
+				scope:actor.top_liege = {
+					has_royal_court = yes
+					has_dlc_feature = royal_court
+					has_court_type = court_diplomatic
+					court_grandeur_current_level >= 1
+				}
+			}
+			add = {
+				value = scope:actor.top_liege.court_grandeur_current
+				if = {
+					limit = { # Reduce the bonus if you are below your expected level
+						scope:actor.top_liege = {
+							court_grandeur_current_level < court_grandeur_minimum_expected_level
+						}
+					}
+					multiply = 0.15
+				}
+				else = {
+					multiply = 0.3
+				}
+			}
+			desc = DIPLOMATIC_COURT_ACCEPTANCE_INCREASE_REASON
+		}
+
+		# LOW LEGITIMACY
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			add = -5
+			scope:actor = {
+				has_legitimacy_flag = reduced_confederation_acceptance
+			}
+		}
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			add = -10
+			scope:actor = {
+				has_legitimacy_flag = very_reduced_confederation_acceptance
+			}
+		}
+
+		# HIGH LEGITIMACY
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			add = 5
+			scope:actor = {
+				has_legitimacy_flag = increased_confederation_acceptance
+			}
+		}
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			add = 20
+			scope:actor = {
+				has_legitimacy_flag = very_increased_confederation_acceptance
+			}
+		}
+
+		# HERD
+		modifier = {
+			add = 40
+			scope:herd_send_option = yes
+			desc = HERD_INTERACTION_ACCEPTANCE_SEND_OPTION
+		}
+
+		# PRESTIGE
+		modifier = {
+			add = 40
+			scope:prestige_send_option = yes
+			desc = PRESTIGE_INTERACTION_ACCEPTANCE_SEND_OPTION
+		}
+
+		#CULTURE
+		modifier = {
+			add = 50
+			scope:actor = {
+				culture = scope:recipient.culture
+			}
+			desc = "SAME_CULTURE_REASON"
+		}
+		modifier = {
+			add = -20
+			NOT = {
+				scope:actor = {
+					culture = scope:recipient.culture
+				}
+			}
+			scope:actor = {
+				NOR = {
+					culture = {
+						any_parent_culture_or_above = {
+							this = scope:recipient.culture
+						}
+					}
+					scope:recipient.culture = {
+						any_parent_culture_or_above = {
+							this = scope:actor.culture
+						}
+					}
+					culture = {
+						has_same_culture_heritage = scope:recipient.culture
+					}
+				}
+			}
+			desc = "DIFFERENT_CULTURE_REASON"
+		}
+
+		#Conquerors have no interest in this
+		modifier = {
+			scope:recipient = {
+				has_trait = conqueror
+			}
+			add = -1000
+		}
+		modifier = {
+			scope:recipient = {
+				has_trait = greatest_of_khans
+			}
+			add = -1000
+		}
+
+		# Are you using a hook?
+		modifier = {
+			trigger = {
+				scope:hook ?= yes
+			}
+			add = 100
+			desc = LEGEND_HOOK_USED
+		}
+
+		#No neighbor scaring them
+		modifier = {
+			add = -30
+			desc = NO_FRIGHTENING_NEIGHBOR_REASON
+			NOT = {
+				scope:recipient = {
+					confederation_neighboring_foe_trigger = { CHARACTER = scope:recipient }
+				}
+			}
+		}
+
+		#Neighbor is TERRIFYING them
+		modifier = {
+			add = 30
+			desc = TERRIFYING_NEIGHBOR_REASON
+			scope:recipient = {
+				save_temporary_scope_as = confederate
+				any_land_neighboring_realm_with_tributaries_owner = {
+					top_suzerain ?= {
+						NOR = {
+							this = scope:actor
+							this = scope:actor.top_liege
+						}
+						confederation_worthy_foe_strength_ratio_value <= 0.25
+						NOT = { is_allied_to = scope:recipient }
+						OR = {
+							highest_held_title_tier >= tier_kingdom
+							faith = {
+								faith_hostility_level = {
+									target = scope:recipient.faith
+									value >= faith_evil_level
+								}
+							}
+							has_trait = conqueror
+							has_trait = greatest_of_khans
+							any_owned_story = {
+								OR = {
+									story_type = story_greatest_of_khans
+									story_type = story_mongol_invasion
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		#You have too many confederates
+		#For duchy
+		modifier = {
+			add = duchy_confederation_vassals_value
+			desc = TOO_MANY_CONFEDERATION_VASSALS_REASON
+			scope:actor = {
+				is_confederation_member = yes
+			}
+			scope:actor.confederation = {
+				any_confederation_member = {
+					count >= 6
+					highest_held_title_tier >= tier_county
+				}
+			}
+		}
+
+		#Another confederation of recipient's culture exists
+		modifier = {
+			add = -100
+			desc = ANOTHER_CULTURE_CONFEDERATION_REASON
+			NOT = {
+				scope:actor.culture = {
+					this = scope:recipient.culture
+				}
+			}
+			any_in_global_list = {
+				variable = confederations
+				NOT = {
+					this = scope:actor.confederation
+				}
+				has_variable = confederation_culture
+				var:confederation_culture = scope:actor.culture
+			}
+		}
+
+		#Forcing them to join war
+		modifier = {
+			add = -100
+			desc = FORCED_TO_JOIN_WAR_REASON
+			scope:actor = {
+				is_at_war_as_defender = yes
+				any_character_war = {
+					primary_defender = {
+						OR = {
+							this = scope:actor
+							AND = {
+								exists = scope:actor.confederation
+								is_member_of_confederation = scope:actor.confederation
+							}
+						}
+					}
+					is_defender = scope:actor
+					NOR = {
+						any_war_attacker = {
+							is_allied_to = scope:recipient
+						}
+						any_war_attacker = {
+							this = scope:recipient
+						}
+						any_war_defender = {
+							this = scope:recipient
+						}
+						any_war_attacker = {
+							scope:recipient = {
+								has_truce = prev
+							}
+						}
+					}
+				}
+			}
+		}
+
+		#You will be taking over their war
+		modifier = {
+			add = 100
+			desc = TAKING_OVER_DEFENSIVE_WAR_REASON
+			scope:recipient = {
+				is_at_war_as_defender = yes
+				any_character_war = {
+					is_war_leader = scope:recipient
+					is_defender = scope:recipient
+					NOR = {
+						any_war_attacker = {
+							is_allied_to = scope:actor
+						}
+						any_war_attacker = {
+							this = scope:actor
+						}
+						any_war_defender = {
+							this = scope:actor
+						}
+					}
+					defender_war_score < 80
+					defender_war_score >= 0
+				}
+			}
+		}
+		modifier = {
+			add = 200
+			desc = TAKING_OVER_DEFENSIVE_WAR_REASON
+			scope:recipient = {
+				is_at_war_as_defender = yes
+				any_character_war = {
+					is_war_leader = scope:recipient
+					is_defender = scope:recipient
+					NOR = {
+						any_war_attacker = {
+							is_allied_to = scope:actor
+						}
+						any_war_attacker = {
+							this = scope:actor
+						}
+						any_war_defender = {
+							this = scope:actor
+						}
+					}
+					defender_war_score < 0
+				}
+			}
+		}
+
+		#Culture is into/not into confederation
+		modifier = {
+			add = 10
+			desc = CONFEDERATION_ETHOS_REASON
+			scope:recipient.culture = {
+				OR = {
+					has_cultural_pillar = ethos_stoic
+					has_cultural_pillar = ethos_communal
+				}
+			}
+		}
+		modifier = {
+			add = 20
+			desc = CONFEDERATION_ETHOS_REASON
+			scope:recipient.culture = {
+				OR = {
+					has_cultural_pillar = ethos_egalitarian
+				}
+			}
+		}
+		modifier = {
+			add = -10
+			desc = CONFEDERATION_ETHOS_REASON
+			scope:recipient.culture = {
+				OR = {
+					has_cultural_pillar = ethos_bellicose
+					has_cultural_pillar = ethos_courtly
+					has_cultural_pillar = ethos_bureaucratic
+				}
+			}
+		}
+
+		modifier = { # Herder
+			add = 50
+			desc = CONFEDERATION_HERDER_REASON
+			trigger = {
+				scope:recipient = {
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+		modifier = {
+			add = -20
+			desc = NOMADIC_AUTHORITY_REASON
+			trigger = {
+				scope:recipient = {
+					has_realm_law = nomadic_authority_3
+				}
+			}
+		}
+		modifier = {
+			add = -50
+			desc = NOMADIC_AUTHORITY_REASON
+			trigger = {
+				scope:recipient = {
+					has_realm_law = nomadic_authority_4
+				}
+			}
+		}
+		modifier = {
+			add = -100
+			desc = NOMADIC_AUTHORITY_REASON
+			trigger = {
+				scope:recipient = {
+					has_realm_law = nomadic_authority_5
+				}
+			}
+		}
+		modifier = {
+			add = -20
+			desc = TRIBAL_AUTHORITY_REASON
+			trigger = {
+				scope:recipient = {
+					has_realm_law = tribal_authority_2
+				}
+			}
+		}
+		modifier = {
+			add = -50
+			desc = TRIBAL_AUTHORITY_REASON
+			trigger = {
+				scope:recipient = {
+					has_realm_law = tribal_authority_3
+				}
+			}
+		}
+		modifier = { #left your confederation
+			add = -50
+			desc = LEFT_YOUR_CONFEDERATION_REASON
+			exists = scope:actor.confederation
+			scope:recipient = {
+				has_variable = left_confederation
+				var:left_confederation ?= {
+					this = scope:actor.confederation
+				}
+			}
+		}
+	}
+
+	send_option = {
+		flag = hook
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		localization = GENERIC_SPEND_A_HOOK
+	}
+
+	send_option = { # Herd
+		is_shown = {
+			scope:actor = {
+				government_has_flag = government_is_nomadic
+				exists = domicile
+			}
+		}
+		is_valid = {
+			scope:recipient = {
+				government_has_flag = government_is_nomadic
+				exists = domicile
+			}
+			scope:actor.domicile = { herd >= minor_herd_value }
+		}
+		flag = herd_send_option
+		localization = TRADE_HERD_FOR_BETTER_AI_ACCEPTANCE_CONFEDERATION
+	}
+
+	send_option = { # Prestige
+		is_shown = {
+			always = yes
+		}
+		is_valid = {
+			scope:actor = { prestige >= minor_prestige_value }
+		}
+		flag = prestige_send_option
+		localization = TRADE_PRESTIGE_FOR_BETTER_AI_ACCEPTANCE
+	}
+
+	send_options_exclusive = no
+
+	on_accept = {
+		if = {
+			#checking that the delay hasn't made the character invalid
+			limit = {
+				scope:recipient = {
+					is_playable_character = yes
+				}
+			}
+			if = {
+				limit = {
+					scope:actor = {
+						has_character_flag = forming_confederation
+					}
+				}
+				scope:actor = { remove_character_flag = forming_confederation }
+			}
+			if = {
+				limit = {
+					scope:recipient = {
+						is_at_war_as_defender = yes
+						any_character_war = {
+							is_war_leader = scope:recipient
+							is_defender = scope:recipient
+						}
+					}
+				}
+				scope:recipient = {
+					every_character_war = {
+						limit = {
+							is_war_leader = scope:recipient
+							is_defender = scope:recipient
+						}
+						add_to_list = recipient_wars
+					}
+				}
+				every_in_list = {
+					list = recipient_wars
+					save_scope_as = recipient_war
+					primary_attacker = {
+						save_scope_as = attacker
+					}
+					add_defender = scope:actor
+					hidden_effect = {
+						scope:actor.confederation ?= {
+							every_confederation_member = {
+								limit = {
+									NOR = {
+										is_attacker_in_war = scope:recipient_war
+										is_defender_in_war = scope:recipient_war
+										is_at_war_with = scope:recipient
+										is_allied_to = scope:attacker
+										is_imprisoned_by = scope:recipient
+										is_at_war_with = scope:recipient
+									}
+								}
+								scope:recipient_war = {
+									add_defender = prev
+								}
+							}
+						}
+					}
+				}
+				if = {
+					limit = {
+						scope:actor.confederation ?= {
+							any_confederation_member = {
+								NOR = {
+									is_attacker_in_war = scope:recipient_war
+									is_defender_in_war = scope:recipient_war
+									this = scope:actor
+									is_at_war_with = scope:recipient
+									is_allied_to = scope:attacker
+									is_imprisoned_by = scope:recipient
+									is_at_war_with = scope:recipient
+								}
+							}
+						}
+					}
+					scope:actor = {
+						custom_tooltip = confederates_joining_recipient_war_tt
+					}
+				}
+			}
+			scope:actor = {
+				save_scope_as = confederation_offerer
+			}
+			scope:recipient = {
+				save_scope_as = confederation_accepter
+			}
+			#Confederation doesn't exist yet
+			if = {
+				limit = {
+					scope:actor = {
+						is_confederation_member = no
+					}
+				}
+				scope:actor = {
+					custom_tooltip = create_confederation_tt
+					custom_tooltip = confederation_defensive_wars_tt
+					custom_tooltip = unlock_leave_confederation_interaction_tt
+					if = {
+						limit = {
+							government_has_flag = government_is_nomadic
+						}
+						add_character_modifier = {
+							modifier = mpo_confederation_member_modifier
+							years = 5
+						}
+						capital_county ?= {
+							change_county_fertility = major_county_fertility_level_gain
+						}
+					}
+				}
+				scope:recipient = {
+					offer_confederation_accepter_effect = yes
+				}
+			}
+			#Confederation already exists
+			else = {
+				scope:actor.confederation = {
+					save_scope_as = confederation
+				}
+				show_as_tooltip = {
+					#If actor is top liege and offering vassaldom
+					scope:recipient = {
+						offer_confederation_accepter_effect = yes
+					}
+				}
+			}
+			if = {
+				limit = {
+					scope:recipient = {
+						government_has_flag = government_is_nomadic
+					}
+				}
+				scope:recipient = {
+					add_character_modifier = {
+						modifier = mpo_confederation_member_modifier
+						years = 5
+					}
+					capital_county ?= {
+						change_county_fertility = major_county_fertility_level_gain
+					}
+				}
+			}
+			if = {
+				limit = {
+					scope:recipient = {
+						is_ai = no
+					}
+				}
+				scope:recipient = {
+					custom_tooltip = confederation_raiding_attacking_tt
+					if = {
+						limit = {
+							government_has_flag = government_is_nomadic
+						}
+						custom_tooltip = confederation_restrictions_warning_tt
+					}
+					else = {
+						custom_tooltip = confederation_restrictions_tribe_warning_tt
+					}
+				}
+			}
+			scope:recipient = {
+				if = {
+					limit = {
+						government_has_flag = government_is_nomadic
+					}
+					custom_tooltip = confederation_migrating_leaving_warning_tt
+				}
+			}
+			scope:actor = {
+				#Event distributor event
+				trigger_event = mpo_interactions_events.0001
+			}
+			if = {
+				limit = {
+					scope:actor = {
+						is_at_war_as_defender = yes
+						any_character_war = {
+							primary_defender = {
+								OR = {
+									this = scope:actor
+									AND = {
+										exists = scope:actor.confederation
+										is_member_of_confederation = scope:actor.confederation
+									}
+								}
+							}
+							is_defender = scope:actor
+							NOR = {
+								any_war_attacker = {
+									is_allied_to = scope:recipient
+								}
+								any_war_attacker = {
+									this = scope:recipient
+								}
+								any_war_defender = {
+									this = scope:recipient
+								}
+								any_war_attacker = {
+									scope:recipient = {
+										has_truce = prev
+									}
+								}
+							}
+						}
+					}
+				}
+				scope:actor = {
+					every_character_war = {
+						limit = {
+							primary_defender = {
+								OR = {
+									this = scope:actor
+									AND = {
+										exists = scope:actor.confederation
+										is_member_of_confederation = scope:actor.confederation
+									}
+								}
+							}
+							is_defender = scope:actor
+							NOR = {
+								any_war_attacker = {
+									is_allied_to = scope:recipient
+								}
+								any_war_attacker = {
+									this = scope:recipient
+								}
+								any_war_defender = {
+									this = scope:recipient
+								}
+								any_war_attacker = {
+									scope:recipient = {
+										has_truce = prev
+									}
+								}
+							}
+						}
+						add_defender = scope:recipient
+					}
+					#Lose legitimacy unless you're taking on a war too
+					if = {
+						limit = {
+							NOT = {
+								scope:recipient = {
+									is_at_war_as_defender = yes
+									any_character_war = {
+										is_war_leader = scope:recipient
+										is_defender = scope:recipient
+										NOR = {
+											any_war_attacker = {
+												is_allied_to = scope:actor
+											}
+											any_war_attacker = {
+												this = scope:actor
+											}
+											any_war_attacker = {
+												scope:actor = {
+													has_truce = prev
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						add_legitimacy = medium_legitimacy_loss
+						custom_tooltip = confederation_legitimacy_loss_war_tt
+					}
+				}
+			}
+			if = {
+				limit = {
+					scope:prestige_send_option = yes
+				}
+				scope:recipient = {
+					add_prestige = scope:actor.minor_prestige_value
+				}
+			}
+			if = {
+				limit = {
+					scope:herd_send_option = yes
+				}
+				scope:actor = {
+					pay_herd = {
+						target = scope:recipient
+						value = domicile.minor_herd_value
+					}
+				}
+			}
+		}
+	}
+
+	on_decline = {
+		#Stop spamming players with this
+		if = {
+			limit = {
+				exists = scope:actor.confederation
+				scope:recipient = {
+					is_ai = no
+				}
+			}
+			scope:recipient = {
+				set_variable = {
+					name = refused_confederation
+					value = scope:actor.confederation
+					years = 3
+				}
+			}
+		}
+		scope:actor = {
+			#letter response
+			trigger_event = mpo_interactions_events.0004
+		}
+	}
+
+	ai_potential = {
+		is_adult = yes
+		OR = {
+			AND = {
+				is_independent_ruler = yes
+				highest_held_title_tier < tier_kingdom
+				has_character_flag = forming_confederation
+			}
+			is_confederation_member = yes
+		}
+		OR = {
+			government_has_flag = government_is_tribal
+			government_has_flag = government_is_nomadic
+		}
+	}
+
+	ai_will_do = {
+		base = 50
+
+		# Cynical rulers are happy to offer religious protection to potential vassals, but only when it makes them accept a vassalization offer they would otherwise refuse.
+		# Zealous rulers become increasingly reluctant to offer religious protection, as they want to enforce religious homogeneity in their realm.
+		modifier = {
+			add = 25
+			scope:actor = {
+				confederation_neighboring_foe_trigger = { CHARACTER = scope:actor }
+			}
+		}
+		modifier = {
+			add = 25
+			scope:recipient = {
+				confederation_neighboring_foe_trigger = { CHARACTER = scope:recipient }
+			}
+		}
+		modifier = {
+			add = -25
+			scope:recipient = {
+				is_at_war = yes
+			}
+		}
+		modifier = {
+			factor = 0
+			OR = {
+				#Will only throw the confederation into a war
+				scope:recipient = {
+					is_at_war = yes
+					NOR = {
+						any_character_war = {
+							primary_defender = scope:recipient
+						}
+						culture = scope:actor.culture
+						scope:actor.confederation = {
+							any_confederation_member = {
+								count >= 4
+								highest_held_title_tier >= tier_county
+							}
+						}
+						reverse_opinion = {
+							target = scope:actor
+							value >= 30
+						}
+					}
+				}
+				AND = {
+					exists = scope:actor.confederation
+					scope:recipient = {
+						has_variable = left_confederation
+						var:left_confederation ?= {
+							this = scope:actor.confederation
+						}
+					}
+				}
+				#Recipient hasn't been asked to join this confederation already
+				scope:recipient = {
+					has_variable = refused_confederation
+					exists = scope:actor.confederation
+					var:refused_confederation = {
+						this = scope:actor.confederation
+					}
+				}
+			}
+		}
+	}
+}
+
+promote_divergent_or_hybrid_culture_interaction = {
+	category = interaction_category_diplomacy
+	icon = icon_culture
+
+	desc = promote_divergent_or_hybrid_culture_interaction_desc
+
+	ai_targets = {
+		ai_recipients = tributaries
+		ai_recipients = vassals
+		max = 10
+	}
+	ai_frequency = 12
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	common_interaction = yes
+
+	is_shown = {
+		scope:actor.domicile ?= {
+			domicile_uses_culture_and_faith = yes
+			domicile_culture = scope:actor.culture
+		}
+		scope:actor.culture ?= {
+			OR = {
+				is_hybrid_culture = yes
+				is_divergent_culture = yes
+			}
+		}
+		scope:recipient = {
+			trigger_if = {
+				limit = {
+					domicile ?= { domicile_uses_culture_and_faith = yes }
+				}
+				domicile.domicile_culture != scope:actor.culture
+			}
+			trigger_else = {
+				culture != scope:actor.culture
+			}
+			OR = {
+				is_tributary_of_suzerain_or_above = scope:actor
+				is_vassal_or_below_of = scope:actor
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:recipient = {
+			NOR = {
+				is_imprisoned_by = scope:actor
+				has_strong_hook = scope:actor
+				is_at_war_with = scope:actor
+			}
+		}
+		custom_tooltip = {
+			text = not_a_nomad_or_herder_tt
+			scope:recipient = {
+				OR = {
+					government_has_flag = government_is_nomadic
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+		trigger_if = {
+			limit = {
+				exists = scope:recipient.domicile
+			}
+			custom_tooltip = {
+				text = not_a_parent_culture_of_domicile_tt
+				scope:actor.culture = {
+					any_parent_culture_or_above = {
+						this = scope:recipient.domicile.domicile_culture
+					}
+				}
+			}
+		}
+		trigger_else = {
+			custom_tooltip = {
+				text = not_a_parent_culture_tt
+				scope:actor.culture = {
+					any_parent_culture_or_above = {
+						this = scope:recipient.culture
+					}
+				}
+			}
+		}
+	}
+
+	greeting = positive
+	notification_text = PROMOTE_DIVERGENT_CULTURE_INTERACTION_NOTIFICATION
+
+	ai_accept = {
+		base = -50
+
+		modifier = {
+			add = 1000
+			scope:recipient = {
+				is_obedient_to = scope:actor
+			}
+			desc = MIGRATION_INTERACTION_OBEDIENT_ACCEPTANCE
+		}
+
+		opinion_modifier = {
+			opinion_target = scope:actor
+			who = scope:recipient
+			multiplier = 1
+			desc = AI_OPINION_REASON
+		}
+
+		modifier = {
+			add = 20
+			desc = NOMADIC_AUTHORITY_POSITIVE_REASON
+			trigger = {
+				scope:actor = {
+					has_realm_law = nomadic_authority_3
+				}
+			}
+		}
+
+		modifier = {
+			add = 50
+			desc = NOMADIC_AUTHORITY_POSITIVE_REASON
+			trigger = {
+				scope:actor = {
+					has_realm_law = nomadic_authority_4
+				}
+			}
+		}
+
+		modifier = {
+			add = 100
+			desc = NOMADIC_AUTHORITY_POSITIVE_REASON
+			trigger = {
+				scope:actor = {
+					has_realm_law = nomadic_authority_5
+				}
+			}
+		}
+
+		# HERD
+		modifier = {
+			add = 60
+			scope:herd_send_option = yes
+			desc = HERD_INTERACTION_ACCEPTANCE_SEND_OPTION
+		}
+
+		# PRESTIGE
+		modifier = {
+			add = 60
+			scope:prestige_send_option = yes
+			desc = PRESTIGE_INTERACTION_ACCEPTANCE_SEND_OPTION
+		}
+
+		# Are you using a hook?
+		modifier = {
+			trigger = {
+				scope:hook ?= yes
+			}
+			add = 1000
+			desc = LEGEND_HOOK_USED
+		}
+
+		modifier = { # Herder
+			add = 100
+			desc = CONFEDERATION_HERDER_REASON
+			trigger = {
+				scope:recipient = {
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+	}
+
+	send_option = {
+		flag = hook
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		localization = GENERIC_SPEND_A_HOOK
+	}
+
+	send_option = { # Herd
+		is_shown = {
+			scope:actor = {
+				government_has_flag = government_is_nomadic
+				exists = domicile
+			}
+		}
+		is_valid = {
+			scope:recipient = {
+				government_has_flag = government_is_nomadic
+				exists = domicile
+			}
+			scope:actor.domicile = { herd >= minor_herd_value }
+		}
+		flag = herd_send_option
+		localization = TRADE_HERD_FOR_BETTER_AI_ACCEPTANCE_CONFEDERATION
+	}
+
+	send_option = { # Prestige
+		is_shown = {
+			always = yes
+		}
+		is_valid = {
+			scope:actor = { prestige >= minor_prestige_value }
+		}
+		flag = prestige_send_option
+		localization = TRADE_PRESTIGE_FOR_BETTER_AI_ACCEPTANCE
+	}
+
+	send_options_exclusive = no
+
+	on_accept = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = promote_culture_accepted_tt
+				left_icon = scope:recipient
+				scope:recipient = {
+					if = {
+						limit = {
+							domicile ?= { domicile_uses_culture_and_faith = yes }
+						}
+						custom_tooltip = {
+							text = family_and_lands_convert_domicile_tt
+							every_held_title = {
+								limit = {
+									tier = tier_county
+									is_landless_type_title = no
+									culture = scope:recipient.domicile.domicile_culture
+								}
+								add_to_list = counties_to_convert
+							}
+							# Family at court also convert
+							every_close_or_extended_family_member = {
+								limit = {
+									is_courtier_of = scope:recipient
+									culture = scope:recipient.domicile.domicile_culture
+								}
+								add_to_list = spouses_and_family_to_convert
+							}
+							domicile = {
+								set_domicile_culture = scope:actor.culture
+							}
+						}
+					}
+					else = {
+						custom_tooltip = {
+							text = family_and_lands_convert_tt
+							every_held_title = {
+								limit = {
+									tier = tier_county
+									is_landless_type_title = no
+									culture = scope:recipient.culture
+								}
+								add_to_list = counties_to_convert
+							}
+							# Family at court also convert
+							every_close_or_extended_family_member = {
+								limit = {
+									is_courtier_of = scope:recipient
+									culture = scope:recipient.culture
+								}
+								add_to_list = spouses_and_family_to_convert
+							}
+						}
+					}
+					if = {
+						limit = {
+							culture != scope:actor.culture
+						}
+						set_culture = scope:actor.culture
+					}
+					hidden_effect = {
+						every_in_list = {
+							list = counties_to_convert
+							set_county_culture = scope:actor.culture
+						}
+						every_in_list = {
+							list = spouses_and_family_to_convert
+							set_culture = scope:actor.culture
+						}
+					}
+					add_opinion = {
+						modifier = respect_opinion
+						opinion = 10
+						target = scope:actor
+					}
+				}
+			}
+			if = {
+				limit = {
+					scope:prestige_send_option = yes
+				}
+				scope:actor = {
+					add_prestige = scope:actor.minor_prestige_loss
+				}
+				scope:recipient = {
+					add_prestige = scope:actor.minor_prestige_value
+				}
+			}
+			if = {
+				limit = {
+					scope:herd_send_option = yes
+				}
+				scope:actor = {
+					pay_herd = {
+						target = scope:recipient
+						value = domicile.minor_herd_value
+					}
+				}
+			}
+			if = {
+				limit = {
+					scope:hook = yes
+				}
+				use_hook = scope:recipient
+			}
+		}
+	}
+
+	on_decline = {
+		scope:actor = {
+		}
+	}
+
+	ai_potential = {
+		government_has_flag = government_is_nomadic
+		highest_held_title_tier >= tier_duchy
+	}
+
+	ai_will_do = {
+		base = 100
+
+		modifier = {
+			add = -1
+			scope:hook ?= yes
+		}
+
+		modifier = {
+			factor = 0
+			OR = {
+				scope:herd_send_option ?= yes
+				scope:prestige_send_option ?= yes
+			}
+		}
+	}
+}
+
+inspire_conversion_interaction = {
+	category = interaction_category_religion
+	icon = government_type_nomad
+
+	desc = inspire_conversion_interaction_desc
+
+	ai_targets = {
+		ai_recipients = tributaries
+		ai_recipients = vassals
+		max = 10
+	}
+	ai_frequency = 12
+	cooldown_against_recipient = { years = 5 }
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	common_interaction = yes
+
+	is_shown = {
+		scope:actor.domicile ?= {
+			domicile_uses_culture_and_faith = yes
+		}
+		scope:recipient = {
+			OR = {
+				trigger_if = {
+					limit = {
+						domicile ?= { domicile_uses_culture_and_faith = yes }
+					}
+					domicile.domicile_faith != scope:actor.domicile.domicile_faith
+				}
+				faith != scope:actor.domicile.domicile_faith
+				faith != scope:actor.faith # Tooltip reasons
+			}
+			OR = {
+				is_tributary_of_suzerain_or_above = scope:actor
+				is_vassal_or_below_of = scope:actor
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:recipient = {
+			NOR = {
+				is_imprisoned_by = scope:actor
+				has_strong_hook = scope:actor
+				is_at_war_with = scope:actor
+			}
+		}
+		custom_description = {
+			text = "is_head_of_religion"
+			subject = scope:recipient
+			NOT = { scope:recipient.faith.religious_head = scope:recipient }
+		}
+		custom_description = {
+			text = "is_protected_via_contract"
+			subject = scope:recipient
+			NAND = { # Vassal Contract forbids meddling by liege
+				exists = scope:recipient.liege
+				scope:recipient.liege = scope:actor
+				scope:recipient = {
+					is_ruler = yes
+					vassal_contract_has_flag = religiously_protected
+				}
+			}
+		}
+		custom_tooltip = {
+			text = you_are_not_of_your_domicile_faith_tt
+			scope:recipient = {
+				OR = {
+					trigger_if = {
+						limit = {
+							domicile ?= { domicile_uses_culture_and_faith = yes }
+						}
+						domicile.domicile_faith != scope:actor.domicile.domicile_faith
+					}
+					faith != scope:actor.domicile.domicile_faith
+				}
+			}
+		}
+		custom_tooltip = {
+			text = not_a_nomad_or_herder_tt
+			scope:recipient = {
+				OR = {
+					government_has_flag = government_is_nomadic
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+	}
+
+	greeting = positive
+	notification_text = INSPIRE_CONVERSION_INTERACTION_NOTIFICATION
+
+	ai_accept = {
+		base = -50
+
+		modifier = {
+			add = 1000
+			scope:recipient = {
+				is_obedient_to = scope:actor
+			}
+			desc = MIGRATION_INTERACTION_OBEDIENT_ACCEPTANCE
+		}
+
+		modifier = {
+			desc = ASK_FOR_CONVERSION_RECIPIENT_IS_ZEALOUS
+			add = -100
+			scope:recipient = {
+				has_trait = zealous
+			}
+		}
+
+		modifier = {
+			desc = INSPIRE_UNREFORMED_FAITH
+			add = -50
+			scope:actor.faith = { has_doctrine_parameter = unreformed }
+		}
+		
+		modifier = {
+			add = 50
+			desc = ZEALOUS_PROSELYTIZER_REASON
+			trigger = {
+				scope:actor = {
+					has_perk = zealous_proselytizer_perk
+				}
+			}
+		}
+
+		modifier = {
+			add = 20
+			desc = NOMADIC_AUTHORITY_POSITIVE_REASON
+			trigger = {
+				scope:actor = {
+					has_realm_law = nomadic_authority_3
+				}
+			}
+		}
+
+		modifier = {
+			add = 50
+			desc = NOMADIC_AUTHORITY_POSITIVE_REASON
+			trigger = {
+				scope:actor = {
+					has_realm_law = nomadic_authority_4
+				}
+			}
+		}
+
+		modifier = {
+			add = 100
+			desc = NOMADIC_AUTHORITY_POSITIVE_REASON
+			trigger = {
+				scope:actor = {
+					has_realm_law = nomadic_authority_5
+				}
+			}
+		}
+
+		opinion_modifier = {
+			opinion_target = scope:actor
+			who = scope:recipient
+			multiplier = 1
+			desc = AI_OPINION_REASON
+		}
+
+		# HERD
+		modifier = {
+			add = 60
+			scope:herd_send_option = yes
+			desc = HERD_INTERACTION_ACCEPTANCE_SEND_OPTION
+		}
+
+		# PIETY
+		modifier = {
+			add = 60
+			scope:piety_send_option = yes
+			desc = PIETY_INTERACTION_ACCEPTANCE_SEND_OPTION
+		}
+
+		# Are you using a hook?
+		modifier = {
+			trigger = {
+				scope:hook ?= yes
+			}
+			add = 1000
+			desc = LEGEND_HOOK_USED
+		}
+
+		modifier = { # Herder
+			add = 100
+			desc = CONFEDERATION_HERDER_REASON
+			trigger = {
+				scope:recipient = {
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+	}
+
+	send_option = {
+		flag = hook
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		localization = GENERIC_SPEND_A_HOOK
+	}
+
+	send_option = { # Herd
+		is_shown = {
+			scope:actor = {
+				government_has_flag = government_is_nomadic
+				exists = domicile
+			}
+		}
+		is_valid = {
+			scope:recipient = {
+				government_has_flag = government_is_nomadic
+				exists = domicile
+			}
+			scope:actor.domicile = { herd >= minor_herd_value }
+		}
+		flag = herd_send_option
+		localization = TRADE_HERD_FOR_BETTER_AI_ACCEPTANCE_CONFEDERATION
+	}
+
+	send_option = { # Piety
+		is_shown = {
+			always = yes
+		}
+		is_valid = {
+			scope:actor = { piety >= medium_piety_value }
+		}
+		flag = piety_send_option
+		localization = TRADE_PRESTIGE_FOR_BETTER_AI_ACCEPTANCE_ICON
+	}
+
+	send_options_exclusive = no
+
+	on_accept = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = inspire_conversion_accepted_tt
+				left_icon = scope:recipient
+				scope:recipient = {
+					if = {
+						limit = {
+							domicile ?= { domicile_uses_culture_and_faith = yes }
+						}
+						custom_tooltip = {
+							text = family_and_lands_inspire_domicile_tt
+							every_held_title = {
+								limit = {
+									tier = tier_county
+									is_landless_type_title = no
+									culture = scope:recipient.domicile.domicile_culture
+									faith != scope:actor.domicile.domicile_faith
+								}
+								add_to_list = counties_to_convert
+							}
+							# Family at court also convert
+							every_close_or_extended_family_member = {
+								limit = {
+									is_courtier_of = scope:recipient
+									faith != scope:actor.domicile.domicile_faith
+								}
+								add_to_list = spouses_and_family_to_convert
+							}
+							domicile = {
+								if = {
+									limit = {
+										domicile_faith != scope:actor.domicile.domicile_faith
+									}
+									set_domicile_faith = scope:actor.domicile.domicile_faith
+								}
+							}
+						}
+					}
+					else = {
+						custom_tooltip = {
+							text = family_and_lands_inspire_tt
+							every_held_title = {
+								limit = {
+									tier = tier_county
+									is_landless_type_title = no
+									culture = scope:recipient.culture
+									faith != scope:actor.domicile.domicile_faith
+								}
+								add_to_list = counties_to_convert
+							}
+							# Family at court also convert
+							every_close_or_extended_family_member = {
+								limit = {
+									is_courtier_of = scope:recipient
+									faith != scope:actor.domicile.domicile_faith
+								}
+								add_to_list = spouses_and_family_to_convert
+							}
+						}
+					}
+					if = {
+						limit = {
+							faith != scope:actor.domicile.domicile_faith
+						}
+						set_character_faith = scope:actor.domicile.domicile_faith
+					}
+					hidden_effect = {
+						every_in_list = {
+							list = counties_to_convert
+							set_county_faith = scope:actor.domicile.domicile_faith
+						}
+						every_in_list = {
+							list = spouses_and_family_to_convert
+							set_character_faith = scope:actor.domicile.domicile_faith
+						}
+					}
+					if = { # If you have the Religious Icon perk they become obedient
+						limit = {
+							scope:actor = {
+								government_has_flag = government_is_nomadic
+								has_perk = religious_icon_perk
+							}
+							scope:recipient = {
+								obedience_target = scope:actor
+								is_obedient = no
+							}
+						}
+						scope:recipient = {
+							add_opinion = {
+								modifier = obedience_opinion
+								target = scope:actor
+							}
+						}
+					}
+					else = {
+						add_opinion = {
+							modifier = respect_opinion
+							opinion = 10
+							target = scope:actor
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					scope:piety_send_option = yes
+				}
+				scope:actor = {
+					add_piety = scope:actor.medium_piety_loss
+				}
+				scope:recipient = {
+					add_piety = scope:actor.medium_piety_value
+				}
+			}
+			if = {
+				limit = {
+					scope:herd_send_option = yes
+				}
+				scope:actor = {
+					pay_herd = {
+						target = scope:recipient
+						value = domicile.minor_herd_value
+					}
+				}
+			}
+		}
+	}
+
+	on_decline = {
+		scope:actor = {
+		}
+	}
+
+	ai_potential = {
+		government_has_flag = government_is_nomadic
+		highest_held_title_tier >= tier_duchy
+		NOR = {
+			any_owned_story = {
+				OR = {
+					story_type = story_mongol_invasion
+					story_type = story_greatest_of_khans
+					
+				}
+			}
+			mpo_has_gok_mongol_empire_trigger = yes
+		}
+	}
+
+	ai_will_do = {
+		base = 100
+
+		modifier = {
+			add = -1
+			scope:hook ?= yes
+		}
+
+		modifier = {
+			add = -1
+			scope:piety_send_option ?= yes
+		}
+
+		modifier = {
+			factor = 0
+			scope:herd_send_option ?= yes
+		}
+	}
+}
+
+# Used by AI code
+migration_interaction = {
+	interface_priority = 120
+	common_interaction = yes
+	use_diplomatic_range = no
+	category = interaction_debug_main
+	icon = herd_interaction
+	hidden = yes
+
+	# Keep AI reply at minimum - don't change default values
+	# ai_min_reply_days = 0
+	# ai_max_reply_days = 0
+
+	can_send_despite_rejection = yes
+
+	interface = migration
+	special_interaction = migration
+
+	cost = {
+		# Free
+	}
+
+	desc = migration_interaction_desc
+
+	is_shown = {
+		scope:actor = {
+			government_has_flag = government_is_nomadic
+			trigger_if = {
+				limit = {
+					is_ai = yes
+				}
+				is_at_war = no
+			}
+			highest_held_title_tier >= tier_county
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			is_imprisoned = no
+			is_independent_ruler = yes
+			is_travelling = no
+			custom_tooltip = {
+				text = no_primary_wars_tt
+				NOT = {
+					any_character_war = {
+						OR = {
+							primary_attacker = { this = scope:actor }
+							primary_defender = { this = scope:actor }
+						}
+					}
+				}
+			}
+			custom_tooltip = {
+				text = must_have_migration_situation_tt
+				any_character_situation = {
+					any_participant_group = {
+						participant_group_type = nomad_rulers_capital
+						participant_group_has_character = scope:actor
+					}
+				}
+			}
+			NOT = { exists = involved_activity }
+		}
+		scope:recipient = {
+			is_ruler = yes
+			NOR = {
+				is_allied_to = scope:actor
+				has_truce = scope:actor
+			}
+		}
+	}
+
+	# can_be_picked_title is unused for migration_interaction and controlled by code
+	# can_be_picked_title = {}
+
+	on_accept = {
+		scope:actor = {
+			if = {
+				limit = {
+					is_ai = yes
+				}
+				set_variable = {
+					name = migration_cooldown
+					years = migration_cooldown_value
+				}
+			}
+			# We add a variable in case you're migrating into a Tributary, for special event Options
+			if = {
+				limit = {
+					scope:recipient = {
+						is_tributary = yes
+						NOT = { is_tributary_of_suzerain_or_above = scope:actor } # They're not your Tributary
+					}
+					trigger_if = {
+						limit = { exists = scope:actor.overlord }
+						scope:recipient.overlord != scope:actor.overlord # You're not subjects of the same ruler already
+					}
+				}
+				set_variable = {
+					name = migrating_into_tributary_var
+					value = scope:recipient.overlord
+				}
+			}
+			if = {
+				limit = {
+					is_confederation_member = yes
+				}
+				confederation = {
+					save_scope_as = confederation_left
+				}
+				confederation_migration_notification_effect = yes
+				confederation = {
+					remove_confederation_member = scope:actor
+				}
+			}
+			# Pay what you need to pay first
+			if = {
+				limit = { scope:hook = yes }
+				use_hook = scope:recipient
+			}
+			if = {
+				limit = { scope:gold_cost = yes }
+				pay_short_term_gold = {
+					target = scope:recipient
+					gold = medium_gold_value
+				}
+			}
+			if = {
+				limit = { scope:herd_cost = yes }
+				pay_herd = {
+					target = scope:recipient
+					value = domicile.medium_herd_value
+				}
+			}
+			if = {
+				limit = {
+					exists = scope:target_title
+				}
+				set_variable = {
+					name = migration_title
+					value = scope:target_title
+				}
+			}
+
+			# Save your old lands
+			save_scope_as = old_holder
+			capital_county = { save_scope_as = old_capital_county }
+			every_held_title = {
+				limit = {
+					tier = tier_county
+					exists = duchy
+					culture = scope:actor.domicile.domicile_culture
+				}
+				add_to_list = old_held_titles
+			}
+
+			# Make a new culture appear in the lands you left behind, as you're bringing _your_ people with you
+			# Delay the creation so that Herders have spawned
+			trigger_event = {
+				id = mpo_misc.0001
+				delayed = yes
+			}
+
+			# Let's migrate!
+			# If there's a Drought, your people get a morale boost
+			if = {
+				limit = {
+					any_character_situation = {
+						any_situation_sub_region = {
+							has_sub_region_phase_parameter = the_great_steppe_migration_morale_boost
+							any_situation_sub_region_participant_group = {
+								participant_group_type = nomad_rulers_capital
+								participant_group_has_character = scope:actor
+							}
+						}
+					}
+				}
+				custom_tooltip = {
+					text = mpo_the_great_steppe_migration_morale_boost_effect_tt
+					every_courtier_or_guest = {
+						add_opinion = {
+							target = prev
+							modifier = drought_migration_opinion
+						}
+					}
+				}
+			}
+
+			if = {
+				limit = {
+					exists = scope:target_title
+				}
+				custom_tooltip = mpo_steppe_migration_migrate_to_tt
+				custom_tooltip = mpo_steppe_migration_lose_land_tt
+				every_vassal = {
+					limit = {
+						OR = {
+							is_ai = no
+							NOT = { is_obedient_to = scope:actor }
+						}
+					}
+					hidden_effect = {
+						break_subject_contract_and_establish_tributary_effect = { 
+							SUZERAIN = scope:actor 
+							TRIBUTARY = this
+						}
+					}
+					custom_tooltip = mpo_steppe_migration_lose_vassal_tt
+				}
+			}
+
+			every_vassal = {
+				limit = {
+					exists = scope:target_title
+					is_obedient_to = scope:actor
+					is_ai = yes
+				}
+				save_scope_as = current_vassal
+				custom_tooltip = mpo_steppe_migration_keep_vassal_tt
+				hidden_effect = {
+					start_travel_plan = {
+						destination = scope:target_title.title_capital_county.title_province
+						return_trip = no
+						travel_with_domicile = yes
+					}
+					migration_set_obedient_vassal_effect = yes
+				}
+			}
+			# Migration travel is handled by code
+		}
+	}
+
+	on_decline = {
+		# We add a variable in case you're migrating into a Tributary, for special event Options
+		if = {
+			limit = {
+				scope:recipient = {
+					is_tributary = yes
+					suzerain != scope:actor # They're not your tributary
+				}
+				trigger_if = {
+					limit = { exists = scope:actor.overlord }
+					scope:recipient.overlord != scope:actor.overlord # You're not subjects of the same ruler already
+				}
+			}
+			scope:actor = {
+				set_variable = {
+					name = migrating_into_tributary_war_var
+					value = scope:recipient.overlord
+				}
+			}
+		}
+		# Migration wars are handled by code
+		scope:actor = {
+			if = {
+				limit = {
+					is_confederation_member = yes
+				}
+				confederation_migration_notification_effect = yes
+				confederation = {
+					remove_confederation_member = scope:actor
+				}
+			}
+			every_vassal = {
+				limit = {
+					exists = scope:target_title
+					is_obedient_to = scope:actor
+					is_ai = yes
+				}
+				save_scope_as = current_vassal
+				hidden_effect = {
+					migration_set_obedient_vassal_effect = yes
+				}
+			}
+		}
+	}
+
+	# Use gold
+	send_option = {
+		flag = gold_cost
+		is_valid = {
+			scope:actor.gold >= scope:actor.medium_gold_value
+		}
+		localization = TRADE_GOLD_FOR_BETTER_MIGRATION_AI_ACCEPTANCE
+	}
+
+	# Use Herd
+	send_option = {
+		is_shown = {
+			scope:recipient = {
+				government_has_flag = government_is_nomadic
+			}
+		}
+		is_valid = {
+			scope:actor = {
+				domicile ?= { herd >= medium_herd_value }
+			}
+		}
+		flag = herd_cost
+		localization = TRADE_HERD_FOR_BETTER_AI_ACCEPTANCE
+	}
+
+	# Use hook
+	send_option = {
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		flag = hook
+		localization = GENERIC_SPEND_A_HOOK
+	}
+	should_use_extra_icon = {
+		scope:actor = { has_usable_hook = scope:recipient }
+	}
+	extra_icon = "gfx/interface/icons/character_interactions/hook_icon.dds"
+
+	send_options_exclusive = no
+
+	ai_accept = {
+		base = 0
+		modifier = {
+			add = -95
+			desc = MIGRATION_INTERACTION_BASE_ACCEPTANCE
+		}
+		modifier = { # Easier for AI to migrate peacefully since they can't send Herd/Gold
+			add = 50
+			trigger = {
+				scope:recipient = { is_ai = yes }
+				scope:actor = { is_ai = yes }
+			}
+			desc = MIGRATION_INTERACTION_ACCEPTANCE_AI
+		}
+		modifier = { # Herders move away immediately
+			trigger = {
+				scope:recipient = { government_has_flag = government_is_herder }
+			}
+			add = 150
+			desc = MIGRATION_INTERACTION_HERDER
+		}
+		modifier = { # Dukes don't really want to move
+			trigger = {
+				scope:recipient = {
+					has_realm_law = nomadic_authority_3
+				}
+			}
+			add = -20
+			desc = MIGRATION_INTERACTION_HIGH_DOMINANCE
+		}
+		modifier = { # Kingdoms/Empires don't want to move
+			trigger = {
+				scope:recipient = {
+					OR = {
+						has_realm_law = nomadic_authority_4
+						has_realm_law = nomadic_authority_5
+					}
+				}
+			}
+			add = -100
+			desc = MIGRATION_INTERACTION_HIGH_DOMINANCE
+		}
+		# Are you using a hook?
+		modifier = {
+			trigger = {
+				scope:hook ?= yes
+			}
+			add = 100
+			desc = MIGRATION_HOOK_USED
+		}
+		# Are you using Gold?
+		modifier = {
+			trigger = {
+				scope:gold_cost ?= yes
+			}
+			add = 25
+			desc = TRADE_GOLD_FOR_BETTER_AI_ACCEPTANCE_TT
+		}
+		# Are you using Herd?
+		modifier = {
+			trigger = {
+				scope:herd_cost ?= yes
+			}
+			add = 25
+			desc = TRADE_HERD_FOR_BETTER_AI_ACCEPTANCE_TT
+		}
+		# Is there a Drought?
+		modifier = {
+			add = 15
+			any_character_situation = {
+				any_situation_sub_region = {
+					has_sub_region_phase_parameter = the_great_steppe_migration_acceptance_boost
+					any_situation_sub_region_participant_group = {
+						participant_group_type = nomad_rulers_capital
+						participant_group_has_character = scope:actor
+					}
+				}
+			}
+			desc = MIGRATION_INTERACTION_DROUGHT_ACCEPTANCE
+		}
+		# Recipient traits
+		modifier = {
+			add = 15
+			scope:recipient = {
+				has_trait = craven
+			}
+			desc = MIGRATION_INTERACTION_CRAVEN_ACCEPTANCE
+		}
+		modifier = {
+			add = 15
+			scope:recipient = {
+				has_trait = content
+			}
+			desc = MIGRATION_INTERACTION_CONTENT_ACCEPTANCE
+		}
+		# Recipient's opinion
+		opinion_modifier = {
+			trigger = {
+				scope:actor = {
+					OR = {
+						has_realm_law = nomadic_authority_1
+						has_realm_law = nomadic_authority_2
+					}
+				}
+			}
+			opinion_target = scope:recipient
+			who = scope:actor
+			multiplier = 1
+			desc = MIGRATION_INTERACTION_OPINION_ACCEPTANCE
+		}
+		opinion_modifier = {
+			trigger = {
+				scope:actor = {
+					OR = {
+						has_realm_law = nomadic_authority_3
+						has_realm_law = nomadic_authority_4
+						has_realm_law = nomadic_authority_5
+					}
+				}
+			}
+			opinion_target = scope:recipient
+			who = scope:actor
+			multiplier = 0.5
+			desc = MIGRATION_INTERACTION_OPINION_ACCEPTANCE
+		}
+		# Recipient's relation to you
+		modifier = {
+			scope:recipient = {
+				has_relation_friend = scope:actor
+			}
+			add = {
+				value = 25
+				if = {
+					limit = {
+						scope:actor = {
+							OR = {
+								has_realm_law = nomadic_authority_1
+								has_realm_law = nomadic_authority_2
+							}
+						}
+					}
+					add = 50
+				}
+			}
+			desc = MIGRATION_INTERACTION_FRIEND_ACCEPTANCE
+		}
+		modifier = {
+			scope:recipient = {
+				has_relation_blood_brother = scope:actor
+			}
+			add = {
+				value = 50
+				if = {
+					limit = {
+						scope:actor = {
+							OR = {
+								has_realm_law = nomadic_authority_1
+								has_realm_law = nomadic_authority_2
+							}
+						}
+					}
+					add = 50
+				}
+			}
+			desc = MIGRATION_INTERACTION_BLOOD_BROTHERS_ACCEPTANCE
+		}
+		# Obedience
+		modifier = {
+			scope:recipient = {
+				is_obedient_to = scope:actor
+			}
+			add = {
+				value = 50
+				if = {
+					limit = {
+						scope:actor = {
+							OR = {
+								has_realm_law = nomadic_authority_1
+								has_realm_law = nomadic_authority_2
+							}
+						}
+					}
+					add = 50
+				}
+			}
+			desc = MIGRATION_INTERACTION_OBEDIENT_ACCEPTANCE
+		}
+		# Relative Prestige
+		modifier = {
+			add = 10
+			prestige_level >= scope:recipient.prestige_level
+			desc = MIGRATION_INTERACTION_PRESTIGE_ACCEPTANCE
+		}
+		# Relative Prowess
+		modifier = {
+			add = 10
+			prowess >= scope:recipient.prowess
+			desc = MIGRATION_INTERACTION_PROWESS_ACCEPTANCE
+		}
+		# Relative Herd
+		modifier = {
+			trigger_if = {
+				exists = scope:recipient.domicile # Herders won't have a domicile
+			}
+			add = 25
+			domicile.herd >= scope:recipient.domicile.herd
+			desc = MIGRATION_INTERACTION_HERD_ACCEPTANCE
+		}
+		# Gurkhan
+		modifier = {
+			add = -1000
+			exists = situation:the_great_steppe
+			scope:recipient = {
+				this = situation:the_great_steppe.situation_top_herd
+			}
+			desc = MIGRATION_INTERACTION_GURKHAN_ACCEPTANCE
+		}
+		modifier = {
+			add = 50
+			trigger_if = {
+				exists = situation:the_great_steppe
+			}
+			scope:actor = {
+				this = situation:the_great_steppe.situation_top_herd
+			}
+			desc = MIGRATION_INTERACTION_GURKHAN_ACTOR_ACCEPTANCE
+		}
+		# Dread
+		modifier = {
+			add = intimidated_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 1
+				}
+			}
+			desc = INTIMIDATED_REASON
+		}
+		modifier = {
+			add = cowed_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 2
+				}
+			}
+			desc = COWED_REASON
+		}
+
+		# Events
+		modifier = {
+			add = 5
+			scope:actor = { has_character_modifier = mpo_elder_flock_migrate_modifier }
+			desc = MIGRATION_INTERACTION_ELDER_FLOCK_ACCEPTANCE
+		}
+
+		#Confederations refuse to be intimidated and don't want to leave
+		modifier = {
+			add = -300
+			desc = CONFEDERATION_MEMBER_REASON
+			scope:recipient = {
+				is_confederation_member = yes
+			}
+		}
+		# High-tier Ruler
+		modifier = {
+			add = -500
+			exists = scope:recipient.primary_title
+			scope:recipient.primary_title.tier >= tier_kingdom
+			desc = MIGRATION_INTERACTION_KING_ACCEPTANCE
+		}
+		
+		# Recently settled nomads don't want to accept
+		modifier = {
+			add = -1000
+			desc = JUST_SETTLED_REASON
+			scope:recipient = {
+				is_tributary = yes
+				NOT = { government_has_flag = government_is_herder }
+				capital_county = {
+					title_held_years < 3
+				}
+			}
+		}
+	}
+
+	ai_instant_response = yes
+
+	# Available scopes and values
+	#
+	# scope:actor - migrating ruler
+	# scope:recipient - ruler who decides if migration is peaceful or hostile
+	# scope:target - main migration target - can be of any tier
+	#
+	# Additional scopes provided from code
+	#
+	# scope:domain - County or duchy that migrating ruler aims to get as their new domain.
+	# Can be the same as scope:target, if county of duchy-level migration
+	#
+	# scope:domain_fertility - Total current fertility of scope:domain - what actor is going to receive
+	# scope:target_fertility - Total current fertility of main migration target
+	#
+	# scope:defenders - Script list of all rulers who will be part of migration war if declined.
+	# It includes all rulers who are going to lose land - holder of main migration target and all rulers
+	# who has land in scope:domain
+	#
+	# scope:defender_power - combined max military power of all members in scope:defenders.
+	# It's power - i.e. scaled by regiments attack and toughness
+	#
+	ai_will_do = {
+		base = 0
+
+		# More likely to migrate to people you don't like
+		opinion_modifier = {
+			opinion_target = scope:recipient
+			multiplier = -0.25
+		}
+
+		# Bold, energetic characters are more likely to migrate
+		ai_value_modifier = {
+			ai_boldness = 0.25
+			ai_energy = 0.25
+		}
+
+		# We substract your Fertility
+		modifier = {
+			add = {
+				value = scope:actor.current_domain_fertility
+				multiply = -1
+			}
+		}
+
+		# And we add the target realm's Fertility
+		modifier = {
+			add = scope:domain_fertility
+		}
+
+		# Less likely to migrate into players
+		modifier = {
+			add = -25
+			scope:recipient = { is_ai = no }
+		}
+
+		# Can you win this war?
+		modifier = {
+			scope:actor.current_military_strength >= scope:defender_power
+			add = 10
+		}
+		modifier = {
+			scope:actor.current_military_strength <= scope:defender_power
+			add = -30
+		}
+
+		# You're moving from a bad season to a good one
+		modifier = {
+			has_bad_season_nomadic_capital_character_trigger = { CHARACTER = scope:actor }
+			has_good_season_nomadic_capital_character_trigger = { CHARACTER = scope:recipient }
+			add = 10
+		}
+		
+		# There's a very bad season in your area
+		modifier = {
+			scope:actor = {
+				any_character_situation = {
+					any_situation_sub_region = {
+						sub_region_current_phase = situation_steppe_havsarsan_zud_season
+						situation_sub_region_has_county = scope:actor.capital_county
+					}
+				}
+			}
+			add = 100
+		}
+		
+		# You are landless and your herd is starving
+		modifier = {
+			scope:actor = {
+				is_landed = no
+			}
+			add = 100
+		}
+
+		# The recipient is a Herder
+		modifier = {
+			scope:recipient = { government_has_flag = government_is_herder }
+			add = 10
+		}
+
+		# You have a hook on the recipient
+		modifier = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+			add = 25
+		}
+
+		# More likely to migrate with Low Dominance
+		modifier = {
+			scope:actor = {
+				OR = {
+					has_realm_law = nomadic_authority_1
+					has_realm_law = nomadic_authority_2
+				}
+			}
+			add = 10
+		}
+		modifier = {
+			exists = scope:target
+			scope:actor = {
+				scope:target.tier >= tier_kingdom
+				primary_title.tier < tier_kingdom
+				OR = {
+					has_realm_law = nomadic_authority_3
+					has_realm_law = nomadic_authority_4
+					has_realm_law = nomadic_authority_5
+				}
+			}
+			add = 100
+		}
+		modifier = {
+			exists = scope:target
+			scope:actor = {
+				scope:target.tier >= tier_empire
+				primary_title.tier < tier_empire
+				OR = {
+					has_realm_law = nomadic_authority_4
+					has_realm_law = nomadic_authority_5
+				}
+			}
+			add = 100
+		}
+		modifier = {
+			scope:actor = {
+				primary_title.tier >= tier_kingdom
+				has_realm_law = nomadic_authority_3
+			}
+			add = -90
+		}
+		modifier = {
+			scope:actor = {
+				primary_title.tier >= tier_empire
+				OR = {
+					has_realm_law = nomadic_authority_4
+					has_realm_law = nomadic_authority_5
+				}
+			}
+			add = -90
+		}
+
+		#You're in a confederation... you don't want to go anywhere
+		modifier = {
+			scope:actor = {
+				is_confederation_member = yes
+				has_character_flag = new_confederate
+			}
+			add = -100
+		}
+		modifier = {
+			scope:actor = {
+				is_confederation_member = yes
+				NOT = { has_character_flag = new_confederate }
+			}
+			add = -30
+		}
+		#The recipient is bordering your confederation (so you can rejoin)
+		modifier = {
+			scope:actor = {
+				is_confederation_member = yes
+			}
+			scope:recipient = {
+				highest_held_title_tier <= tier_duchy
+				any_land_neighboring_realm_with_tributaries_owner = {
+					OR = {
+						is_member_of_confederation = scope:actor.confederation
+						suzerain ?= {
+							is_member_of_confederation = scope:actor.confederation
+						}
+					}
+				}
+			}
+			add = 30
+		}
+
+		# Don't migrate somewhere where there's a disease or Havsaran Zud
+		modifier = {
+			factor = 0
+			scope:domain = {
+				OR = {
+					AND = {
+						tier = tier_county
+						any_county_situation_sub_region = {
+							sub_region_current_phase = situation_steppe_havsarsan_zud_season
+						}
+					}
+					AND = {
+						tier = tier_county
+						any_county_province = {
+							any_province_epidemic = {
+							}
+						}
+					}
+				}
+			}
+		}
+		# Don't migrate into a domain that contains a vassal player
+		modifier = {
+			scope:domain = {
+				any_in_de_facto_hierarchy = {
+					holder ?= {
+						is_ai = no
+						is_independent_ruler = no
+					}
+				}
+			}
+			factor = 0
+		}
+		# Don't be suicidal
+		modifier = {
+			factor = 0
+			scope:defender_power >= scope:actor.twice_current_military_strength
+		}
+		modifier = {
+			factor = 0
+			scope:defender_power >= 10
+			scope:actor.current_military_strength <= 500
+		}
+		# Do not downgrade your title
+		modifier = {
+			factor = 0
+			exists = scope:target
+			scope:target.tier < scope:actor.primary_title.tier
+		}
+		# Tributaries want to stick close to their suzerain
+		modifier = {
+			factor = 0
+			scope:actor = {
+				is_tributary = yes
+			}
+			scope:domain = {
+				NOR = {
+					holder ?= {
+						is_tributary_of_suzerain_or_above = scope:actor.suzerain
+					}
+					AND = {
+						tier = tier_county
+						any_neighboring_county = {
+							holder ?= {
+								is_tributary_of_suzerain_or_above = scope:actor.suzerain
+							}
+						}
+					}
+					any_in_de_jure_hierarchy = {
+						tier = tier_county
+						OR = {
+							holder ?= {
+								is_tributary_of_suzerain_or_above = scope:actor.suzerain
+							}
+							any_neighboring_county = {
+								holder ?= {
+									is_tributary_of_suzerain_or_above = scope:actor.suzerain
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		# Small AI nomads should only migrate to same-culture areas or right next to them, as everything else looks really bad.
+		modifier = {
+			factor = 0
+			scope:actor = {
+				any_character_situation = {
+					this = situation:the_great_steppe
+				}
+				has_realm_law = nomadic_authority_1
+				# If the character's culture does not exist outside of their realm, allow lenient migrations (otherwise small cultures get stuck)
+				culture = {
+					any_culture_county = {
+						holder.top_liege != scope:actor
+					}
+				}
+			}
+			scope:domain = {
+				NOR = {
+					AND = {
+						tier = tier_county
+						save_temporary_scope_as = county_culture_check
+						OR = {
+							culture = scope:actor.culture
+							culture = {
+								any_parent_culture_or_above = {
+									this = scope:actor.culture
+								}
+							}
+							scope:actor.culture = {
+								any_parent_culture_or_above = {
+									this = scope:county_culture_check.culture
+								}
+							}
+							any_neighboring_county = {
+								OR = {
+									culture = scope:actor.culture
+									culture = {
+										any_parent_culture_or_above = {
+											this = scope:actor.culture
+										}
+									}
+									scope:actor.culture = {
+										any_parent_culture_or_above = {
+											this = scope:county_culture_check.culture
+										}
+									}
+								}
+							}
+						}
+					}
+					any_in_de_jure_hierarchy = {
+						tier = tier_county
+						save_temporary_scope_as = county_culture_check
+						OR = {
+							culture = scope:actor.culture
+							culture = {
+								any_parent_culture_or_above = {
+									this = scope:actor.culture
+								}
+							}
+							scope:actor.culture = {
+								any_parent_culture_or_above = {
+									this = scope:county_culture_check.culture
+								}
+							}
+							any_neighboring_county = {
+								OR = {
+									culture = scope:actor.culture
+									culture = {
+										any_parent_culture_or_above = {
+											this = scope:actor.culture
+										}
+									}
+									scope:actor.culture = {
+										any_parent_culture_or_above = {
+											this = scope:county_culture_check.culture
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		# Slightly bigger nomads are also allowed to migrate into non-nomadic lands
+		modifier = {
+			factor = 0
+			scope:actor = {
+				any_character_situation = {
+					this = situation:the_great_steppe
+				}
+				has_realm_law = nomadic_authority_2
+				# If the character's culture does not exist outside of their realm, allow lenient migrations (otherwise small cultures get stuck)
+				culture = {
+					any_culture_county = {
+						holder.top_liege != scope:actor
+					}
+				}
+			}
+			scope:domain = {
+				NOR = {
+					AND = {
+						tier = tier_county
+						save_temporary_scope_as = county_culture_check
+						OR = {
+							culture = scope:actor.culture
+							culture = {
+								any_parent_culture_or_above = {
+									this = scope:actor.culture
+								}
+							}
+							scope:actor.culture = {
+								any_parent_culture_or_above = {
+									this = scope:county_culture_check.culture
+								}
+							}
+							any_neighboring_county = {
+								OR = {
+									culture = scope:actor.culture
+									culture = {
+										any_parent_culture_or_above = {
+											this = scope:actor.culture
+										}
+									}
+									scope:actor.culture = {
+										any_parent_culture_or_above = {
+											this = scope:county_culture_check.culture
+										}
+									}
+								}
+							}
+							title_province = {
+								NOR = {
+									has_holding_type = nomad_holding
+									has_holding_type = herder_holding
+								}
+							}
+						}
+					}
+					any_in_de_jure_hierarchy = {
+						tier = tier_county
+						save_temporary_scope_as = county_culture_check
+						OR = {
+							culture = scope:actor.culture
+							culture = {
+								any_parent_culture_or_above = {
+									this = scope:actor.culture
+								}
+							}
+							scope:actor.culture = {
+								any_parent_culture_or_above = {
+									this = scope:county_culture_check.culture
+								}
+							}
+							any_neighboring_county = {
+								OR = {
+									culture = scope:actor.culture
+									culture = {
+										any_parent_culture_or_above = {
+											this = scope:actor.culture
+										}
+									}
+									scope:actor.culture = {
+										any_parent_culture_or_above = {
+											this = scope:county_culture_check.culture
+										}
+									}
+								}
+							}
+							title_province = {
+								NOR = {
+									has_holding_type = nomad_holding
+									has_holding_type = herder_holding
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		# Big nomads move more freely, and the small ones will follow because they'll spread their culture there!
+		modifier = {
+			factor = 0
+			scope:actor = {
+				any_character_situation = {
+					this = situation:the_great_steppe
+				}
+				NOR = {
+					has_realm_law = nomadic_authority_1
+					has_realm_law = nomadic_authority_2
+				}
+				# If the character's culture does not exist outside of their realm, allow lenient migrations (otherwise small cultures get stuck)
+				culture = {
+					any_culture_county = {
+						holder.top_liege != scope:actor
+					}
+				}
+				capital_county = {
+					any_county_situation_sub_region = {
+						NOR = {
+							sub_region_current_phase = situation_steppe_havsarsan_zud_season
+							sub_region_current_phase = situation_steppe_severe_drought_season
+							sub_region_current_phase = situation_steppe_cold_zud_season
+							sub_region_current_phase = situation_steppe_white_zud_season
+						}
+					}
+				}
+			}
+			scope:domain = {
+				NOR = {
+					AND = {
+						tier = tier_county
+						save_temporary_scope_as = county_culture_check
+						OR = {
+							culture = scope:actor.culture
+							culture = {
+								any_parent_culture_or_above = {
+									this = scope:actor.culture
+								}
+							}
+							culture = {
+								has_same_culture_heritage = scope:actor.culture
+							}
+							culture = {
+								any_parent_culture_or_above = {
+									has_same_culture_heritage = scope:actor.culture
+								}
+							}
+							scope:actor.culture = {
+								any_parent_culture_or_above = {
+									this = scope:county_culture_check.culture
+								}
+							}
+							scope:actor.culture = {
+								any_parent_culture_or_above = {
+									has_same_culture_heritage = scope:county_culture_check.culture
+								}
+							}
+							any_neighboring_county = {
+								OR = {
+									culture = scope:actor.culture
+									culture = {
+										any_parent_culture_or_above = {
+											this = scope:actor.culture
+										}
+									}
+									culture = {
+										has_same_culture_heritage = scope:actor.culture
+									}
+									culture = {
+										any_parent_culture_or_above = {
+											has_same_culture_heritage = scope:actor.culture
+										}
+									}
+									scope:actor.culture = {
+										any_parent_culture_or_above = {
+											this = scope:county_culture_check.culture
+										}
+									}
+									scope:actor.culture = {
+										any_parent_culture_or_above = {
+											has_same_culture_heritage = scope:county_culture_check.culture
+										}
+									}
+								}
+							}
+							title_province = {
+								NOR = {
+									has_holding_type = nomad_holding
+									has_holding_type = herder_holding
+								}
+							}
+						}
+					}
+					any_in_de_jure_hierarchy = {
+						tier = tier_county
+						save_temporary_scope_as = county_culture_check
+						OR = {
+							culture = scope:actor.culture
+							culture = {
+								any_parent_culture_or_above = {
+									this = scope:actor.culture
+								}
+							}
+							culture = {
+								has_same_culture_heritage = scope:actor.culture
+							}
+							culture = {
+								any_parent_culture_or_above = {
+									has_same_culture_heritage = scope:actor.culture
+								}
+							}
+							scope:actor.culture = {
+								any_parent_culture_or_above = {
+									this = scope:county_culture_check.culture
+								}
+							}
+							scope:actor.culture = {
+								any_parent_culture_or_above = {
+									has_same_culture_heritage = scope:county_culture_check.culture
+								}
+							}
+							any_neighboring_county = {
+								OR = {
+									culture = scope:actor.culture
+									culture = {
+										any_parent_culture_or_above = {
+											this = scope:actor.culture
+										}
+									}
+									culture = {
+										has_same_culture_heritage = scope:actor.culture
+									}
+									culture = {
+										any_parent_culture_or_above = {
+											has_same_culture_heritage = scope:actor.culture
+										}
+									}
+									scope:actor.culture = {
+										any_parent_culture_or_above = {
+											this = scope:county_culture_check.culture
+										}
+									}
+									scope:actor.culture = {
+										any_parent_culture_or_above = {
+											has_same_culture_heritage = scope:county_culture_check.culture
+										}
+									}
+								}
+							}
+							title_province = {
+								NOR = {
+									has_holding_type = nomad_holding
+									has_holding_type = herder_holding
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+# PAIZA
+mpo_interaction_grant_paiza = {
+	category = interaction_category_diplomacy
+	icon = paiza_interaction
+	common_interaction = no
+
+	desc = mpo_interaction_grant_paiza_desc
+
+	ai_frequency = 8
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	is_shown = {
+		scope:actor = {
+			has_character_flag = established_paiza_system
+			exists = situation:the_great_steppe
+			any_character_situation = {
+				this = situation:the_great_steppe
+			}
+			government_has_flag = government_is_nomadic
+		}
+		scope:recipient = {
+			government_has_flag = government_is_nomadic
+			OR = {
+				is_vassal_of = scope:actor
+				is_tributary_of = scope:actor
+				is_courtier_of = scope:actor
+			}
+		}
+	}
+
+	cooldown_against_recipient = { years = 10 }
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			NOT = {
+				is_at_war_with = scope:recipient
+			}
+			is_independent_ruler = yes
+			custom_tooltip = {
+				text = mpo_character_interaction_gurkhan
+				is_gurkhan = yes
+			}
+			custom_tooltip = {
+				text = mpo_character_interaction_established_paiza_system
+				has_character_flag = established_paiza_system
+			}
+		}
+		scope:recipient = {
+			custom_tooltip = {
+				text = mpo_character_interaction_obedient
+				NOT = { is_obedient_to = scope:actor }
+			}
+			NOT = {
+				any_character_artifact = {
+					scope:recipient = { can_benefit_from_artifact = prev }
+					scope:artifact.var:paiza_patron ?= { is_gurkhan = yes }
+					scope:artifact.var:paiza_patron ?= scope:actor
+				}
+			}
+		}
+	}
+
+	cost = {
+		prestige = major_prestige_value
+		gold = 25
+	}
+
+	on_accept = {
+		make_obedient_recipient_to_actor_effect = yes
+		scope:recipient = {
+			mpo_create_paiza_artifact_effect = {
+				PATRON = scope:actor
+				GRANTEE = scope:recipient
+			}
+			custom_tooltip = mpo_establish_paiza_system_decision.paiza_abuse_authority_unlocked
+			custom_tooltip = mpo_establish_paiza_system_decision.leverage_khan_authority_unlocked
+		}
+		scope:actor = {
+			switch = {
+				trigger = scope:recipient.primary_title.tier
+				tier_empire = {
+					add_legitimacy_effect = { LEGITIMACY = massive_legitimacy_gain }
+				}
+				tier_kingdom = {
+					add_legitimacy_effect = { LEGITIMACY = major_legitimacy_gain }
+				}
+				tier_duchy = {
+					add_legitimacy_effect = { LEGITIMACY = medium_legitimacy_gain }
+				}
+				tier_county = {
+					add_legitimacy_effect = { LEGITIMACY = miniscule_legitimacy_gain }
+				}
+			}
+		}
+	}
+
+	ai_targets = {
+		ai_recipients = vassals
+		ai_recipients = tributaries
+	}
+
+
+	ai_accept = {
+		base = -20
+		opinion_modifier = {
+			opinion_target = scope:actor
+			who = scope:recipient
+			multiplier = 1
+		}
+		modifier = {
+			add = intimidated_external_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 1
+				}
+			}
+			desc = INTIMIDATED_REASON
+		}
+		modifier = {
+			add = cowed_external_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 2
+				}
+			}
+			desc = COWED_REASON
+		}
+		modifier = {
+			add = 40
+			scope:recipient = {
+				ai_honor < 0
+				ai_greed > 0
+			}
+			desc = will_abuse_paiza_reason
+		}
+	}
+
+	ai_will_do = {
+		base = 10
+
+		modifier = {
+			factor = 10
+			scope:recipient = {
+				is_ai = no
+				OR = {
+					is_vassal_of = scope:actor
+					is_tributary_of = scope:actor
+				}
+			}
+		}
+
+		modifier = {
+			factor = 10
+			scope:recipient = {
+				NOT = {
+					is_obedient_to = root
+				}
+				OR = {
+					is_powerful_vassal = yes
+					is_kurultai_trigger = yes
+				}
+			}
+		}
+	}
+}
+
+mpo_interaction_ask_for_paiza = {
+	category = interaction_category_diplomacy
+	icon = paiza_interaction
+	common_interaction = no
+
+	desc = mpo_interaction_ask_for_paiza_desc
+
+	ai_frequency = 8
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	is_shown = {
+		scope:recipient = {
+			government_has_flag = government_is_nomadic
+			has_character_flag = established_paiza_system
+		}
+		scope:actor = {
+			OR = {
+				government_has_flag = government_is_nomadic
+				top_liege = scope:recipient
+			}
+			NOT = {
+				is_at_war_with = scope:recipient
+			}
+		}
+	}
+
+	cooldown_against_recipient = { years = 10 }
+
+	is_valid_showing_failures_only = {
+		scope:recipient = {
+			is_independent_ruler = yes
+			is_gurkhan = yes
+		}
+		scope:actor = {
+			custom_tooltip = {
+				text = already_received_a_paiza
+				NOT = {
+					any_character_artifact = {
+						scope:actor = { can_benefit_from_artifact = prev }
+						var:paiza_patron ?= scope:recipient
+					}
+				}
+			}		
+		}
+	}
+
+	send_options_exclusive = no
+	send_option = {
+		flag = hook
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		localization = GENERIC_SPEND_A_HOOK
+	}
+
+	send_option = { # Herd
+		is_shown = {
+			scope:actor = {
+				government_has_flag = government_is_nomadic
+				exists = domicile
+			}
+		}
+		is_valid = {
+			scope:actor = {
+				government_has_flag = government_is_nomadic
+				exists = domicile
+			}
+			scope:actor.domicile = { herd >= scope:recipient.domicile.massive_herd_value }
+		}
+		flag = herd_send_option
+		localization = TRADE_HERD_FOR_BETTER_AI_ACCEPTANCE_CONFEDERATION
+	}
+
+	on_accept = {
+		scope:actor = {
+			make_obedient_recipient_to_actor_effect = yes
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = mpo_decisions_events.paiza_granted
+				mpo_create_paiza_artifact_effect = {
+					PATRON = scope:recipient
+					GRANTEE = scope:actor
+				}
+				left_icon = scope:recipient
+				right_icon = scope:created_paiza
+			}
+			custom_tooltip = mpo_establish_paiza_system_decision.paiza_abuse_authority_unlocked
+			custom_tooltip = mpo_establish_paiza_system_decision.leverage_khan_authority_unlocked	
+			if = {
+				limit = {
+					scope:herd_send_option = yes
+				}
+				pay_herd = {
+					target = scope:recipient
+					value = scope:recipient.domicile.massive_herd_value
+				}
+			}
+			if = {
+				limit = {
+					scope:hook = yes
+				}
+				use_hook = scope:recipient
+			}
+		}
+		scope:recipient = {
+			switch = {
+				trigger = scope:actor.primary_title.tier
+				tier_empire = {
+					add_legitimacy_effect = { LEGITIMACY = massive_legitimacy_gain }
+				}
+				tier_kingdom = {
+					add_legitimacy_effect = { LEGITIMACY = major_legitimacy_gain }
+				}
+				tier_duchy = {
+					add_legitimacy_effect = { LEGITIMACY = medium_legitimacy_gain }
+				}
+				tier_county = {
+					add_legitimacy_effect = { LEGITIMACY = miniscule_legitimacy_gain }
+				}
+			}
+			add_character_flag = {
+				flag = paiza_recently_granted
+				years = 1
+			}
+		}
+	}
+
+	ai_accept = {
+		base = -60	
+		modifier = {
+			add = intimidated_external_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 1
+				}
+			}
+			desc = INTIMIDATED_REASON
+		}
+		modifier = {
+			add = cowed_external_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 2
+				}
+			}
+			desc = COWED_REASON
+		}
+		modifier = {
+			add = 40
+			scope:actor = {
+				NOT = {
+					is_obedient_to = root
+				}
+				OR = {
+					is_powerful_vassal = yes
+					is_kurultai_trigger = yes
+				}
+			}
+			desc = AI_NOT_OBEDIENT_REVERSE_REASON
+		}
+		modifier = {
+			add = -20
+			scope:actor = {
+				is_obedient_to = scope:recipient
+			}
+			desc = AI_OBEDIENT_REVERSE_REASON
+		}
+		modifier = {
+			scope:recipient = {
+				has_relation_blood_brother = scope:actor
+			}
+			add = 100
+			desc = MIGRATION_INTERACTION_BLOOD_BROTHERS_ACCEPTANCE
+		}
+		
+		modifier = {
+			trigger = {
+				scope:hook ?= yes
+			}
+			add = 60
+			desc = LEGEND_HOOK_USED
+		}
+
+		modifier = {
+			add = 20
+			trigger = {
+				scope:herd_send_option ?= yes
+			}
+			desc = HERD_INTERACTION_ACCEPTANCE_SEND_OPTION
+		}
+
+		opinion_modifier = {
+			opinion_target = scope:actor
+			who = scope:recipient
+			multiplier = 0.4
+		}
+		
+	}
+
+	ai_will_do = {
+		base = 10
+
+		modifier = {
+			add = 100
+			scope:recipient = {
+				has_relation_blood_brother = scope:actor
+			}
+		}
+
+		modifier = {
+			add = scope:actor.ai_greed
+			scope:actor = {
+				ai_greed > 0
+			}
+		}
+
+		modifier = {
+			add = {
+				value = scope:actor.primary_title.tier
+				subtract = scope:recipient.primary_title.tier
+				multiply = 10
+				max = 0
+			}
+		}
+
+		modifier = {
+			add = scope:actor.ai_honor
+			scope:actor = {
+				ai_honor > 0
+			}
+		}
+
+		modifier = {
+			factor = 0.1
+			scope:recipient = {
+				has_character_flag = paiza_recently_granted
+			}
+		}
+
+		ai_value_modifier = {
+			ai_boldness = -0.4
+			ai_honor = 0.2
+			ai_greed = 0.2
+			ai_energy = -0.2
+		}
+	}
+
+	ai_targets = {
+		ai_recipients = liege
+		ai_recipients = suzerain
+	}
+}
+
+mpo_interaction_leverage_khan_authority = {
+	category = interaction_category_hostile
+	icon = paiza_interaction
+	common_interaction = no
+
+	desc = mpo_interaction_leverage_khan_authority_desc
+
+	ai_frequency = 8
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	cooldown = { months = 6 }
+
+	cooldown_against_recipient = { years = 10 }
+
+	is_shown = {
+		scope:actor = {
+			any_character_artifact = {
+				scope:actor = { can_benefit_from_artifact = prev }
+				has_variable = paiza_patron
+				OR = {
+					scope:recipient.top_liege = var:paiza_patron
+					scope:recipient = {
+						is_independent_ruler = yes
+						primary_title.tier < scope:actor.primary_title.tier
+						government_has_flag = government_is_nomadic
+					}
+					scope:recipient = {
+						liege = {
+							OR = {
+								government_has_flag = government_is_nomadic
+								scope:recipient.top_liege = prev.var:paiza_patron
+							}
+						}
+					}
+				}
+			}
+			NOT = {
+				has_character_flag = established_paiza_system
+			}
+		}
+		scope:recipient = {
+			is_ai = yes
+			is_gurkhan = no
+			age >= 12
+			NOT = {
+				has_character_flag = established_paiza_system		
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			custom_tooltip = {
+				text = mpo_abuse_authority_paiza_decision.no_more_paiza_abuse
+				NOT = { has_character_flag = no_more_paiza_abuse }			
+			}
+			custom_tooltip = {
+        	    text = mpo_abuse_authority_paiza_decision.paiza_patron_not_topdog
+        	    any_character_artifact = {
+        	        scope:actor = { can_benefit_from_artifact = prev }
+        	        exists = var:paiza_patron
+        	        var:paiza_patron ?= {
+        	            is_gurkhan = yes
+        	        }    
+        	    }
+        	}
+        	NOT = {
+				is_at_war_with = scope:recipient
+			}
+		}
+	}
+
+	ai_accept = {
+		base = -60
+		modifier = {
+			add = 10
+			has_trait = craven
+			desc = BLACKMAIL_INTERACTION_CRAVEN_ACCEPTANCE
+		}
+		modifier = {
+			add = -20
+			has_trait = arrogant
+			desc = BLACKMAIL_INTERACTION_ARROGANT_ACCEPTANCE
+		}
+		modifier = {
+			add = -20
+			has_trait = brave
+			desc = BLACKMAIL_INTERACTION_BRAVE_ACCEPTANCE
+		}
+		modifier = {
+			add = -20
+			has_trait = paranoid
+			desc = BLACKMAIL_INTERACTION_PARANOID_ACCEPTANCE 
+		}
+		modifier = {
+			add = {
+				value = scope:recipient.intrigue
+				multiply = -2
+			}
+			desc = INDEBT_GUEST_INTRIGUE_RECIPIENT
+		}
+		modifier = {
+			add = {
+				value = scope:actor.intrigue
+			}
+			desc = INDEBT_GUEST_INTRIGUE_ACTOR
+		}
+		modifier = {
+			add = {
+				value = scope:actor.dread
+				divide = 2
+			}
+			scope:actor.dread >= 2
+			desc = offer_vassalization_interaction_aibehavior_dreaded_tt
+		}
+		opinion_modifier = {
+			opinion_target = situation:the_great_steppe.situation_top_herd
+			who = scope:recipient
+			multiplier = 0.4
+		}
+		opinion_modifier = {
+			opinion_target = scope:actor
+			who = scope:recipient
+			multiplier = 0.2
+		}
+	}
+
+	ai_will_do = {
+		base = -40
+		modifier = {
+            add = 30
+			domicile ?= { herd <= twenty_percent_herd_value }
+        }
+		modifier = {
+            add = 10
+			domicile ?= { herd <= sixty_percent_herd_value }
+        }
+        modifier = {
+            add = 10
+            has_trait = greedy
+        }
+        modifier = {
+            add = 10
+            has_trait = wrathful
+        }
+        modifier = {
+            add = 10
+            has_trait = ambitious
+        }
+	}
+
+	ai_targets = {
+		ai_recipients = peer_vassals
+	}
+
+	on_accept = {
+		scope:actor = {
+			send_interface_toast = {
+				left_icon = scope:recipient
+				right_icon = situation:the_great_steppe.situation_top_herd
+				title = mpo_interaction_leverage_khan_authority
+				make_obedient_recipient_to_actor_effect = yes
+				scope:recipient = {
+					pay_short_term_gold = {
+						target = scope:actor
+						gold = {
+							value = current_gold_value
+							divide = 2
+						}
+					}
+					if = {
+						limit = {
+							government_has_flag = government_is_nomadic
+							scope:recipient = {
+								government_has_flag = government_is_nomadic
+							}
+						}
+						pay_herd = {
+							target = scope:actor
+							value = {
+								value = domicile.herd
+								multiply = 0.5
+							}
+						}
+					}	
+				}
+				if = {
+					limit = {
+						scope:recipient = {
+							OR = {
+								is_landed = yes
+							}
+						}
+					}
+					add_prestige = medium_prestige_value
+				}
+				else = {
+					add_prestige = minor_prestige_value
+				}
+			}
+		}
+		
+		scope:actor = {	
+			random_character_artifact = {
+				limit = {
+					scope:actor = { can_benefit_from_artifact = prev }
+					has_variable = paiza_patron
+				}
+				var:paiza_patron = {
+					scope:actor = {
+						mpo_paiza_abuse_counter_effect = {
+							PAIZA_PATRON = prev
+							PAIZA_ABUSER = scope:actor
+						}
+					}
+				}
+			}
+			
+		}
+	}
+}
+
+# Interrogate
+# Used in the Ill-Advised event chain - nomad_events.0001 - 0099
+interrogate_interaction = {
+	category = interaction_category_hostile
+	icon = icon_scheme_challenge_status
+	common_interaction = no
+
+	auto_accept = yes
+
+	desc = interrogate_interaction_desc
+
+	is_shown = {
+		scope:actor = { has_variable = can_interrogate_var }
+		scope:recipient = {
+			is_target_in_variable_list = {
+				name = valid_to_interrogate_var
+				target = scope:actor
+			}
+		}
+		# And Achmach is still around
+		scope:actor = {
+			any_courtier_or_guest = {
+				has_variable = achmach_loyalty
+			}
+		}
+	}
+
+	cooldown_against_recipient = { years = 10 }
+
+	on_accept = {
+		scope:actor = {
+			custom_tooltip = interrogate_interaction_tt
+			trigger_event = nomad_events.0006
+		}
+		scope:recipient = {
+			custom_tooltip = interrogate_interaction_recipient_tt
+		}
+	}
+
+	ai_will_do = {
+		base = 100
+	}
+}
+
+# Steal Herd
+steal_herd_interaction = {
+	icon = icon_scheme_steal_herd
+	interface_priority = 90
+	common_interaction = yes
+	category = interaction_category_hostile
+
+	send_name = START_SCHEME
+
+	scheme = steal_herd
+	ignores_pending_interaction_block = yes
+
+	is_shown = {
+		NOT = { scope:recipient = scope:actor }
+		scope:actor = {
+			is_landed = yes
+			is_adult = yes
+			is_imprisoned = no
+			government_has_flag = government_is_nomadic
+			in_diplomatic_range = scope:recipient
+			trigger_if = {
+				limit = {
+					is_ai = yes
+				}
+				NOR = {
+					is_tributary_of_suzerain_or_above = scope:recipient
+					is_vassal_or_below_of = scope:recipient
+					scope:recipient = {
+						is_ai = no
+						any_targeting_scheme = {
+							scheme_type = steal_herd
+						}
+					}
+				}
+			}
+		}
+		scope:recipient = {
+			is_landed = yes
+			is_adult = yes
+			government_has_flag = government_is_nomadic
+			highest_held_title_tier >= tier_county
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			can_start_scheme = {
+				type = steal_herd
+				target_character = scope:recipient
+			}
+		}
+		scope:recipient = { NOT = { has_strong_hook = scope:actor } }
+	}
+
+	desc = {
+		triggered_desc = {
+			trigger = {
+				scope:actor = {
+					can_start_scheme = {
+						type = steal_herd
+						target_character = scope:recipient
+					}
+				}
+			}
+			desc = scheme_interaction_tt_steal_herd_approved
+		}
+	}
+
+	on_accept = {
+		scope:actor = {
+			stress_impact = {
+				compassionate = minor_stress_impact_gain
+				honest = minor_stress_impact_gain
+				craven = minor_stress_impact_gain
+				content = minor_stress_impact_gain
+			}
+			send_interface_toast = {
+				type = event_toast_effect_neutral
+				title = steal_herd_interaction_notification
+
+				left_icon = scope:actor
+				right_icon = scope:recipient
+
+				begin_scheme_basic_effect = {
+					SCHEME_TYPE = steal_herd
+					TARGET_TYPE = target_character
+					TARGET_SCOPE = scope:recipient
+				}
+
+				if = {
+					limit = {
+						domicile ?= { herd >= ninety_percent_herd_value }
+					}
+					custom_tooltip = steal_herd_interaction_tt.warning
+				}
+				scope:new_scheme ?= {
+					if = {
+						limit = {
+							scope:steal_herd_low ?= yes
+						}
+						set_variable = steal_herd_low
+					}
+					else_if = {
+						limit = {
+							scope:steal_herd_normal ?= yes
+						}
+						set_variable = steal_herd_normal
+					}
+					else_if = {
+						limit = {
+							scope:steal_herd_high ?= yes
+						}
+						set_variable = steal_herd_high
+					}
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+		trigger_if = {
+			limit = {
+				NOT = {
+					domicile ?= {
+						has_domicile_building_or_higher = steal_herd_yurt_01
+					}
+				}
+			}
+			ai_honor <= 50
+		}
+		primary_title.tier >= tier_county
+		NOR = {
+			scheme_generic_ai_blocker_trigger = yes
+			primary_title = {
+				is_mercenary_company = yes
+			}
+		}
+		prestige >= medium_prestige_value # In case they fail
+	}
+
+	auto_accept = yes
+	
+	ai_will_do = {
+		base = -30
+
+		modifier = {
+			add = 20
+			domicile ?= { herd <= twenty_percent_herd_value }
+		}
+
+		modifier = {
+			add = 20
+			domicile ?= { herd <= sixty_percent_herd_value }
+		}
+		
+		modifier = {
+			add = {
+				value = intrigue
+				multiply = 3
+			}
+		}
+		
+		modifier = {
+			add = {
+				value = ai_greed
+				multiply = -1
+			}
+		}
+		modifier = {
+			add = {
+				value = ai_honor
+				multiply = -0.25
+			}
+		}
+		modifier = {
+			scope:actor = {
+				has_trait = schemer
+			}
+			add = 60
+		}
+		modifier = {
+			scope:actor = {
+				has_relation_rival = scope:recipient
+			}
+			add = 60
+		}
+		modifier = {
+			scope:actor = {
+				has_relation_nemesis = scope:recipient
+			}
+			add = 150
+		}
+		modifier = {
+			scope:actor = {
+				opinion = {
+					target = scope:recipient
+					value >= low_positive_opinion
+				}
+				ai_greed <= high_positive_ai_value
+			}
+			factor = 0
+		}
+		modifier = {
+			scope:recipient = {
+				OR = {
+					has_relation_friend = scope:actor
+					has_relation_lover = scope:actor
+					is_obedient_to = scope:actor
+				}
+			}
+			factor = 0
+		}
+		start_hostile_scheme_ai_base_modifiers = yes # At the end so Cowed can block it completely
+	}
+
+	ai_targets = {
+		ai_recipients = scripted_relations
+		ai_recipients = neighboring_rulers
+		ai_recipients = peer_vassals
+	}
+
+	# Options
+	options_heading = schemes.t.herd_amount
+	send_options_exclusive = yes
+	## Steal a little herd
+	send_option = {
+		flag = steal_herd_low
+		current_description = steal_herd_interaction.tt.low
+	}
+	## Steal a moderate amount of herd
+	send_option = {
+		flag = steal_herd_normal
+		current_description = steal_herd_interaction.tt.normal
+	}
+	## Steal a lot of herd
+	send_option = {
+		flag = steal_herd_high
+		current_description = steal_herd_interaction.tt.high
+	}
+
+	ai_frequency = 36
+}
+
+mpo_ask_for_herd_interaction = {
+	category = interaction_category_hostile
+	icon = demand_herd
+	desc = mpo_ask_for_herd_interaction_desc
+	interface_priority = 80
+	common_interaction = yes
+
+	ai_frequency = 8
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	is_shown = {
+		scope:actor = {
+			government_has_flag = government_is_nomadic
+			exists = domicile
+		}
+		scope:recipient = {
+			government_has_flag = government_is_nomadic
+			exists = domicile
+			is_ai = yes
+		}
+		NOT = {
+			scope:actor = {
+				has_variable = had_mpo_temujin_flavor_0020
+				var:had_mpo_temujin_flavor_0020 ?= scope:recipient
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			NOT = {
+				is_imprisoned = yes
+			}
+		}
+		scope:recipient = {
+			NOR = {
+				is_imprisoned = yes
+				is_at_war = yes
+				is_a_faction_member = yes
+				custom_description = {
+					text = ask_for_herd_not_enough_herd
+					domicile.herd < scope:recipient.domicile.ask_for_herd_base_value
+					government_has_flag = government_is_nomadic
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+		primary_title.tier >= tier_duchy
+	}
+
+	send_option = {
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		flag = hook
+		localization = GENERIC_SPEND_A_HOOK
+	}
+
+	send_option = {
+		is_valid = {
+			scope:recipient.domicile ?= {
+				herd > ask_for_herd_double_value
+			}
+			scope:recipient = {
+				NOT = {
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+		flag = more_herd
+		localization = ASK_FOR_HERD_MORE_HERD
+	}
+
+	send_options_exclusive = no
+
+	ai_accept = {
+		base = -100
+		modifier = {
+			trigger = {
+				scope:more_herd ?= yes
+			}
+			add = -100
+			desc = ASK_FOR_HERD_MORE_HERD_REASON
+		}
+		modifier = {
+			trigger = {
+				scope:hook ?= yes
+			}
+			add = 1000
+			desc = MIGRATION_HOOK_USED
+		}
+		modifier = {
+			add = {
+				value = ai_boldness
+				multiply = -1
+				divide = 4
+			}
+			NOT = { ai_boldness = 0 }
+			desc = ARTIFACT_BOLDNESS_REASON
+		}
+		opinion_modifier = {
+			who = scope:recipient
+			opinion_target = scope:actor
+			desc = AI_OPINION_REASON
+		}
+		bp2_hostage_dread_modifier = yes
+	}
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			add = 20
+			scope:actor.domicile.herd < scope:actor.domicile.ask_for_herd_double_value
+		}
+	}
+
+	cooldown_against_recipient = { years = 6 }
+
+	ai_targets = {
+		ai_recipients = vassals
+		ai_recipients = neighboring_rulers
+		ai_recipients = peer_vassals
+	}
+
+	on_accept = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = ask_for_herd_toast
+				left_icon = scope:recipient
+				scope:recipient = {
+					# How much Herd are you getting?
+					if = {
+						limit = {
+							scope:more_herd ?= yes
+						}
+						if = {
+							limit = {
+								scope:actor = { has_variable = nomad_events_0210_herd_var }
+							}
+							pay_herd = {
+								target = scope:actor
+								value = {
+									value = scope:recipient.domicile.ask_for_herd_double_value
+									multiply = 2
+								}
+							}
+						}
+						else = {
+							pay_herd = {
+								target = scope:actor
+								value = scope:recipient.domicile.ask_for_herd_double_value
+							}
+						}
+					}
+					else = {
+						if = {
+							limit = {
+								scope:actor = { has_variable = nomad_events_0210_herd_var }
+							}
+							pay_herd = {
+								target = scope:actor
+								value = {
+									value = scope:recipient.domicile.ask_for_herd_base_value
+									multiply = 2
+								}
+							}
+						}
+						else = {
+							pay_herd = {
+								target = scope:actor
+								value = scope:recipient.domicile.ask_for_herd_base_value
+							}
+						}
+					}
+					# Extra Herd during the Abundant Grazing season
+					if = {
+						limit = {
+							any_character_situation = {
+								any_situation_sub_region = {
+									has_sub_region_phase_parameter = the_great_steppe_demand_herd_higher_rate
+									any_situation_sub_region_participant_group = {
+										participant_group_type = nomad_rulers_capital
+										participant_group_has_character = scope:actor
+									}
+								}
+							}
+						}
+						custom_tooltip = {
+							text = ask_for_herd_abundant_grazing_tt
+							pay_herd = {
+								target = scope:actor
+								value = scope:recipient.domicile.ask_for_herd_half_value
+							}
+						}
+					}
+					# Now opinion maluses
+					if = {
+						limit = {
+							scope:more_herd ?= yes
+						}
+						if = {
+							limit = {
+								scope:recipient = {
+									has_dread_level_towards = { target = scope:actor level = 2 }
+								}
+							}
+							custom_tooltip = ask_for_herd_dread_effect_tt
+							add_opinion = {
+								target = scope:actor
+								modifier = ask_for_herd_opinion
+								opinion = -20
+							}
+						}
+						else_if = {
+							limit = {
+								scope:recipient = {
+									has_dread_level_towards = { target = scope:actor level = 1 }
+								}
+							}
+							custom_tooltip = ask_for_herd_dread_effect_tt
+							add_opinion = {
+								target = scope:actor
+								modifier = ask_for_herd_opinion
+								opinion = -40
+							}
+						}
+						else = {
+							add_opinion = {
+								target = scope:actor
+								modifier = ask_for_herd_opinion
+								opinion = -60
+							}
+						}
+					}
+					else = {
+						if = {
+							limit = { #herders cannot give you more herd
+								scope:recipient = {
+									government_has_flag = government_is_herder
+								}
+							}
+							scope:actor = {
+								change_herd = major_herd_gain
+								add_legitimacy = minor_legitimacy_loss
+							}
+							scope:recipient.primary_title = {
+								custom_tooltip = ask_for_herd_herder_recipient_tt
+								add_county_modifier = {
+									modifier = ask_for_herd_county_depleted_modifier
+									years = 12
+								}
+							}
+						}
+						else = {
+							if = {
+								limit = {
+									scope:recipient = {
+										has_dread_level_towards = { target = scope:actor level = 2 }
+									}
+								}
+								custom_tooltip = ask_for_herd_dread_effect_tt
+								add_opinion = {
+									target = scope:actor
+									modifier = ask_for_herd_opinion
+									opinion = -10
+								}
+							}
+							else_if = {
+								limit = {
+									scope:recipient = {
+										has_dread_level_towards = { target = scope:actor level = 1 }
+									}
+								}
+								custom_tooltip = ask_for_herd_dread_effect_tt
+								add_opinion = {
+									target = scope:actor
+									modifier = ask_for_herd_opinion
+									opinion = -20
+								}
+							}
+							else = {
+								add_opinion = {
+									target = scope:actor
+									modifier = ask_for_herd_opinion
+									opinion = -40
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+### Demand Obedience
+mpo_demand_obedience_interaction = {
+	category = interaction_category_vassal
+	icon = demand_obedience
+	desc = mpo_demand_obedience_interaction_desc
+	interface_priority = 80
+	common_interaction = yes
+
+	ai_frequency = 4
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	is_shown = {
+		scope:actor = {
+			government_has_flag = government_is_nomadic
+		}
+		scope:recipient = {
+			is_ai = yes
+			obedience_target ?= scope:actor
+			is_obedient = no
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			age >= 16
+			is_physically_able = yes
+			NOT = {
+				is_at_war_with = scope:recipient
+			}
+		}
+		scope:actor = { dread >= medium_dread_value }
+	}
+
+	cost = { prestige = minor_prestige_value }
+
+	ai_potential = {
+		government_has_flag = government_is_nomadic
+		primary_title.tier >= tier_duchy
+	}
+
+	send_option = {
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		flag = hook
+		localization = GENERIC_SPEND_A_HOOK
+	}
+
+	send_options_exclusive = no
+
+	ai_accept = {
+		base = -50
+		modifier = {
+			trigger = {
+				scope:hook ?= yes
+			}
+			add = 100
+			desc = MIGRATION_HOOK_USED
+		}
+		modifier = {
+			add = 10
+			scope:actor = { has_realm_law = nomadic_authority_2 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_DOMINANCE_ACCEPTANCE
+		}
+		modifier = {
+			add = 20
+			scope:actor = { has_realm_law = nomadic_authority_3 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_DOMINANCE_ACCEPTANCE
+		}
+		modifier = {
+			add = 50
+			scope:actor = { has_realm_law = nomadic_authority_4 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_DOMINANCE_ACCEPTANCE
+		}
+		modifier = {
+			add = 100
+			scope:actor = { has_realm_law = nomadic_authority_5 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_DOMINANCE_ACCEPTANCE
+		}
+		modifier = {
+			add = -20
+			scope:actor = { legitimacy_level = 1 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = 10
+			scope:actor = { legitimacy_level = 3 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = 25
+			scope:actor = { legitimacy_level = 4 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = 50
+			scope:actor = { legitimacy_level = 5 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = {
+				value = ai_boldness
+				multiply = -1
+				divide = 4
+			}
+			NOT = { ai_boldness = 0 }
+			desc = ARTIFACT_BOLDNESS_REASON
+		}
+		modifier = {
+			add = -20
+			scope:recipient = {
+				has_trait = brave
+			}
+			desc = BLACKMAIL_INTERACTION_BRAVE_ACCEPTANCE
+		}
+		modifier = {
+			add = -50
+			scope:recipient = {
+				has_trait = arrogant
+			}
+			desc = BLACKMAIL_INTERACTION_ARROGANT_ACCEPTANCE
+		}
+		modifier = {
+			add = -50
+			scope:recipient = {
+				has_trait = disloyal
+			}
+			desc = DEMAND_OBEDIENCE_INTERACTION_DISLOYAL_ACCEPTANCE
+		}
+		modifier = {
+			add = 10
+			scope:recipient = {
+				has_trait = craven
+			}
+			desc = BLACKMAIL_INTERACTION_CRAVEN_ACCEPTANCE
+		}
+		modifier = {
+			add = 10
+			scope:recipient = {
+				has_trait = content
+			}
+			desc = DEMAND_OBEDIENCE_INTERACTION_CONTENT_ACCEPTANCE
+		}
+		modifier = {
+			add = 25
+			any_character_situation = {
+				any_situation_sub_region = {
+					has_sub_region_phase_parameter = the_great_steppe_easier_obedience
+					any_situation_sub_region_participant_group = {
+						participant_group_type = nomad_rulers_capital
+						participant_group_has_character = scope:actor
+					}
+				}
+			}
+			desc = DEMAND_OBEDIENCE_INTERACTION_ZUD_ACCEPTANCE
+		}
+		bp2_hostage_dread_modifier = yes
+	}
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			scope:actor = { dread >= major_dread_value }
+			add = 25
+		}
+		modifier = {
+			scope:actor = {
+				any_councillor = {
+					is_kurultai_trigger = yes
+					NOT = { is_obedient_to = prev }
+				}
+			}
+			add = 25
+		}
+	}
+
+	cooldown_against_recipient = { years = 10 }
+
+	ai_targets = {
+		ai_recipients = vassals
+		ai_recipients = courtiers
+		ai_recipients = tributaries
+		chance = 0.25
+	}
+	
+	ai_targets = { # They will try to get a Stable Succession
+		ai_recipients = councillors
+	}
+
+	on_accept = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = mpo_demand_obedience_interaction_toast
+				left_icon = scope:recipient
+				scope:recipient = {
+					add_opinion = {
+						target = scope:actor
+						modifier = obedience_opinion
+					}
+				}
+				# Belligerent Vassal Opinion
+				if = {
+					limit = {
+						any_vassal = { has_vassal_stance = belligerent }
+					}
+					every_vassal = {
+						limit = { has_vassal_stance = belligerent }
+						custom = every_belligerent_vassal
+						add_opinion = {
+							modifier = impressed_opinion
+							target = scope:actor
+							opinion = 15
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+##################
+# Refill MaA
+##################
+
+refill_maa_nomad_interaction = {
+	icon = icon_soldier_survivor
+	category = interaction_debug_main
+	interface_priority = 20
+	common_interaction = yes
+	desc = refill_maa_nomad_interaction_desc
+	cooldown = { months = 6 }
+	hidden = yes
+
+	is_shown = {
+		has_mpo_dlc_trigger = yes
+		scope:actor = {
+			is_nomad = yes
+			government_allows = conditional_maa_refill
+		}
+		scope:recipient = scope:actor
+	}
+
+	is_valid_showing_failures_only = {
+		custom_tooltip = {
+			text = reinforce_soldiers_any_regiment_tt
+			scope:actor.maa_regiments_count >= 1
+		}
+		custom_tooltip = {
+			text = reinforce_soldiers_unfull_regiment_tt
+			scope:actor = {
+				any_maa_regiment = { maa_regiments_valid_to_refill_trigger = yes }
+			}
+		}
+		custom_tooltip = {
+			text = SUPPLY_LOSS_AT_SEA
+			scope:actor = { any_laamp_portion_at_sea_trigger = no }
+		}
+		custom_tooltip = {
+			text = PROCURE_ESTATE_AT_WAR_TT
+			scope:actor = {
+				NOT = {
+					any_army = {
+						location.county.holder = {
+							OR = {
+								is_at_war_with = scope:actor
+								any_liege_or_above = { is_at_war_with = scope:actor }
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	send_options_exclusive = yes
+
+	send_option = {
+		flag = herd
+		localization = reinforce_soldiers_option_herd
+		is_valid = {
+			scope:actor.domicile.herd >= 5
+		}
+	}
+
+	send_option = {
+		flag = gold
+		localization = reinforce_soldiers_option_gold
+		is_valid = {
+			scope:actor.gold >= 5
+		}
+	}
+
+	on_accept = {
+		scope:actor = {
+			switch = {
+				trigger = yes
+				scope:gold = {
+					if = {
+						limit = { gold > replenishable_troops_payed_gold_tt_value }
+						custom_tooltip = refill_maa_gold_full_tt
+					}
+					else = { custom_tooltip = refill_maa_gold_tt }
+					custom_tooltip = refill_maa_gold_cost_tt
+					refill_maa_with_gold_effect = yes
+				}
+				scope:herd = {
+					if = {
+						limit = { domicile.herd > replenishable_troops_payed_herd_tt_value }
+						custom_tooltip = refill_maa_herd_full_tt
+					}
+					else = { custom_tooltip = refill_maa_herd_tt }
+					custom_tooltip = refill_maa_herd_cost_tt
+					refill_maa_with_herd_effect = yes
+				}
+			}
+			if = {
+				limit = {
+					is_ai = yes
+					NOR = {
+						scope:gold = yes
+						scope:herd = yes
+					}
+				}
+				refill_maa_with_herd_effect = yes
+			}
+			custom_tooltip = martial_skill_discount_tt
+		}
+	}
+
+	ai_frequency = 1
+	ai_targets = {
+		ai_recipients = self
+	}
+	ai_potential = {
+		is_nomad = yes
+		government_allows = conditional_maa_refill
+		any_maa_regiment = { maa_current_troops_count < maa_max_troops_count }
+	}
+
+	ai_will_do = {
+		base = 100
+	}
+}
+
+### Commander Trait interaction for guardians
+# actor = guardian
+# recipient = ward/hostage
+# This has to be update every time a new Commander trait is added to the game, otherwise you won't be able to pass it down
+influence_child_commander_interaction = {
+	category = interaction_category_friendly
+	common_interaction = yes
+	interface_priority = 60
+	icon = child
+	ai_maybe = yes
+	ai_min_reply_days = 4
+	ai_max_reply_days = 9
+	can_send_despite_rejection = yes
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	pre_answer_maybe_key = ANSWER_MIGHT_SUCCEED
+	pre_answer_no_key = ANSWER_CANT_SUCCEED
+	pre_answer_yes_key = ANSWER_WILL_SUCCEED
+	pre_answer_maybe_breakdown_key = ANSWER_SUM_CHANCE
+
+	desc = influence_child_commander_interaction_desc
+
+	is_shown = { #any  ai ward/hostage
+		has_mpo_dlc_trigger = yes
+		scope:recipient = {
+			is_ai = yes
+			is_adult = no
+			OR = {
+				scope:actor = { has_relation_ward = scope:recipient }
+				is_hostage_of = scope:actor
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:recipient = { #be old enough to fight and don't have any commander traits yet
+			age >= 10
+			number_of_commander_traits <= 1
+			#checking all trait individually through the set scope in order to catch if all of your traits are either the same or opposite
+			trigger_if = {
+				limit = {
+					scope:actor = {
+						number_of_commander_traits > 0
+					}
+				}
+				custom_description = {
+					text = influence_child_commander_interaction_all_same_traits
+					switch = {
+						trigger = yes
+						scope:logistician = {
+							scope:recipient = { NOT = { has_trait = logistician } }
+						}
+						scope:military_engineer = {
+							scope:recipient = { NOT = { has_trait = military_engineer } }
+						}
+						scope:aggressive_attacker = {
+							scope:recipient = { NOT = { has_trait = aggressive_attacker } }
+						}
+						scope:unyielding_defender = {
+							scope:recipient = { NOT = { has_trait = unyielding_defender } }
+						}
+						scope:forder = {
+							scope:recipient = { NOT = { has_trait = forder } }
+						}
+						scope:flexible_leader = {
+							scope:recipient = { NOT = { has_trait = flexible_leader } }
+						}
+						scope:desert_warrior = {
+							scope:recipient = { NOT = { has_trait = desert_warrior } }
+						}
+						scope:jungle_stalker = {
+							scope:recipient = { NOT = { has_trait = jungle_stalker } }
+						}
+						scope:reaver = {
+							scope:recipient = { NOT = { has_trait = reaver } }
+						}
+						scope:reckless = {
+							scope:recipient = { NOT = { has_trait = reckless } }
+						}
+						scope:holy_warrior = {
+							scope:recipient = { NOT = { has_trait = holy_warrior } }
+						}
+						scope:open_terrain_expert = {
+							scope:recipient = { NOT = { has_trait = open_terrain_expert } }
+						}
+						scope:rough_terrain_expert = {
+							scope:recipient = { NOT = { has_trait = rough_terrain_expert } }
+						}
+						scope:forest_fighter = {
+							scope:recipient = { NOT = { has_trait = forest_fighter } }
+						}
+						scope:cautious_leader = {
+							scope:recipient = { NOT = { has_trait = cautious_leader } }
+						}
+						scope:organizer = {
+							scope:recipient = { NOT = { has_trait = organizer } }
+						}
+						scope:winter_soldier = {
+							scope:recipient = { NOT = { has_trait = winter_soldier } }
+						}
+					}
+				}
+			}
+			is_physically_able = yes
+		}
+		scope:actor = {
+			is_adult = yes
+			number_of_commander_traits >= 1
+			is_imprisoned = no
+			is_physically_able = yes
+		}
+	}
+
+	cooldown_against_recipient = { years = 3 }
+
+	can_send = {
+	}
+	#each option is shown if the actor has the corresponding trait and valid if recipient don't have it yet or don't have an opposite trait
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = logistician }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = logistician
+					trait:logistician = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = logistician
+		localization = trait_logistician
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = military_engineer }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = military_engineer
+					trait:military_engineer = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = military_engineer
+		localization = trait_military_engineer
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = aggressive_attacker }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = aggressive_attacker
+					trait:aggressive_attacker = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = aggressive_attacker
+		localization = trait_aggressive_attacker
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = unyielding_defender }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = unyielding_defender
+					trait:unyielding_defender = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = unyielding_defender
+		localization = trait_unyielding_defender
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = forder }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = forder
+					trait:forder = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = forder
+		localization = trait_forder
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = flexible_leader }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = flexible_leader
+					trait:flexible_leader = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = flexible_leader
+		localization = trait_flexible_leader
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = desert_warrior }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = desert_warrior
+					trait:desert_warrior = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = desert_warrior
+		localization = trait_desert_warrior
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = jungle_stalker }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = jungle_stalker
+					trait:jungle_stalker = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = jungle_stalker
+		localization = trait_jungle_stalker
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = reaver }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = reaver
+					trait:reaver = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = reaver
+		localization = trait_reaver
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = reckless }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = reckless
+					trait:reckless = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = reckless
+		localization = trait_reckless
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = holy_warrior }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = holy_warrior
+					trait:holy_warrior = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = holy_warrior
+		localization = trait_holy_warrior
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = open_terrain_expert }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = open_terrain_expert
+					trait:open_terrain_expert = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = open_terrain_expert
+		localization = trait_open_terrain_expert
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = rough_terrain_expert }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = rough_terrain_expert
+					trait:rough_terrain_expert = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = rough_terrain_expert
+		localization = trait_rough_terrain_expert
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = forest_fighter }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = forest_fighter
+					trait:forest_fighter = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = forest_fighter
+		localization = trait_forest_fighter
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = cautious_leader }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = cautious_leader
+					trait:cautious_leader = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = cautious_leader
+		localization = trait_cautious_leader
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = organizer }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = organizer
+					trait:organizer = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = organizer
+		localization = trait_organizer
+	}
+	send_option = {
+		is_shown = {
+			scope:actor = { has_trait = winter_soldier }
+		}
+		is_valid = {
+			scope:recipient = {
+				NOR = {
+					has_trait = winter_soldier
+					trait:winter_soldier = {
+						any_opposite_trait = {
+							scope:recipient = { has_trait = prev }
+						}
+					}
+				}
+			}
+		}
+		flag = winter_soldier
+		localization = trait_winter_soldier
+	}
+
+	send_options_exclusive = yes
+
+	on_send = {
+		switch = {#save which trait was chosen as scope:target_trait
+			trigger = yes
+			scope:logistician = {
+				trait:logistician = { save_scope_as = target_trait }
+			}
+			scope:military_engineer = {
+				trait:military_engineer = { save_scope_as = target_trait }
+			}
+			scope:aggressive_attacker = {
+				trait:aggressive_attacker = { save_scope_as = target_trait }
+			}
+			scope:unyielding_defender = {
+				trait:unyielding_defender = { save_scope_as = target_trait }
+			}
+			scope:forder = {
+				trait:forder = { save_scope_as = target_trait }
+			}
+			scope:flexible_leader = {
+				trait:flexible_leader = { save_scope_as = target_trait }
+			}
+			scope:desert_warrior = {
+				trait:desert_warrior = { save_scope_as = target_trait }
+			}
+			scope:jungle_stalker = {
+				trait:jungle_stalker = { save_scope_as = target_trait }
+			}
+			scope:reaver = {
+				trait:reaver = { save_scope_as = target_trait }
+			}
+			scope:reckless = {
+				trait:reckless = { save_scope_as = target_trait }
+			}
+			scope:holy_warrior = {
+				trait:holy_warrior = { save_scope_as = target_trait }
+			}
+			scope:open_terrain_expert = {
+				trait:open_terrain_expert = { save_scope_as = target_trait }
+			}
+			scope:rough_terrain_expert = {
+				trait:rough_terrain_expert = { save_scope_as = target_trait }
+			}
+			scope:forest_fighter = {
+				trait:forest_fighter = { save_scope_as = target_trait }
+			}
+			scope:cautious_leader = {
+				trait:cautious_leader = { save_scope_as = target_trait }
+			}
+			scope:organizer = {
+				trait:organizer = { save_scope_as = target_trait }
+			}
+			scope:winter_soldier = {
+				trait:winter_soldier = { save_scope_as = target_trait }
+			}
+			fallback = {
+				scope:actor = {
+					random_character_trait = {
+						limit = { has_trait_category = commander }
+						save_scope_as = target_trait
+					}
+				}
+			}
+		}
+	}
+
+	on_accept = {
+		scope:actor = {
+			# Trait you're trying to make your ward gained is saved as scope:target_trait
+			trigger_event = mpo_interactions_events.0101
+			show_as_tooltip = {
+				add_stress = minor_stress_gain
+				add_opinion = {
+					target = scope:recipient
+					modifier = pleased_opinion
+					opinion = 20
+				}
+			}
+		}
+		scope:recipient = {
+			show_as_tooltip = {
+				switch = {#save which trait was chosen as scope:target_trait
+					trigger = yes
+					scope:logistician = {
+						trait:logistician = { save_scope_as = target_trait }
+					}
+					scope:military_engineer = {
+						trait:military_engineer = { save_scope_as = target_trait }
+					}
+					scope:aggressive_attacker = {
+						trait:aggressive_attacker = { save_scope_as = target_trait }
+					}
+					scope:unyielding_defender = {
+						trait:unyielding_defender = { save_scope_as = target_trait }
+					}
+					scope:forder = {
+						trait:forder = { save_scope_as = target_trait }
+					}
+					scope:flexible_leader = {
+						trait:flexible_leader = { save_scope_as = target_trait }
+					}
+					scope:desert_warrior = {
+						trait:desert_warrior = { save_scope_as = target_trait }
+					}
+					scope:jungle_stalker = {
+						trait:jungle_stalker = { save_scope_as = target_trait }
+					}
+					scope:reaver = {
+						trait:reaver = { save_scope_as = target_trait }
+					}
+					scope:reckless = {
+						trait:reckless = { save_scope_as = target_trait }
+					}
+					scope:holy_warrior = {
+						trait:holy_warrior = { save_scope_as = target_trait }
+					}
+					scope:open_terrain_expert = {
+						trait:open_terrain_expert = { save_scope_as = target_trait }
+					}
+					scope:rough_terrain_expert = {
+						trait:rough_terrain_expert = { save_scope_as = target_trait }
+					}
+					scope:forest_fighter = {
+						trait:forest_fighter = { save_scope_as = target_trait }
+					}
+					scope:cautious_leader = {
+						trait:cautious_leader = { save_scope_as = target_trait }
+					}
+					scope:organizer = {
+						trait:organizer = { save_scope_as = target_trait }
+					}
+					scope:winter_soldier = {
+						trait:winter_soldier = { save_scope_as = target_trait }
+					}
+				}
+				if = {
+					limit = { exists = scope:target_trait }
+					add_trait = scope:target_trait
+				}
+				add_opinion = {
+					target = scope:actor
+					modifier = admiration_opinion
+					opinion = 20
+				}
+			}
+		}
+	}
+
+	on_decline = {
+		scope:actor = {
+			# Trait you're trying to make your ward gained is saved as scope:target_trait
+			trigger_event = mpo_interactions_events.0102
+			show_as_tooltip = {
+				add_stress = medium_stress_gain
+				add_opinion = {
+					target = scope:recipient
+					modifier = disappointed_opinion
+					opinion = -20
+				}
+			}
+		}
+		scope:recipient = {
+			show_as_tooltip = {
+				add_opinion = {
+					target = scope:actor
+					modifier = confused_opinion
+					opinion = -20
+				}
+			}
+		}
+	}
+
+	auto_accept = no
+
+	ai_accept = {
+		base = 0 # Try to make it 0 for most interactions
+		opinion_modifier = { # Opinion Factor
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 0.5
+			desc = AI_OPINION_REASON
+		}
+
+		modifier = { # Perk boost
+			desc = influence_children_groomed_to_rule_perk_tt
+			trigger = {
+				scope:actor = { has_perk = groomed_to_rule_perk }
+			}
+			add = groomed_to_rule_value
+		}
+
+		modifier = { #more likely if you already have something in common
+			add = {
+				value = 5
+				if = {
+					limit = {
+						number_of_personality_traits_in_common = {
+							target = scope:recipient
+							value = 2
+						}
+					}
+					multiply = 2
+				}
+				else_if = {
+					limit = {
+						number_of_personality_traits_in_common = {
+							target = scope:recipient
+							value = 3
+						}
+					}
+					multiply = 3
+				}
+			}
+			number_of_personality_traits_in_common = {
+				target = scope:recipient
+				value >= 1
+			}
+			desc = we_are_alike_tt
+		}
+
+		modifier = { #less likely if you already have opposite traits
+			add = {
+				value = -5
+				if = {
+					limit = {
+						scope:recipient = {
+							number_of_opposing_personality_traits = {
+								target = scope:actor
+								value = 2
+							}
+						}
+					}
+					multiply = 2
+				}
+				else_if = {
+					limit = {
+						scope:recipient = {
+							number_of_opposing_personality_traits = {
+								target = scope:actor
+								value = 3
+							}
+						}
+					}
+					multiply = 3
+				}
+			}
+			scope:recipient = {
+				number_of_opposing_personality_traits = {
+					target = scope:actor
+					value >= 1
+				}
+			}
+			desc = we_are_NOT_alike_tt
+		}
+
+		modifier = { #adding your knowledge
+			add = {
+				value = scope:actor.martial
+				multiply = 0.5
+			}
+			desc = HAS_MARTIAL_SKILL_REASON
+		}
+
+		modifier = { #adding your fighting skills
+			add = {
+				value = scope:actor.prowess
+				multiply = 0.5
+			}
+			desc = HAS_PROWESS_SKILL_REASON
+		}
+
+		modifier = { #more likely with a Wet Nurse employed
+			exists = scope:actor.court_position:champion_court_position
+			add = 10
+			desc = HAS_CHAMPION_REASON
+		}
+
+		modifier = { #more likely if chosen trait is compatible with recipients childhood personality
+			add = 15
+			switch = {
+				trigger = yes
+				scope:logistician = {
+					scope:recipient = {
+						OR = {
+							has_trait = curious
+							has_trait = pensive
+						}
+					}
+				}
+				scope:military_engineer = {
+					scope:recipient = {
+						OR = {
+							has_trait = curious
+							has_trait = pensive
+						}
+					}
+				}
+				scope:aggressive_attacker = {
+					scope:recipient = {
+						OR = {
+							has_trait = bossy
+							has_trait = rowdy
+						}
+					}
+				}
+				scope:unyielding_defender = {
+					scope:recipient = {
+						OR = {
+							has_trait = bossy
+							has_trait = rowdy
+						}
+					}
+				}
+				scope:forder = {
+					scope:recipient = {
+						OR = {
+							has_trait = rowdy
+							has_trait = curious
+						}
+					}
+				}
+				scope:flexible_leader = {
+					scope:recipient = {
+						OR = {
+							has_trait = charming
+							has_trait = curious
+						}
+					}
+				}
+				scope:desert_warrior = {
+					scope:recipient = {
+						has_trait = rowdy
+					}
+				}
+				scope:jungle_stalker = {
+					scope:recipient = {
+						has_trait = rowdy
+					}
+				}
+				scope:reaver = {
+					scope:recipient = {
+						OR = {
+							has_trait = bossy
+							has_trait = rowdy
+						}
+					}
+				}
+				scope:reckless = {
+					scope:recipient = {
+						OR = {
+							has_trait = bossy
+							has_trait = rowdy
+						}
+					}
+				}
+				scope:holy_warrior = {
+					scope:recipient = {
+						has_trait = pensive
+					}
+				}
+				scope:open_terrain_expert = {
+					scope:recipient = {
+						has_trait = rowdy
+					}
+				}
+				scope:rough_terrain_expert = {
+					scope:recipient = {
+						has_trait = rowdy
+					}
+				}
+				scope:forest_fighter = {
+					scope:recipient = {
+						has_trait = rowdy
+					}
+				}
+				scope:cautious_leader = {
+					scope:recipient = {
+						has_trait = pensive
+					}
+				}
+				scope:organizer = {
+					scope:recipient = {
+						OR = {
+							has_trait = bossy
+							has_trait = charming
+						}
+					}
+				}
+				scope:winter_soldier = {
+					scope:recipient = {
+						has_trait = rowdy
+					}
+				}
+			}
+			desc = has_compatible_personality_tt
+		}
+
+		modifier = { #less likely if chosen trait is incompatible with recipients childhood personality
+			add = -15
+			switch = {
+				trigger = yes
+				scope:logistician = {
+					scope:recipient = {
+						NOR = {
+							has_trait = curious
+							has_trait = pensive
+						}
+					}
+				}
+				scope:military_engineer = {
+					scope:recipient = {
+						NOR = {
+							has_trait = curious
+							has_trait = pensive
+						}
+					}
+				}
+				scope:aggressive_attacker = {
+					scope:recipient = {
+						NOR = {
+							has_trait = bossy
+							has_trait = rowdy
+						}
+					}
+				}
+				scope:unyielding_defender = {
+					scope:recipient = {
+						NOR = {
+							has_trait = bossy
+							has_trait = rowdy
+						}
+					}
+				}
+				scope:forder = {
+					scope:recipient = {
+						NOR = {
+							has_trait = rowdy
+							has_trait = curious
+						}
+					}
+				}
+				scope:flexible_leader = {
+					scope:recipient = {
+						NOR = {
+							has_trait = charming
+							has_trait = curious
+						}
+					}
+				}
+				scope:desert_warrior = {
+					scope:recipient = {
+						NOT = { has_trait = rowdy }
+					}
+				}
+				scope:jungle_stalker = {
+					scope:recipient = {
+						NOT = { has_trait = rowdy }
+					}
+				}
+				scope:reaver = {
+					scope:recipient = {
+						NOR = {
+							has_trait = bossy
+							has_trait = rowdy
+						}
+					}
+				}
+				scope:reckless = {
+					scope:recipient = {
+						NOR = {
+							has_trait = bossy
+							has_trait = rowdy
+						}
+					}
+				}
+				scope:holy_warrior = {
+					scope:recipient = {
+						NOT = { has_trait = pensive }
+					}
+				}
+				scope:open_terrain_expert = {
+					scope:recipient = {
+						NOT = { has_trait = rowdy }
+					}
+				}
+				scope:rough_terrain_expert = {
+					scope:recipient = {
+						NOT = { has_trait = rowdy }
+					}
+				}
+				scope:forest_fighter = {
+					scope:recipient = {
+						NOT = { has_trait = rowdy }
+					}
+				}
+				scope:cautious_leader = {
+					scope:recipient = {
+						NOT = { has_trait = pensive }
+					}
+				}
+				scope:organizer = {
+					scope:recipient = {
+						NOR = {
+							has_trait = bossy
+							has_trait = charming
+						}
+					}
+				}
+				scope:winter_soldier = {
+					scope:recipient = {
+						NOT = { has_trait = rowdy }
+					}
+				}
+			}
+			desc = has_incompatible_personality_tt
+		}
+
+		modifier = { #more likely if actor is afraid of you
+			add = intimidated_halved_reason_value
+			scope:recipient = {
+				target_is_liege_or_above = scope:actor
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 1
+				}
+			}
+			desc = INTIMIDATED_REASON
+		}
+		modifier = { #more likely if actor is afraid of you
+			add = cowed_halved_reason_value
+			scope:recipient = {
+				target_is_liege_or_above = scope:actor
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 2
+				}
+			}
+			desc = COWED_REASON
+		}
+		modifier = { #less likely if recipient already has a commander trait
+			add = -50
+			scope:recipient = {
+				number_of_commander_traits >= 1
+			}
+			desc = has_commander_traits_already
+		}
+	}
+
+	# AI
+	ai_potential = {
+		any_relation = {
+			type = ward
+			count >= 1
+		}
+	}
+	ai_frequency = 12
+	ai_targets = {
+		ai_recipients = courtiers
+	}
+	ai_will_do = {
+		base = -100
+		modifier = { # If the recipient is a player, do not bother sending
+			factor = 0
+			scope:recipient = {
+				is_ai = no
+			}
+		}
+		modifier = {
+			add = ai_honor
+		}
+		modifier = {
+			add = ai_energy
+		}
+		modifier = {
+			add = ai_sociability
+		}
+		modifier = {
+			add = ai_boldness
+		}
+	}
+}
+
+mpo_make_blood_brother = {
+	category = interaction_category_diplomacy
+	icon = blood_brother
+	desc = make_blood_brother_desc
+	common_interaction = yes
+	can_send_despite_rejection = yes
+	interface_priority = 60
+
+	greeting = positive
+	notification_text = MAKE_BLOOD_BROTHER_NOTIFICATION
+	popup_on_receive = yes
+	ai_maybe = yes
+
+	cooldown = { months = 1 }
+	cooldown_against_recipient = { years = 5 }
+
+	is_shown = {
+		# Scope:actor needs to have a suitable CulTrad.
+		scope:actor = {
+			mpo_valid_for_blood_brotherhood_trigger = yes
+			NOT = { var:had_mpo_temujin_flavor_0020 ?= scope:recipient }
+		}
+		scope:recipient = {
+			mpo_valid_for_blood_brotherhood_trigger = yes
+			NOT = {
+				this = scope:actor
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		mpo_can_be_blood_brothers_trigger = { CHARACTER_1 = scope:actor CHARACTER_2 = scope:recipient }
+		# Both characters must be available
+		scope:actor = {
+			is_imprisoned = no
+			is_incapable = no
+		}
+		scope:recipient = {
+			is_imprisoned = no
+			is_incapable = no
+		}
+	}
+	#Mutual enemy that you oppose together
+	send_option = {
+		flag = common_enemy
+		is_valid = {
+			custom_description = {
+				text = blood_brother_common_enemy_trigger
+				mpo_blood_brother_common_enemy_trigger = yes
+			}
+		}
+		localization = BLOOD_BROTHER_COMMON_ENEMY
+	}
+	#Shared memories
+	send_option = {
+		flag = memories_together
+		is_valid = {
+			custom_description = {
+				text = blood_brother_memory_trigger
+				scope:actor = {
+					any_memory = {
+						has_memory_participant = scope:recipient
+						mpo_blood_brother_reason_memory_trigger = yes
+					}
+				}
+			}
+		}
+		localization = BLOOD_BROTHER_MEMORIES
+	}
+
+	#Fought together in a war
+	send_option = {
+		flag = war_allies
+		is_valid = {
+			custom_description = {
+				text = blood_brother_former_war_allies_trigger
+				scope:actor = {
+					has_variable_list = former_war_allies
+					any_in_list = {
+						variable = former_war_allies
+						this = scope:recipient
+					}
+				}
+			}
+		}
+		localization = BLOOD_BROTHER_WAR_ALLIES
+	}
+
+	# Normal
+	send_option = {
+		is_shown = {
+			always = no
+		}
+		is_valid = {
+			always = yes
+		}
+		flag = normal
+		localization = BLOOD_BROTHER_NORMAL
+		starts_enabled = { always = yes	}
+	}
+
+	cost = {
+		piety = minor_piety_value
+	}
+
+	send_options_exclusive = no
+
+	on_accept = {
+		# Notifications with most effects.
+		scope:actor = {
+			# Become blood brothers
+			#Tooltip effect because it happens later/in the blood brother on action
+			show_as_tooltip = {
+				set_relation_blood_brother = scope:recipient
+			}
+			custom_tooltip = blood_brother_alliance_actor_alliance_tt
+			custom_tooltip = blood_brother_actor_gains_hook_tt
+			if = {
+				limit = {
+					scope:recipient = {
+						mpo_blood_brother_august_trigger = { OTHER_BROTHER = scope:actor }
+					}
+				}
+				if = {
+					limit = {
+						scope:actor = {
+							government_has_flag = government_is_nomadic
+						}
+					}
+					custom_tooltip = blood_brother_august_nomadic_modifier_tt
+				}
+				else = {
+					custom_tooltip = blood_brother_august_modifier_tt
+				}
+			}
+			if = {
+				limit = {
+					scope:recipient = {
+						mpo_blood_brother_warrior_trigger = { OTHER_BROTHER = scope:actor }
+					}
+				}
+				custom_tooltip = blood_brother_warrior_modifier_tt
+			}
+			if = {
+				limit = {
+					scope:recipient = {
+						mpo_blood_brother_clever_trigger = yes
+					}
+				}
+				if = {
+					limit = {
+						scope:actor = {
+							government_has_flag = government_is_nomadic
+						}
+					}
+					custom_tooltip = blood_brother_clever_nomadic_modifier_tt
+				}
+				else = {
+					custom_tooltip = blood_brother_clever_modifier_tt
+				}
+			}
+			if = {
+				limit = {
+					scope:recipient = {
+						mpo_blood_brother_loving_trigger = yes
+					}
+				}
+				custom_tooltip = blood_brother_loving_modifier_tt
+			}
+			if = {
+				limit = {
+					always = scope:common_enemy
+				}
+				custom_tooltip = blood_brother_foe_modifier_tt
+			}
+		}
+		scope:recipient = {
+			# Become blood brothers
+			#Tooltip effect because it happens later/in the blood brother on action
+
+			show_as_tooltip = { set_relation_blood_brother = scope:actor }
+			custom_tooltip = blood_brother_alliance_recipient_alliance_tt
+			custom_tooltip = blood_brother_recipient_gains_hook_tt
+			if = {
+				limit = {
+					scope:actor = {
+						mpo_blood_brother_august_trigger = { OTHER_BROTHER = scope:recipient }
+					}
+				}
+				if = {
+					limit = {
+						scope:recipient = {
+							government_has_flag = government_is_nomadic
+						}
+					}
+					custom_tooltip = blood_brother_august_nomadic_modifier_tt
+				}
+				else = {
+					custom_tooltip = blood_brother_august_modifier_tt
+				}
+			}
+			if = {
+				limit = {
+					scope:actor = {
+						mpo_blood_brother_warrior_trigger = { OTHER_BROTHER = scope:recipient }
+					}
+				}
+				custom_tooltip = blood_brother_warrior_modifier_tt
+			}
+			if = {
+				limit = {
+					scope:actor = {
+						mpo_blood_brother_clever_trigger = yes
+					}
+				}
+				if = {
+					limit = {
+						scope:recipient = {
+							government_has_flag = government_is_nomadic
+						}
+					}
+					custom_tooltip = blood_brother_clever_nomadic_modifier_tt
+				}
+				else = {
+					custom_tooltip = blood_brother_clever_modifier_tt
+				}
+			}
+			if = {
+				limit = {
+					scope:actor = {
+						mpo_blood_brother_loving_trigger = yes
+					}
+				}
+				custom_tooltip = blood_brother_loving_modifier_tt
+			}
+			if = {
+				limit = {
+					always = scope:common_enemy
+				}
+				custom_tooltip = blood_brother_foe_modifier_tt
+			}
+		}
+
+		# If we're a clan this interaction affects unity
+		add_clan_unity_interaction_effect = {
+			CHARACTER = scope:actor
+			TARGET = scope:recipient
+			VALUE = minor_unity_gain
+			DESC = clan_unity_oath_of_true_friendship.desc
+			REVERSE_NON_HOUSE_TARGET = no
+		}
+		if = {
+			limit = {
+				always = scope:common_enemy
+			}
+			scope:actor = {
+				make_blood_brother_save_common_enemy_effect = yes
+			}
+		}
+		#Fire events for each char, resetting scopes to be appropriate in each
+		hidden_effect = {
+			scope:recipient = {
+				save_scope_as = blood_bro
+			}
+			scope:actor = {
+				set_relation_blood_brother = {
+					reason = sworn_blood_brother
+					target = scope:recipient
+				}
+				trigger_event = mpo_interactions_events.0006
+			}
+			clear_saved_scope = blood_bro
+			scope:actor = {
+				save_scope_as = blood_bro
+			}
+			scope:recipient = {
+				trigger_event = mpo_interactions_events.0006
+			}
+		}
+	}
+
+	on_decline = {
+		# Scope:actor gains some stress over the whole ordeal.
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_bad
+				title = make_blood_brother_interaction.decline.actor.tt
+				left_icon = scope:recipient
+				add_stress = minor_stress_gain
+			}
+		}
+		# Scope:actor loses opinion of scope:recipient.
+		scope:recipient = {
+			send_interface_toast = {
+				type = event_toast_effect_neutral
+				title = make_blood_brother_interaction.decline.recipient.tt
+				left_icon = scope:actor
+				scope:actor = {
+					add_opinion = {
+						target = scope:recipient
+						modifier = hurt_opinion
+						opinion = -20
+					}
+				}
+			}
+		}
+		# And set up a little hidden drama for later...
+		hidden_effect = {
+			scope:recipient = {
+				if = {
+					limit = {
+						# We don't use the standard check for this, since they'll already be friends by definition, so the trigger would always return as false.
+						# Instead, we just check to make sure they're not *already* potential rivals; this can happen regardless, so really we're just setting them up for drama if the friendship ever falters.
+						NOT = { has_relation_potential_rival = scope:actor }
+					}
+					random = {
+						chance = 20
+						set_relation_potential_rival = scope:actor
+					}
+				}
+			}
+		}
+
+		# If we're a clan this interaction affects unity
+		add_clan_unity_interaction_effect = {
+			CHARACTER = scope:actor
+			TARGET = scope:recipient
+			VALUE = minor_unity_loss
+			DESC = clan_unity_declined_true_friendship.desc
+			REVERSE_NON_HOUSE_TARGET = no
+		}
+	}
+
+	# AI
+	## Standard Acceptance stuff
+	ai_accept = {
+		base = -50
+
+		mpo_blood_brother_interactions_ai_accept_modifier = yes
+
+		# Common foe send option
+		# Are you offering confederation leadership?
+		modifier = {
+			trigger = {
+				scope:common_enemy ?= yes
+			}
+			add = 75
+			desc = BLOOD_BROTHER_COMMON_ENEMY_VALUE
+		}
+		# Memories send option
+		modifier = {
+			trigger = {
+				scope:memories_together ?= yes
+			}
+			add = 50
+			desc = BLOOD_BROTHER_MEMORIES_VALUE
+		}
+		# Former war allies send option
+		modifier = {
+			trigger = {
+				scope:war_allies ?= yes
+			}
+			add = 30
+			desc = BLOOD_BROTHER_WAR_ALLIES_VALUE
+		}
+	}
+	## Performance-enhancement
+	ai_potential = {
+		is_imprisoned = no
+		is_at_war = no
+		has_blood_brother = no
+	}
+	ai_target_quick_trigger = { adult = yes }
+	ai_targets = { ai_recipients = liege }
+	ai_targets = { ai_recipients = scripted_relations }
+	ai_targets = {
+		ai_recipients = peer_vassals
+		max = 25
+	}
+	ai_targets = {
+		ai_recipients = neighboring_rulers_including_tributary_borders
+		max = 25
+	}
+	## Frequency
+	ai_frequency = 48
+	ai_will_do = {
+		base = -50
+
+		#Dishonorable characters don't want to be bound like this
+		modifier = {
+			scope:recipient = {
+				ai_honor <= medium_negative_ai_value
+			}
+			add = -40
+		}
+		modifier = {
+			scope:recipient = {
+				ai_sociability <= medium_negative_ai_value
+			}
+			add = -20
+		}
+
+		#This will mostly just annoy players, unless AI is worthy and has a good reason
+		modifier = {
+			scope:recipient = {
+				is_ai = no
+			}
+			NOT = {
+				scope:actor = {
+					is_landed = yes
+					OR = {
+						has_relation_friend = scope:recipient
+						has_relation_soulmate = scope:recipient
+						is_allied_to = scope:recipient
+					}
+				}
+			}
+			add = -100
+		}
+		modifier = {
+			add = 25
+			any_ally = {
+				count < 1
+			}
+		}
+		modifier = {
+			add = 75
+			any_ally = {
+				count < 2
+			}
+			scope:recipient = { # Don't propose alliances to tiny insignificant rulers just because
+				OR = {
+					current_military_strength >= scope:actor.eighty_percent_of_current_military_strength
+					primary_title.tier >= scope:actor.primary_title.tier
+					AND = {
+						primary_title.tier >= tier_duchy
+						scope:actor.primary_title.tier < tier_empire
+					}
+				}
+			}
+		}
+
+		modifier = {
+			add = 25
+			scope:actor = {
+				mpo_blood_brother_common_enemy_trigger = yes
+			}
+		}
+		modifier = {
+			add = 25
+			scope:actor = {
+				scope:actor = {
+					any_memory = {
+						has_memory_participant = scope:recipient
+						mpo_blood_brother_reason_memory_trigger = yes
+					}
+				}
+			}
+		}
+		modifier = {
+			add = 10
+			scope:actor = {
+				has_variable_list = former_war_allies
+				any_in_list = {
+					variable = former_war_allies
+					this = scope:recipient
+				}
+			}
+		}
+
+		mpo_blood_brother_interactions_ai_accept_modifier = yes
+
+		modifier = { # The AI shouldn't propose to their Lieges
+			factor = 0.5
+			is_liege_or_above_of = scope:recipient
+		}
+		modifier = { # The AI shouldn't propose to their Vassals unless Clan
+			factor = 0.5
+			scope:actor = {
+				NOT = { government_has_flag = government_is_clan }
+			}
+			scope:recipient = {
+				is_vassal_of = scope:actor
+			}
+		}
+		modifier = {
+			factor = 0
+			scope:recipient = {
+				has_character_modifier = broke_blood_brotherhood_modifier
+			}
+		}
+	}
+}
+
+mpo_retrieve_land_from_herder_interaction = {
+	category = interaction_category_diplomacy
+	common_interaction = yes
+	notification_text = REVOKE_TITLE_PROPOSAL
+	interface_priority = 100
+	icon = mpo_retrieve_land_from_herder_interaction
+	desc = mpo_retrieve_land_from_herder_interaction_desc
+
+	special_interaction = revoke_title_interaction
+	interface = revoke_title
+	target_type = title
+	target_filter = recipient_domain_titles
+	ai_maybe = yes
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	interface_priority = 60
+	ai_min_reply_days = 4
+	ai_max_reply_days = 9
+
+	# actor character giving the titles
+	# recipient character receiving the titles
+
+	is_shown = {
+		scope:recipient = {
+			government_has_flag = government_is_herder
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			is_adult = yes
+			is_imprisoned = no
+			prestige >= minor_prestige_value
+			custom_tooltip = {
+				text = mpo_retrieve_land_from_herder_interaction_neighbour_tt
+				any_sub_realm_county = {
+					any_neighboring_county = {
+						holder = {
+							this = scope:recipient
+						}
+					}
+				}
+			}
+		}
+		scope:recipient = {
+			custom_tooltip = {
+				text = mpo_retrieve_land_from_herder_independent_tt
+				OR = {
+					AND = {
+						is_independent_ruler = yes
+						is_tributary = no
+					}
+					is_tributary_of_suzerain_or_above = scope:actor
+					is_vassal_of = scope:actor 
+				}
+			}
+			custom_tooltip = {
+				text = mpo_retrieve_land_migration_tt
+				capital_county = { is_migration_target = no }
+			}
+		}
+	}
+
+	can_be_picked_title = {
+		scope:target = {
+			title_revocation_standard_can_pick_title_trigger = yes
+		}
+	}
+
+	has_valid_target = {
+		scope:target = {
+			is_landless_type_title = no
+			NOT = { is_noble_family_title = yes }
+			NOT = { is_nomad_title = yes }
+		}
+	}
+
+	#Use hook -- Has to stay so the UI doesn't break
+	send_option = {
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		flag = hook
+		localization = SCHEME_HOOK
+	}
+	should_use_extra_icon = {
+		scope:actor = { has_usable_hook = scope:recipient }
+	}
+	extra_icon = "gfx/interface/icons/character_interactions/hook_icon.dds"
+
+	send_options_exclusive = no
+
+	on_auto_accept = {
+		scope:recipient = {
+			trigger_event = char_interaction.0200
+		}
+	}
+
+	on_accept = {
+		scope:recipient = {
+			if = {
+				limit = {
+					is_tributary = yes
+					NOT = {
+						is_tributary_of = scope:actor
+					}
+				}
+				suzerain = {
+					add_opinion = {
+						target = scope:actor
+						modifier = upset_opinion
+						opinion = -25
+					}
+				}
+			}
+		}
+		save_scope_value_as = {
+			name = revoke_title_interaction
+			value = yes
+		}
+		scope:recipient = {
+			capital_county = {
+				change_county_control = -25
+			}
+		}
+		scope:actor = {
+			add_prestige = minor_prestige_loss
+			trigger_event = char_interaction.0199
+		}
+		revoke_title_interaction_effect = yes
+
+		if = {
+			limit = {
+				scope:actor = { has_character_flag = flag_hostile_actions_disabled_delay }
+			}
+			scope:actor = { remove_character_flag = flag_hostile_actions_disabled_delay }
+		}
+	}
+
+	auto_accept = yes
+
+	# AI
+	ai_targets = {
+		ai_recipients = tributaries 
+	}
+	ai_targets = {
+		ai_recipients = neighboring_rulers
+		max = 5
+	}
+	ai_frequency = 4
+
+	ai_potential = {
+		domain_size < domain_limit
+		primary_title.tier >= tier_county
+	}
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			scope:actor = {
+				government_has_flag = government_is_nomadic
+				current_domain_fertility <= bad_county_fertility_level
+			}
+			add = 100
+		}
+		modifier = {
+			scope:actor = {
+				NOT = { government_has_flag = government_is_nomadic }
+				short_term_gold >= massive_gold_value
+				NOR = {
+					has_trait = humble
+					has_trait = content
+				}
+			}
+			add = 25
+		}
+	}
+}
+
+mpo_vassal_to_tributary_interaction = {
+	category = interaction_category_vassal
+	icon = become_tributary_interaction
+	common_interaction = yes
+
+	desc = mpo_vassal_to_tributary_interaction_desc
+
+	ai_frequency = 8
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	is_shown = {
+		scope:actor = {
+			is_ai = no
+			is_vassal_of = scope:recipient
+			government_has_flag = government_is_nomadic
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:recipient = {
+			is_imprisoned = no
+		}
+		scope:actor = {
+			is_imprisoned = no
+			NOR = {
+				is_at_war_with = scope:recipient
+				exists = involved_activity
+				is_travelling = yes
+			}
+		}
+	}
+	
+	is_highlighted = {
+		always = yes
+	}
+	
+	# Start with higher taxes
+	send_option = {
+		flag = high_obligations
+		localization = VASSAL_TO_TRIBUTARY_HIGHER_OBLIGATIONS
+	}
+	
+	#Use hook
+	send_option = {
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		flag = hook	
+		localization = GENERIC_SPEND_A_HOOK
+	}
+	should_use_extra_icon = {
+		scope:actor = { has_usable_hook = scope:recipient }
+	}
+	extra_icon = "gfx/interface/icons/character_interactions/hook_icon.dds"
+	
+	send_options_exclusive = no
+
+	on_accept = {
+		scope:actor = {
+			show_as_tooltip = {
+				break_subject_contract_and_establish_tributary_effect = { SUZERAIN = scope:recipient TRIBUTARY = scope:actor }
+			}
+		}
+		scope:actor = {
+			trigger_event = mpo_interactions_events.0010
+		}
+	}
+	
+	on_decline = {
+		scope:actor = {
+			#Letter response, they get a bit pissed
+			trigger_event = mpo_interactions_events.0011
+		}
+	}
+
+	ai_accept = {
+		base = 0
+		
+		modifier = {
+			add = -50
+			desc = BASE_RELUCTANCE
+		}
+		
+		# Do they like you?
+		opinion_modifier = {
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 1
+			desc = AI_OPINION_REASON
+		}
+		
+		# If you're friends
+		modifier = {
+			add = 50
+			scope:recipient = {
+				has_relation_friend = scope:actor
+			}
+			desc = AI_FRIEND_REASON
+		}
+		
+		# If you're lovers
+		modifier = {
+			add = 50
+			scope:recipient = {
+				has_relation_lover = scope:actor
+			}
+			desc = AI_YOUR_LOVER
+		}
+		
+		# You're using a hook
+		modifier = {
+			add = 100
+			desc = SCHEME_WEAK_HOOK_USED
+			scope:hook = yes
+		}
+		
+		# You promised higher taxes
+		modifier = {
+			add = 25
+			desc = AI_HIGHER_OBLIGATIONS_REASON
+			scope:high_obligations = yes
+		}
+		
+		# Are they Nomadic
+		modifier = {
+			add = 25
+			desc = game_concept_nomadic_government
+			scope:recipient = { government_has_flag = government_is_nomadic }
+		}
+	}
+
+	ai_will_do = {
+		base = 0
+	}
+
+	ai_targets = {
+		ai_recipients = suzerain
+	}
+}
+
+mpo_gift_herd_interaction = {
+	icon = herd_interaction
+	category = interaction_category_friendly
+	common_interaction = yes
+	interface_priority = 65
+	desc = mpo_gift_herd_interaction_desc
+
+	greeting = positive
+	notification_text = SEND_GIFT_HERD_PROPOSAL
+
+	answer_accept_key = SEND_GIFT_HERD_ACCEPT
+	answer_reject_key = SEND_GIFT_HERD_REJECT
+
+	ai_targets = {
+		ai_recipients = scripted_relations
+		ai_recipients = liege
+		ai_recipients = suzerain
+		ai_recipients = head_of_faith
+	}
+	ai_targets = {
+		ai_recipients = neighboring_rulers
+		ai_recipients = peer_vassals
+		max = 10
+	}
+	ai_targets = {
+		ai_recipients = vassals
+		max = 10
+	}
+	ai_targets = {
+		ai_recipients = tributaries
+		max = 10
+	}
+	ai_target_quick_trigger = {
+		adult = yes
+	}
+	ai_frequency = 60
+
+	is_shown = {
+		NOT = {
+			scope:recipient = scope:actor
+		}
+		scope:actor = { government_has_flag = government_is_nomadic }
+		scope:recipient = {
+			government_has_flag = government_is_nomadic
+			exists = domicile
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		NOT = { scope:actor.domicile.herd < herd_gift_value }
+		scope:recipient = { is_busy_in_events_localised = yes }
+	}
+
+	on_auto_accept = {
+		scope:recipient = {
+			trigger_event = mpo_interactions_events.0020
+		}
+	}
+
+	on_accept = {
+		scope:recipient = {
+			# Verify that they could become friend
+			if = {
+				limit = {
+					NAND = {
+						has_relation_friend = scope:actor
+						has_relation_lover = scope:actor
+						has_relation_soulmate = scope:actor
+						has_relation_best_friend = scope:actor
+					}
+				}
+				gifting_leads_towards_friendship_effect = yes
+			}
+		}
+
+		scope:actor = {
+			# Warning for multiple gifts
+			if = {
+				limit = {
+					scope:recipient = {
+						has_opinion_modifier = {
+							target = scope:actor
+							modifier = sent_herd_opinion
+						}
+					}
+				}
+				custom_tooltip = ALREADY_SENT_GIFT_HERD_WARNING
+			}
+			
+			send_interface_message = {
+				type = event_gold_neutral
+				title = gift_interaction_notification
+				right_icon = scope:recipient
+				pay_herd = {
+					target = scope:recipient
+					value = domicile.herd_gift_value
+				}
+				stress_impact = {
+					greedy = medium_stress_impact_gain
+				}
+				if = {
+					limit = {
+						scope:recipient = {
+							NOT = {
+								is_heir_of = scope:actor
+							}
+						}
+					}
+					stress_impact = {
+						generous = medium_stress_impact_loss
+					}
+				}
+				
+				#FP3 Tenet Communal Possessions Perk - piety gain for gift giving. 
+				if = {
+					limit = {
+						scope:actor = {
+							faith = {
+					 			has_doctrine_parameter = piety_from_gifts_active
+					 		}
+					 	}
+					}
+					scope:actor = {
+						add_piety = minor_piety_gain
+					}
+				}
+				
+				# Let's apply the opinion modifier last, as to apply everything else correctly first
+				scope:recipient = {
+					add_opinion = {
+						target = scope:actor
+						modifier = sent_herd_opinion
+						opinion = sent_herd_opinion_value
+					}
+				}
+			}
+		}
+	}
+	
+	ai_accept = {
+		base = 0
+		modifier = {
+			add = 100
+			desc = HERD_REASON
+		}
+	}
+	
+	ai_potential = {
+		is_available_at_peace_ai_adult = yes
+		ai_greed < medium_positive_ai_value
+		domicile.herd >= {
+			value = major_herd_value_static
+			multiply = 3
+		}
+		ai_has_conqueror_personality = no
+		ai_should_focus_on_building_in_their_capital = no
+	}
+	
+	auto_accept = {
+		custom_description = {
+			text = auto_accept_interaction_ai	
+			object = scope:recipient
+			scope:recipient = {
+				is_ai = yes
+			}
+		}
+	}
+	
+	ai_min_reply_days = 1
+	ai_max_reply_days = 1
+	
+	ai_will_do = {
+		base = 100
+		
+		modifier = { # Do not send double-gifts
+			factor = 0
+			scope:recipient = {
+				has_opinion_modifier = {
+					target = scope:actor
+					modifier = sent_herd_opinion
+				}
+			}
+		}
+		
+		modifier = { # Special Blood Brother weight
+			add = 100
+			scope:actor = {
+				has_relation_blood_brother = scope:recipient
+				domicile.herd >= { # Do not lose all your Herd for this
+					value = herd_gift_value
+					multiply = 2
+				}
+			}
+		}
+		
+		modifier = {
+			add = 100
+			scope:recipient = {
+				is_tributary_of = scope:actor
+				OR = {
+					ai_greed <= -50
+					is_obedient_to = scope:actor
+					opinion = {
+						target = scope:actor
+						value >= 50
+					}
+				}
+			}
+		}
+		
+		modifier = { # Basic Filtering
+			factor = 0
+			scope:recipient = {
+				NOR = {
+					AND = { # Bankrupt lovers, friends and a bankrupt liege should be considered
+						OR = {
+							scope:actor = {
+								any_liege_or_above = {
+									this = scope:recipient
+								}
+							}
+							has_secret_relation_lover = scope:actor
+							has_relation_lover = scope:actor
+							has_relation_soulmate = scope:actor
+							has_relation_friend = scope:actor
+							has_relation_best_friend = scope:actor
+						}
+						domicile.herd < minor_herd_value_static
+					}
+					AND = { # Generous characters will give gifts to their friends/lovers
+						OR = {
+							has_secret_relation_lover = scope:actor
+							has_relation_lover = scope:actor
+							has_relation_soulmate = scope:actor
+							has_relation_friend = scope:actor
+							has_relation_best_friend = scope:actor
+						}
+						scope:actor = {
+							OR = {
+								ai_greed <= high_negative_ai_value
+								AND = {
+									ai_greed < 0
+									culture = {
+										has_cultural_parameter = gives_more_gifts
+									}
+								}
+							}
+						}
+					}
+					AND = { # Characters with the Generous Cultural Tradition will give gifts to more people
+						is_ruler = yes
+						OR = {
+							is_allied_to = scope:actor
+							is_close_or_extended_family_of = scope:actor
+						}
+						scope:actor = {
+							ai_greed < 0
+							culture = {
+								has_cultural_parameter = gives_more_gifts
+							}
+						}
+					}
+					AND = { # Characters with the loyal trait more likely to give gifts to friends/lieges
+						OR = {
+							scope:actor.liege ?= this
+							has_relation_friend = scope:actor
+							has_relation_best_friend = scope:actor
+							is_allied_to = scope:actor
+							is_close_or_extended_family_of = scope:actor
+						}
+						scope:actor = {
+							ai_greed <= 0
+							has_trait = loyal
+						}
+					}
+					AND = { # Powerful vassals should be considered
+						is_powerful_vassal_of = scope:actor
+						opinion = {
+							target = scope:actor
+							value < 0
+						}
+						NOT ={
+							has_opinion_modifier = {
+								target = scope:actor
+								modifier = sent_herd_opinion
+							}
+						}
+					}
+					AND = { # Factioneering vassals should be considered
+						is_vassal_of = scope:actor
+						is_a_faction_member = yes
+						NOT ={
+							has_opinion_modifier = {
+								target = scope:actor
+								modifier = sent_herd_opinion
+							}
+						}
+					}
+					AND = { # Realm Priests should be considered
+						scope:actor = {
+							faith = { has_doctrine = doctrine_theocracy_temporal }
+							exists = cp:councillor_court_chaplain
+							cp:councillor_court_chaplain = scope:recipient
+						}
+						opinion = {
+							target = scope:actor
+							value <= 25
+						}
+						NOT = {
+							has_opinion_modifier = {
+								target = scope:actor
+								modifier = sent_herd_opinion
+							}
+						}
+					}
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0.1
+			scope:recipient = {
+				opinion = {
+					target = scope:actor
+					value < 0
+				}
+				NAND = {
+					is_vassal_of = scope:actor
+					scope:actor = {
+						ai_rationality > 50
+					}
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0.1
+			scope:recipient = {
+				has_relation_rival = scope:actor
+			}
+		}
+	}
+}
+
+mpo_offer_submission_or_ruin = {
+	category = interaction_category_vassal
+	icon = invasion
+	popup_on_receive = yes
+	pause_on_receive = yes
+	ai_maybe = yes
+
+	desc = mpo_offer_submission_or_ruin_desc
+
+	ai_targets = {
+		ai_recipients = neighboring_rulers
+	}
+	ai_frequency = 3
+	interface_priority = 300
+	common_interaction = yes
+	force_notification = yes
+
+	is_shown = {
+		scope:actor = {
+			mpo_offer_submission_or_ruin_shown_actor_trigger = yes
+		}
+		scope:recipient = {
+			mpo_offer_submission_or_ruin_shown_recipient_trigger = yes
+		}
+		
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			mpo_offer_submission_or_ruin_valid_actor_trigger = yes
+		}
+		scope:recipient = {
+			mpo_offer_submission_or_ruin_valid_recipient_trigger = yes
+		}
+	}
+
+	is_highlighted = {
+		always = yes
+	}
+
+	greeting = positive
+	notification_text = OFFER_SUBMISSION_OR_RUIN_INTERACTION_NOTIFICATION
+
+	can_send_despite_rejection = yes
+
+	ai_min_reply_days = 3
+	ai_max_reply_days = 5
+
+	ai_accept = {
+		base = -50
+		# MAIN
+		# Heretic/Infidel modifier.
+		# Tier difference modifier.
+		# Dejure modifier.
+		# Distant/Remote Realm modifier.
+		# Military power difference modifier.
+
+		# MINOR
+		# Rivalry modifier.
+		# Same Dynasty modifier.
+		# Cultural/Cultural Group modifiers.
+		# Ageism modifier vs kids.
+		# Ruler Legitimacy modifier.
+		# Claimant modifier.
+		# FP3 Piety Level modifier.
+
+		# OPINION SCALES
+		# Dread
+		# Compare Opinion modifier.
+
+		#CONFEDERATION
+		modifier = {
+			desc = CONFEDERATION_MEMBER_REASON
+			scope:recipient = {
+	 			is_confederation_member = yes
+ 			}
+ 			add = -500
+		}
+
+		#HERDER
+		modifier = {
+			scope:recipient = { government_has_flag = government_is_herder }
+			add = 10000
+			desc = HERDER_REASON
+		}
+
+		#TRIBUTARY
+		modifier = {
+			desc = KING_SUZERAIN_REASON
+			scope:recipient = {
+	 			is_tributary = yes
+	 			NOT = {
+	 				is_tributary_of_suzerain_or_above = scope:actor
+	 			}
+	 			suzerain = {
+	 				highest_held_title_tier >= tier_kingdom
+	 			}
+ 			}
+ 			add = -50
+		}
+		modifier = {
+			desc = STRONG_SUZERAIN_REASON
+			scope:recipient = {
+	 			is_tributary = yes
+	 			NOT = {
+	 				is_tributary_of_suzerain_or_above = scope:actor
+	 			}
+	 			suzerain = {
+	 				sub_realm_size >= 20
+	 			}
+ 			}
+ 			add = -100
+		}
+		modifier = {
+			desc = STRONG_SUZERAIN_REASON
+			scope:recipient = {
+	 			is_tributary = yes
+	 			NOT = {
+	 				is_tributary_of_suzerain_or_above = scope:actor
+	 			}
+	 			scope:recipient.suzerain = {
+	 				current_military_strength >= scope:actor.current_military_strength
+	 			}
+ 			}
+ 			add = -300
+		}
+		modifier = {
+			desc = ALREADY_TRIBUTARY_REASON
+			scope:recipient = {
+	 			is_tributary_of_suzerain_or_above = scope:actor
+ 			}
+ 			add = 30
+		}
+		
+		# PERKS
+		modifier = { # Perk boost
+			desc = offer_vassalization_true_ruler_perk_tt
+			trigger = {
+				scope:actor = { has_perk = true_ruler_perk }
+			}
+			add = 30
+		}
+		modifier = { # Education 5 boost
+			desc = offer_vassalization_education_diplomacy_5_tt
+			trigger = {
+				scope:actor = { has_trait_with_flag = offer_vassalisation_25 }
+			}
+			add = 25
+		}
+
+		# EVENTS - temporary bonuses gained by events
+		modifier = {
+			desc = event_bonus_to_vassal_accept_tt
+			trigger = {
+				scope:actor = { has_character_modifier = event_bonus_to_vassal_accept }
+			}
+			add = 20
+		}
+
+
+		# STRUGGLES - bonus gained by successful Sway scheme during the Persian Struggle
+		modifier = {
+			desc = fp3_persian_struggle_previously_swayed_tt
+			trigger = {
+				scope:recipient = {
+					has_opinion_modifier = {
+						modifier = scheme_sway_and_compelled_to_submit_opinion
+						target = scope:actor
+					}
+				}
+			}
+			add = 20
+		}
+
+		modifier = {
+			desc = fp3_rekindler_of_iran_modifier_reason
+			trigger = {
+				AND = { 
+					scope:actor = { dynasty ?={ has_dynasty_modifier = fp3_rekindler_of_iran_modifier } }
+					scope:recipient = { culture = { has_cultural_pillar = heritage_iranian } }
+				}
+			}
+			add = 20
+		}
+		
+		# OBEDIENCE
+		modifier = {
+			desc = obedient_interaction_reason
+			trigger = {
+				is_obedient_to = scope:actor
+			}
+			add = 100
+		}
+
+		modifier = { # Cultural Acceptance
+			add = offer_vassalage_acceptance_value
+			desc = cultural_acceptance_interaction_reason
+			trigger = {
+				scope:actor = {
+					NOR = {
+						has_same_culture_as = scope:recipient
+						government_has_flag = government_is_nomadic # Nomads do not care about Culture
+						has_trait = nomadic_philosophy
+					}
+					culture = {
+						cultural_acceptance = { target = scope:recipient.culture value <= 90 }
+					}
+				}
+			}
+		}
+
+		# MAIN
+		modifier = { #Different faith, no pluralism.
+			desc = offer_vassalization_interaction_aibehavior_differentfaith_tt
+			trigger = {
+				scope:actor = {
+					NOR = { # Nomads do not care about Faith
+						government_has_flag = government_is_nomadic
+						has_trait = nomadic_philosophy
+					}
+				}
+				scope:recipient = {
+					NOR = { #Of two different faiths AND the potential vassal's faith is not pluralistic.
+						faith = scope:actor.faith
+						faith = { has_doctrine = doctrine_pluralism_pluralistic }
+					}
+				}
+			}
+			add = {
+				value = -40
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_hostile_level
+							}
+						}
+					}
+					add = -40
+				}
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_evil_level
+							}
+						}
+					}
+					add = -40
+				}
+			}
+		}
+
+		modifier = { #Different faith, pluralism.
+			desc = offer_vassalization_interaction_aibehavior_differentfaith_tt
+			trigger = {
+				scope:actor = {
+					NOR = { # Nomads do not care about Faith
+						government_has_flag = government_is_nomadic
+						has_trait = nomadic_philosophy
+					}
+				}
+				scope:recipient = {
+					NOT = {
+						faith = scope:actor.faith
+					}
+					NOT = {
+						scope:actor.faith = { has_doctrine = doctrine_pluralism_pluralistic }
+					}
+					faith = { has_doctrine = doctrine_pluralism_pluralistic }
+				}
+			}
+			add = {
+				value = -20
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_hostile_level
+							}
+						}
+					}
+					add = -20
+				}
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_evil_level
+							}
+						}
+					}
+					add = -20
+				}
+			}
+		}
+
+		modifier = { #Different faith, both have pluralism.
+			desc = offer_vassalization_interaction_aibehavior_differentfaith_tt
+			trigger = {
+				scope:actor = {
+					NOR = { # Nomads do not care about Faith
+						government_has_flag = government_is_nomadic
+						has_trait = nomadic_philosophy
+					}
+				}
+				scope:recipient = {
+					NOT = {
+						faith = scope:actor.faith
+					}
+					scope:actor.faith = { has_doctrine = doctrine_pluralism_pluralistic }
+					faith = { has_doctrine = doctrine_pluralism_pluralistic }
+				}
+			}
+			add = {
+				value = -10
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_hostile_level
+							}
+						}
+					}
+					add = -10
+				}
+				if = {
+					limit = {
+						scope:recipient.faith = {
+							faith_hostility_level = {
+								target = scope:actor.faith
+								value >= faith_evil_level
+							}
+						}
+					}
+					add = -10
+				}
+			}
+		}
+		modifier = { #I am a King!
+			desc = offer_vassalization_interaction_aibehavior_amkingtier_tt
+			trigger = {
+				scope:recipient = { highest_held_title_tier = tier_kingdom }
+			}
+			add = {
+				value = -50
+				if = {
+					limit = {
+						scope:recipient = {
+							OR = {
+								government_has_flag = government_is_republic
+								government_has_flag = government_is_theocracy
+							}
+						}
+					}
+					add = -50
+				}
+				if = {
+					limit = {
+						scope:recipient.sub_realm_size >= 5
+					}
+					add = -50
+				}
+				if = {
+					limit = {
+						scope:recipient.sub_realm_size >= 10
+					}
+					add = -100
+				}
+				if = {
+					limit = {
+						scope:actor = {
+							is_ai = yes
+						}
+					}
+					add = -10000
+				}
+			}
+		}
+		modifier = { #I am an Emperor!!!
+			desc = offer_vassalization_interaction_aibehavior_amkingtier_tt
+			trigger = {
+				scope:recipient = { highest_held_title_tier >= tier_empire }
+			}
+			add = {
+				value = -200
+				if = {
+					limit = {
+						scope:recipient = {
+							OR = {
+								government_has_flag = government_is_republic
+								government_has_flag = government_is_theocracy
+							}
+						}
+					}
+					add = -100
+				}
+				if = {
+					limit = {
+						scope:recipient.sub_realm_size >= 10
+					}
+					add = -100
+				}
+				if = {
+					limit = {
+						scope:recipient.sub_realm_size >= 20
+					}
+					add = -100
+				}
+				if = {
+					limit = {
+						scope:recipient.sub_realm_size >= 40
+					}
+					add = -200
+				}
+				if = {
+					limit = {
+						scope:actor = {
+							is_ai = yes
+						}
+					}
+					add = -10000
+				}
+			}
+		}
+		modifier = { #I fought an independence war against you.
+			desc = offer_vassalization_interaction_aibehavior_independence_war_tt
+			trigger = {
+				scope:recipient = {
+					exists = var:independence_war_former_liege
+					var:independence_war_former_liege = scope:actor
+				}
+			}
+			add = -300
+		}
+		modifier = { # We are both nomadic
+			desc = interaction_nonnomad_vs_nomad
+			trigger = {
+				scope:actor = {
+					government_has_flag = government_is_nomadic
+				}
+				scope:recipient = {
+					government_has_flag = government_is_nomadic
+				}
+			}
+			add = 25
+		}
+		modifier = { # Isolationist tradition
+			desc = isolationist_reason
+			trigger = {
+				NOT = {
+					scope:actor.culture = scope:recipient.culture
+				}
+				scope:recipient.culture = {
+					has_cultural_tradition = tradition_isolationist
+				}
+			}
+			add = -25
+		}
+		modifier = { #Bankrupt
+			desc = bankrupt_reason
+			trigger = {
+				scope:actor.gold <= -1
+			}
+			add = -100
+		}
+		modifier = { #Wide difference in rank
+			desc = offer_vassalization_interaction_aibehavior_widetitletier_tt
+			trigger = {
+				scope:actor = {
+					tier_difference = {
+						target = scope:recipient
+						value > 2
+					}
+				}
+			}
+			add = 40
+		}
+		modifier = { # Allied
+			desc = offer_vassalization_interaction_aibehavior_allied_tt
+			trigger = {
+				scope:recipient = {
+					is_allied_to = scope:actor
+				}
+			}
+			add = 25
+		}
+		modifier = { # Is the Rightful Liege of recipient
+			desc = offer_vassalization_interaction_aibehavior_rightfulliegetitleholder_tt
+			trigger = {
+				scope:actor = { is_rightful_liege_of = scope:recipient }
+			}
+			add = 50
+		}
+		modifier = { # Encircled
+			desc = offer_vassalization_interaction_aibehavior_encircled_tt
+			trigger = {
+				scope:recipient = {
+					NOT = {
+						any_neighboring_top_liege_realm_owner = {
+							NOT = {
+								this = scope:actor
+							}
+						}
+					}
+					NOT = {
+						any_realm_county = {
+							is_coastal_county = yes
+						}
+					}
+				}
+			}
+			add = 50
+		}
+		modifier = { #Distant Realm — Overseas Connection
+			desc = offer_vassalization_interaction_aibehavior_distantrealm_tt
+			trigger = {
+				scope:actor = {
+					character_is_realm_neighbor = scope:recipient
+					NOT = { #Ibiza should want to be a vassal of Mallorca, etc.
+						character_is_land_realm_neighbor = scope:recipient
+						scope:actor = { is_rightful_liege_of = scope:recipient }
+					}
+				}
+			}
+			add = -50
+		}
+		modifier = { #Distant Realm — No Connection
+			desc = offer_vassalization_interaction_aibehavior_distantrealm_tt
+			trigger = {
+				scope:actor = {
+					NOT = {
+						character_is_realm_neighbor = scope:recipient
+					}
+				}
+				scope:recipient.capital_province = { squared_distance = { target = scope:actor.capital_province value < 200000 } }
+			}
+			add = -100
+		}
+		modifier = { #Remote Realm.
+			desc = offer_vassalization_interaction_aibehavior_remoterealm_tt
+			trigger = {
+				scope:actor = {
+					NOT = {
+						character_is_realm_neighbor = scope:recipient
+					}
+				}
+				scope:recipient.capital_province = { squared_distance = { target = scope:actor.capital_province value >= 200000 } }
+			}
+			add = -200
+		}
+		modifier = {
+			desc = offer_vassalization_interaction_aibehavior_power_tt
+	  	  	add = {
+				value = 1
+				subtract = {
+					value = scope:recipient.max_military_strength # Intended for recipient to use max, to avoid having vassalizations become too easy for weakened realms
+					divide = { value = scope:actor.current_military_strength min = 1 }
+				}
+				multiply = 100
+				ceiling = yes
+	  		}
+		}
+		modifier = {
+			desc = offer_vassalization_interaction_aibehavior_vassal_opinion_tt
+			trigger = {
+				scope:actor = {
+				number_of_powerful_vassals >= 1
+				}
+			}
+
+	  	  	add = {
+				value = 0
+				scope:actor = {
+					every_powerful_vassal = {
+						if = {
+							limit = {
+								save_temporary_opinion_value_as = {
+									name = vassal_opinion
+									target = scope:actor
+								}
+							}
+							add = scope:vassal_opinion
+						}
+					}
+
+					if = {
+						limit = {
+							number_of_powerful_vassals > 0
+						}
+						divide = number_of_powerful_vassals
+					}
+					else = {
+						divide = 10
+					}
+				}
+
+				divide = 10
+	  		}
+		}
+
+		# MINOR
+		modifier = { #Friend modifier.
+			desc = offer_vassalization_interaction_aibehavior_friend_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_friend = scope:actor
+					NOT = { has_relation_best_friend = scope:actor }
+				}
+			}
+			add = 20
+		}
+		modifier = { #Best Friend modifier.
+			desc = offer_vassalization_interaction_aibehavior_best_friend_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_best_friend = scope:actor
+				}
+			}
+			add = 50
+		}
+		modifier = { #Lover modifier.
+			desc = interaction_lover
+			trigger = {
+				scope:recipient = {
+					has_relation_lover = scope:actor
+					NOT = { has_relation_soulmate = scope:actor }
+				}
+			}
+			add = 20
+		}
+		modifier = { #Soulmate modifier.
+			desc = interaction_soulmate
+			trigger = {
+				scope:recipient = {
+					has_relation_soulmate = scope:actor
+				}
+			}
+			add = 50
+		}
+		modifier = { #Rivalry modifier.
+			desc = offer_vassalization_interaction_aibehavior_rival_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_rival = scope:actor
+					NOT = { has_relation_nemesis = scope:actor }
+				}
+			}
+			add = -200
+		}
+		modifier = { #Nemesis modifier.
+			desc = offer_vassalization_interaction_aibehavior_nemesis_tt
+			trigger = {
+				scope:recipient = {
+					has_relation_nemesis = scope:actor
+				}
+			}
+			add = -2000
+		}
+		modifier = { #Same Dynasty modifier.
+			desc = offer_vassalization_interaction_aibehavior_dynasty_tt
+			trigger = {
+				scope:recipient = {
+					dynasty = scope:actor.dynasty
+				}
+			}
+			add = 25
+		}
+
+		modifier = { # Same language
+			add = 5
+			desc = speaks_same_language_interaction_reason
+			trigger = {
+				scope:actor = {
+					knows_language_of_culture = scope:recipient.culture
+				}
+			}
+		}
+
+		modifier = { # Iberian Struggle, less likely for outsiders to vassalize inside
+			add = -35
+			desc = iberian_struggle_reason_reason
+			trigger = {
+				scope:actor = {
+					NOT = {
+						any_character_struggle = { is_struggle_type = iberian_struggle }
+					}
+				}
+				scope:recipient = {
+					any_character_struggle = { is_struggle_type = iberian_struggle }
+				}
+			}
+		}
+
+		modifier = { #Ageism modifier vs kids.
+			desc = offer_vassalization_interaction_aibehavior_child_tt
+			trigger = {
+				scope:actor = {
+					age < 12
+				}
+				scope:recipient = {
+					age > 16
+				}
+			}
+			add = -5
+		}
+		modifier = { #Illegitimacy modifier.
+			desc = offer_vassalization_interaction_aibehavior_illegitimate_tt
+			trigger = {
+				scope:actor = {
+					OR = {
+						AND = {
+							has_trait = bastard
+							scope:recipient = {
+								faith = { NOT = { has_doctrine = doctrine_bastardry_none } }
+							}
+						}
+						has_trait = denounced
+						has_trait = disinherited
+					}
+				}
+			}
+			add = -10
+		}
+
+		modifier = { #Claimant modifier.
+			desc = offer_vassalization_interaction_aibehavior_claimant_tt
+			trigger = {
+				scope:actor.primary_title = {
+					scope:recipient = {
+						has_claim_on = prev
+					}
+				}
+			}
+			add = -50
+		}
+
+		modifier = { # Ambitious
+			desc = TAKE_THE_VOWS_AMBITIOUS
+			trigger = {
+				scope:recipient = {
+					has_trait = ambitious
+				}
+			}
+			add = -30
+		}
+		modifier = { # Brave
+			desc = INTERACTION_BRAVE
+			trigger = {
+				scope:recipient = {
+					has_trait = brave
+				}
+			}
+			add = -30
+		}
+		modifier = { # wrathful
+			desc = INTERACTION_WRATHFUL
+			trigger = {
+				scope:recipient = {
+					has_trait = wrathful
+				}
+			}
+			add = -40
+		}
+		modifier = { # vengeful
+			desc = INTERACTION_VENGEFUL
+			trigger = {
+				scope:recipient = {
+					has_trait = vengeful
+				}
+			}
+			add = -20
+		}
+		modifier = { # peasant leader
+			desc = INTERACTION_PEASANT_LEADER
+			trigger = {
+				scope:recipient = {
+					has_trait = peasant_leader
+				}
+			}
+			add = -40
+		}
+		modifier = { # populist leader
+			desc = INTERACTION_POPULIST_LEADER
+			trigger = {
+				scope:recipient = {
+					has_trait = populist_leader
+				}
+			}
+			add = -100
+		}
+		modifier = { #martial leader
+			desc = INTERACTION_MARTIAL_EDUCATION
+			trigger = {
+				scope:recipient = {
+					OR = {
+						has_education_martial_trigger = yes
+						has_martial_lifestyle_trait_trigger = yes
+					}
+				}
+			}
+			add = -10
+		}
+		modifier = { # Arrogant
+			desc = INTERACTION_ARROGANT
+			trigger = {
+				scope:recipient = {
+					has_trait = arrogant
+				}
+			}
+			add = -60
+		}
+
+		modifier = { # Fickle
+			desc = INTERACTION_FICKLE
+			trigger = {
+				scope:recipient = {
+					has_trait = fickle
+				}
+			}
+			add = -10
+		}
+
+		modifier = { # Stubborn
+			desc = INTERACTION_STUBBORN
+			trigger = {
+				scope:recipient = {
+					has_trait = stubborn
+				}
+			}
+			add = -180
+		}
+
+		modifier = { # Trusting
+			desc = TAKE_THE_VOWS_TRUSTING
+			trigger = {
+				scope:recipient = {
+					has_trait = trusting
+				}
+			}
+			add = 20
+		}
+
+		modifier = { # Humble
+			desc = INTERACTION_HUMBLE
+			trigger = {
+				scope:recipient = {
+					has_trait = humble
+				}
+			}
+			add = 20
+		}
+
+		modifier = { # Content
+			desc = INTERACTION_CONTENT
+			trigger = {
+				scope:recipient = {
+					has_trait = content
+				}
+			}
+			add = 20
+		}
+
+		modifier = { # Craven
+			desc = INTERACTION_CRAVEN
+			trigger = {
+				scope:recipient = {
+					has_trait = craven
+				}
+			}
+			add = 100
+		}
+
+		modifier = { # FP3 modifier.
+			desc = GENERIC_YOUR_PIETY_LEVEL_MODIFIER
+			trigger = { scope:actor = { any_character_struggle = { has_struggle_phase_parameter = piety_level_affects_vassalage_acceptance } } }
+			add = {
+				value = {
+					value = scope:actor.piety_level
+					subtract = low_piety_level
+				}
+				multiply = 10
+			}
+		}
+
+		# OPINION INFLUENCE
+		modifier = {
+			add = intimidated_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 1
+				}
+			}
+			desc = INTIMIDATED_REASON
+		}
+		modifier = {
+			add = cowed_reason_value
+			scope:recipient = {
+				has_dread_level_towards = {
+					target = scope:actor
+					level = 2
+				}
+			}
+			desc = COWED_REASON
+		}
+		opinion_modifier = { #Compare Opinion modifier - Clans care more about opinion
+			trigger = {
+				scope:actor = {
+					government_has_flag = government_is_clan
+				}
+				scope:recipient = {
+					government_has_flag = government_is_clan
+				}
+			}
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 0.7
+		}
+		opinion_modifier = { #Compare Opinion modifier.
+			trigger = {
+				OR = {
+					scope:actor = {
+						NOT = { government_has_flag = government_is_clan }
+					}
+					scope:recipient = {
+						NOT = { government_has_flag = government_is_clan }
+					}
+				}
+			}
+			who = scope:recipient
+			opinion_target = scope:actor
+			multiplier = 0.35
+		}
+
+		# DIPLOMATIC COURT GRANDEUR BONUS
+		modifier = {
+			trigger = {
+				scope:actor = {
+					has_royal_court = yes
+					has_dlc_feature = royal_court
+					has_court_type = court_diplomatic
+					court_grandeur_current_level >= 1
+				}
+			}
+			add = {
+				value = scope:actor.court_grandeur_current
+				if = {
+					limit = { # Reduce the bonus if you are below your expected level
+						scope:actor = {
+							court_grandeur_current_level < court_grandeur_minimum_expected_level
+						}
+					}
+					multiply = 0.15
+				}
+				else = {
+					multiply = 0.3
+				}
+			}
+			desc = DIPLOMATIC_COURT_ACCEPTANCE_INCREASE_REASON
+		}
+
+		# CONTRACT OPTIONS
+		modifier = {
+			add = 20
+			scope:actor = {
+				faith = {
+					has_doctrine = doctrine_pluralism_pluralistic
+				}
+			}
+			scope:recipient = {
+				OR = {
+					government_has_flag = government_is_feudal
+					government_has_flag = government_is_clan
+				}
+			}
+			desc = CONTRACT_RELIGIOUS_EXEMPTION_REASON
+		}
+		modifier = {
+			add = 30
+			scope:low_obligations = yes
+			desc = CONTRACT_MERCIFUL_KHAN_REASON
+		}
+		modifier = {
+			add = -10
+			scope:send_siege_weapons = yes
+			desc = CONTRACT_SEND_SIEGE_WEAPONS_REASON
+		}
+		modifier = {
+			add = -50
+			scope:recipient = {
+				NOT = {
+					government_has_flag = government_is_herder
+				}
+			}
+			scope:send_tribute = yes
+			desc = CONTRACT_SEND_TRIBUTE_REASON
+		}
+
+		# INSPECTION BONUSES
+		modifier = {
+			desc = "INSPECTION_REASON"
+			add = 5
+			scope:recipient = {
+				has_variable_list = lesser_inspection_bonus
+				is_target_in_variable_list = {
+					name = lesser_inspection_bonus
+					target = scope:actor
+				}
+			}
+		}
+		modifier = {
+			desc = "INSPECTION_REASON"
+			add = 10
+			scope:recipient = {
+				has_variable_list = inspection_bonus
+				is_target_in_variable_list = {
+					name = inspection_bonus
+					target = scope:actor
+				}
+			}
+		}
+		modifier = {
+			desc = "INSPECTION_REASON_REWARD"
+			add = 10
+			scope:recipient = {
+				has_variable_list = inspection_reward
+				is_target_in_variable_list = {
+					name = inspection_reward
+					target = scope:actor
+				}
+			}
+		}
+		modifier = {
+			desc = "INSPECTION_REASON_REWARD_FOCUSED"
+			add = 10
+			scope:actor = { has_character_modifier = inspection_reward_focused_vassal_acceptance }
+		}
+
+		# LOW LEGITIMACY
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			add = -10
+			scope:actor = {
+				has_legitimacy_flag = reduced_vassalization_acceptance
+			}
+		}
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			add = -20
+			scope:actor = {
+				has_legitimacy_flag = very_reduced_vassalization_acceptance
+			}
+		}
+		modifier = {
+			desc = "LOW_LEGITIMACY_REASON"
+			add = -50
+			scope:actor = {
+				has_legitimacy_flag = massively_reduced_vassalization_acceptance
+			}
+		}
+
+		# HIGH LEGITIMACY
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			add = 25
+			scope:actor = {
+				has_legitimacy_flag = increased_vassalization_acceptance
+			}
+		}
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			add = 50
+			scope:actor = {
+				has_legitimacy_flag = very_increased_vassalization_acceptance
+			}
+		}
+		modifier = {
+			desc = "HIGH_LEGITIMACY_REASON"
+			add = 75
+			scope:actor = {
+				has_legitimacy_flag = extra_increased_vassalization_acceptance
+			}
+		}
+
+		# INFLUENCE
+		modifier = {
+			add = 25
+			scope:influence_send_option = yes
+			desc = INFLUENCE_INTERACTION_ACCEPTANCE_SEND_OPTION
+		}
+
+		#HISTORICALLY ADMIN PEOPLES WANT TO BE ADMIN
+		modifier = {
+			add = 30
+			scope:actor = {
+				government_has_flag = government_is_administrative
+			}
+			scope:recipient = {
+				culture = {
+					OR = {
+						this = culture:greek
+						any_parent_culture_or_above = {
+							this = culture:greek
+						}
+						this = culture:han
+						any_parent_culture_or_above = {
+							this = culture:han
+						}
+					}
+				}
+			}
+			
+			desc = "HISTORICAL_ADMIN_REASON"
+		}
+
+		modifier = { # AI-only weights, keep the pope from vassalizing too fast
+			trigger = {
+				exists = faith:catholic.religious_head
+				faith:catholic.religious_head = scope:actor
+				scope:actor = { is_ai = yes }
+			}
+			add = -50
+		}
+
+		modifier = {
+			trigger = {
+				scope:actor = {
+					has_variable = severed_head_vassalization
+					var:severed_head_vassalization = {
+						this = scope:recipient
+					}
+				}
+			}
+			add = 200
+			desc = COWED_BY_SEVERED_HEAD_MODIFIER
+		}
+
+		modifier = { #You're distracted by another war
+			desc = IS_AT_WAR_REASON
+			trigger = {
+				scope:actor = {
+					is_at_war = yes
+				}
+			}
+			add = -20
+		}
+		modifier = { #You're distracted by multiple wars
+			desc = HAS_MULTIPLE_WARS_REASON
+			trigger = {
+				scope:actor = {
+					any_character_war = {
+						count >= 2
+						exists = this
+					}
+				}
+			}
+			add = {
+				value = 0
+				scope:actor = {
+					every_character_war = {
+						add = -15
+					}
+				}
+			}
+		}
+		modifier = { #You have waged terrifying wars of devastation...
+			desc = WAGED_KHANS_TERROR_WARS_REASON
+			trigger = {
+				scope:actor = {
+					has_variable = gok_terror_war_value
+				}
+			}
+			add = scope:actor.var:gok_terror_war_value
+		}
+		modifier = { # Pacing needed for AI genghis
+			trigger = {
+				scope:actor = {
+					is_ai = yes
+				}
+				scope:recipient = {
+					is_ai = yes
+					ai_boldness >= 0
+				}
+			}
+			add = -1000
+		}
+	}
+
+	# Low starting obligations
+	send_option = {
+		is_shown = {
+			scope:recipient = {
+				NOT = {
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+		flag = low_obligations
+		localization = lenient_obligations
+	}
+
+	#Normal obligations for normies
+	send_option = {
+		is_shown = {
+			scope:recipient = {
+				OR = {
+					highest_held_title_tier < tier_duchy
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+		starts_enabled = { always = yes	}
+		flag = normal_obligations
+		localization = gok_normal_obligations
+	}
+	#Demand army
+	send_option = {
+		is_shown = {
+			scope:recipient = {
+				NOT = {
+					government_has_flag = government_is_herder
+				}
+				highest_held_title_tier >= tier_duchy
+			}
+		}
+		flag = send_army
+		localization = send_army
+		starts_enabled = {
+			scope:recipient = {
+				mpo_gok_auto_cultural_maa_trigger = yes
+				highest_held_title_tier >= tier_duchy
+			}
+		}
+	}
+	#Demand siege weapons
+	send_option = {
+		is_shown = {
+			scope:recipient = {
+				NOR = {
+					government_has_flag = government_is_herder
+					government_has_flag = government_is_tribal
+					government_has_flag = government_is_nomadic
+				}
+				highest_held_title_tier >= tier_duchy
+			}
+		}
+		flag = send_siege_weapons
+		localization = send_siege_weapons
+		starts_enabled = {
+			scope:recipient = {
+				mpo_gok_auto_cultural_maa_trigger = no
+				highest_held_title_tier >= tier_duchy
+			}
+		}
+	}
+
+	#Demand immediate tribute
+	send_option = {
+		is_shown = {
+			scope:recipient = {
+				NOT = {
+					government_has_flag = government_is_herder
+				}
+			}
+		}
+		flag = send_tribute
+		localization = send_tribute
+	}
+
+	send_option = { # EP3 Influence
+		is_shown = {
+			scope:actor = {
+				government_has_flag = government_has_influence
+			}
+		}
+		is_valid = {
+			scope:actor = { influence >= medium_influence_value }
+		}
+		flag = influence_send_option
+		localization = TRADE_INFLUENCE_FOR_BETTER_AI_ACCEPTANCE
+	}
+
+	send_options_exclusive = yes
+
+	on_accept = {
+		scope:actor = {
+			save_scope_as = gok
+		}
+		mpo_gok_offer_submission_effect = yes
+
+		scope:recipient = {
+			add_character_flag = {
+				flag = accepted_gok_submission
+				years = 3
+			}
+		}
+
+		scope:actor = {
+			#If recipient isn't a big deal, fire a hidden event that just creates a feed notification (to minimize khan clicking)
+			if = {
+				limit = {
+					scope:recipient = {
+						NOR = {
+							highest_held_title_tier >= tier_kingdom
+							sub_realm_size >= 10
+						}
+					}
+				}
+				trigger_event = mpo_greatest_of_khans.0020
+			}
+			else = {
+				trigger_event = mpo_greatest_of_khans.0021
+			}
+			
+			## Remove bonus, it's been used
+			if = {
+				limit = { has_character_modifier = event_bonus_to_vassal_accept }
+				remove_character_modifier = event_bonus_to_vassal_accept
+			}
+
+			if = { # FP3
+				limit = { any_character_struggle = { has_struggle_phase_parameter = offer_vassalization_removes_disloyalty } }
+				scope:recipient = { remove_trait = disloyal }
+			}
+		}
+	}
+
+	on_decline = {
+		scope:recipient = {
+			save_scope_as = gok_victim
+		}
+		scope:actor = {
+			show_as_tooltip = {
+				mpo_gok_offer_submission_refusal_effect = yes
+			}
+			
+			trigger_event = mpo_greatest_of_khans.0022
+		}
+	}
+
+	ai_potential = {
+		any_owned_story = {
+			OR = {
+				story_type = story_greatest_of_khans
+				story_type = story_mongol_invasion
+			}
+		}
+		is_independent_ruler = yes
+		#Not defending or losing an attacking war
+		NOT = {
+			any_character_war = {
+				OR = {
+					AND = {
+						any_war_attacker = {
+							this = root
+						}
+						attacker_war_score < 0
+					}
+					any_war_defender = {
+						this = root
+					}
+				}
+			}
+		}
+		#Already engaged in three wars
+		any_character_war = {
+			count >= 3
+			exists = this
+		}
+	}
+
+	ai_will_do = {
+		base = 100
+
+		# AI prefers to receive higher obligations from their vassals when possible.
+		modifier = {
+			factor = 2
+			scope:low_obligations = yes
+		}
+
+		modifier = {
+			factor = 3
+			scope:normal_obligations = yes
+		}
+
+		modifier = {
+			factor = 4
+			scope:send_army = yes
+		}
+		modifier = {
+			factor = 4
+			scope:send_siege_weapons = yes
+		}
+		modifier = {
+			factor = 5
+			scope:send_tribute = yes
+		}
+		modifier = {
+			factor = 3
+			scope:recipient = {
+				sub_realm_size < 3
+			}
+		}
+
+		#really want to get of little realms we encircle
+		modifier = {
+			factor = 10
+			scope:recipient = {
+				realm_size <= 20
+				NOT = {
+					any_neighboring_top_liege_realm_owner = {
+						NOT = {
+							this = scope:actor
+						}
+					}
+				}
+			}
+		}
+		#Would rather just destroy someone they hate or distrust
+		modifier = {
+			factor = 0
+			OR = {
+				has_relation_rival = scope:recipient
+				opinion = {
+					target = scope:recipient
+					value <= -90
+				}
+				scope:recipient = {
+					has_trait = disloyal
+				}
+				scope:recipient = {
+					has_trait = conqueror
+				}
+				scope:recipient = {
+					has_trait = ambitious
+				}
+				scope:recipient = {
+					ai_greed >= medium_positive_ai_value
+					ai_honor <= medium_negative_ai_value
+				}
+			}
+		}
+		modifier = {
+			factor = 0
+			scope:recipient = {
+				current_military_strength > 0
+				scope:actor.current_military_strength > 0
+				current_military_strength > scope:actor.current_military_strength
+			}
+		}
+	}
+}
+
+### Negotiate Obedience
+mpo_negotiate_obedience_interaction = {
+	category = interaction_category_vassal
+	icon = demand_obedience
+	desc = mpo_negotiate_obedience_interaction_desc
+	interface_priority = 80
+	common_interaction = yes
+
+	ai_frequency = 6
+	popup_on_receive = yes
+	pause_on_receive = yes
+
+	is_shown = {
+		scope:actor = {
+			government_has_flag = government_is_nomadic
+			exists = domicile
+		}
+		scope:recipient = {
+			is_ai = yes
+			obedience_target ?= scope:actor
+			is_obedient = no
+		}
+	}
+	
+	cost = {
+		prestige = {
+			value = medium_prestige_value
+			if = {
+				limit = {
+					scope:actor = { has_realm_law = nomadic_authority_2 }
+				}
+				multiply = 1.25
+			}
+			else_if = {
+				limit = {
+					scope:actor = { has_realm_law = nomadic_authority_3 }
+				}
+				multiply = 1.5
+			}
+			else_if = {
+				limit = {
+					scope:actor = { has_realm_law = nomadic_authority_4 }
+				}
+				multiply = 1.75
+			}
+			else_if = {
+				limit = {
+					scope:actor = { has_realm_law = nomadic_authority_5 }
+				}
+				multiply = 2
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		scope:actor = {
+			is_imprisoned = no
+			NOT = {
+				is_at_war_with = scope:recipient
+			}
+		}
+		trigger_if = {
+			limit = {
+				scope:recipient = { is_landed = yes }
+			}
+			OR = {
+				scope:recipient = { is_vassal_or_below_of = scope:actor }
+				scope:actor = {
+					custom_tooltip = {
+						text = mpo_interaction_not_neighbouring_tt
+						any_land_neighboring_realm_with_tributaries_owner = { 
+							this = scope:recipient
+						}
+					}
+				}
+			}
+		}
+		trigger_else = {}
+	}
+
+	ai_potential = {
+		government_has_flag = government_is_nomadic
+		primary_title.tier >= tier_duchy
+		prestige >= major_prestige_value
+	}
+
+	send_option = {
+		is_valid = {
+			scope:actor = {
+				has_usable_hook = scope:recipient
+			}
+		}
+		flag = hook
+		localization = GENERIC_SPEND_A_HOOK
+	}
+	
+	send_option = {
+		is_valid = {
+			scope:actor = {
+				gold >= medium_gold_value
+			}
+		}
+		flag = gold
+		localization = OFFER_GOLD_FOR_BETTER_AI_ACCEPTANCE
+	}
+	
+	send_option = {
+		is_valid = {
+			scope:actor.domicile = {
+				herd >= medium_herd_value
+			}
+		}
+		flag = herd
+		localization = OFFER_HERD_FOR_BETTER_AI_ACCEPTANCE
+	}
+
+	send_options_exclusive = no
+
+	ai_accept = {
+		base = -95
+		modifier = {
+			trigger = {
+				scope:hook ?= yes
+			}
+			add = 100
+			desc = MIGRATION_HOOK_USED
+		}
+		modifier = {
+			trigger = {
+				scope:gold ?= yes
+			}
+			add = 100
+			desc = TRADE_GOLD_FOR_BETTER_AI_ACCEPTANCE_TT
+		}
+		modifier = {
+			trigger = {
+				scope:herd ?= yes
+			}
+			add = 100
+			desc = TRADE_HERD_FOR_BETTER_AI_ACCEPTANCE_TT
+		}
+		modifier = {
+			add = 5
+			scope:actor = { has_realm_law = nomadic_authority_2 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_DOMINANCE_ACCEPTANCE
+		}
+		modifier = {
+			add = 10
+			scope:actor = { has_realm_law = nomadic_authority_3 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_DOMINANCE_ACCEPTANCE
+		}
+		modifier = {
+			add = 20
+			scope:actor = { has_realm_law = nomadic_authority_4 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_DOMINANCE_ACCEPTANCE
+		}
+		modifier = {
+			add = 100
+			scope:actor = { has_realm_law = nomadic_authority_5 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_DOMINANCE_ACCEPTANCE
+		}
+		modifier = {
+			add = -30
+			scope:actor = { legitimacy_level = 1 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = -20
+			scope:actor = { legitimacy_level = 2 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = 5
+			scope:actor = { legitimacy_level = 3 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = 15
+			scope:actor = { legitimacy_level = 4 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = 30
+			scope:actor = { legitimacy_level = 5 }
+			desc = DEMAND_OBEDIENCE_INTERACTION_LEGITIMACY_ACCEPTANCE
+		}
+		modifier = {
+			add = {
+				value = ai_boldness
+				multiply = -1
+				divide = 2
+			}
+			NOT = { ai_boldness = 0 }
+			desc = ARTIFACT_BOLDNESS_REASON
+		}
+		modifier = {
+			add = {
+				value = ai_greed
+				multiply = -1
+				divide = 2
+			}
+			ai_greed > 0
+			desc = ARTIFACT_GREED_REASON
+		}
+		modifier = {
+			add = {
+				value = ai_honor
+				divide = 4
+			}
+			NOT = { ai_honor = 0 }
+			desc = ARTIFACT_HONOR_REASON
+		}
+		modifier = {
+			add = -20
+			scope:recipient = {
+				has_trait = brave
+			}
+			desc = BLACKMAIL_INTERACTION_BRAVE_ACCEPTANCE
+		}
+		modifier = {
+			add = -50
+			scope:recipient = {
+				has_trait = arrogant
+			}
+			desc = BLACKMAIL_INTERACTION_ARROGANT_ACCEPTANCE
+		}
+		modifier = {
+			add = 25
+			scope:recipient = {
+				has_trait = trusting
+			}
+			desc = BLACKMAIL_INTERACTION_TRUSTING_ACCEPTANCE
+		}
+		modifier = {
+			add = -50
+			scope:recipient = {
+				has_trait = disloyal
+			}
+			desc = DEMAND_OBEDIENCE_INTERACTION_DISLOYAL_ACCEPTANCE
+		}
+		modifier = {
+			add = -500
+			scope:recipient = {
+				exists = domicile
+				domicile.herd >= 100
+				domicile.herd > scope:actor.domicile.herd
+			}
+			desc = DEMAND_OBEDIENCE_INTERACTION_HERD_ACCEPTANCE
+		}
+		modifier = {
+			add = -500
+			scope:recipient = {
+				current_military_strength >= 100
+				current_military_strength > scope:actor.current_military_strength
+			}
+			desc = DEMAND_OBEDIENCE_INTERACTION_MILITARY_MIGHT_ACCEPTANCE
+		}
+		modifier = {
+			add = 10
+			scope:recipient = {
+				has_trait = craven
+			}
+			desc = BLACKMAIL_INTERACTION_CRAVEN_ACCEPTANCE
+		}
+		modifier = {
+			add = 10
+			scope:recipient = {
+				has_trait = content
+			}
+			desc = DEMAND_OBEDIENCE_INTERACTION_CONTENT_ACCEPTANCE
+		}
+		modifier = {
+			add = 25
+			any_character_situation = {
+				any_situation_sub_region = {
+					has_sub_region_phase_parameter = the_great_steppe_easier_obedience
+					any_situation_sub_region_participant_group = {
+						participant_group_type = nomad_rulers_capital
+						participant_group_has_character = scope:actor
+					}
+				}
+			}
+			desc = DEMAND_OBEDIENCE_INTERACTION_ZUD_ACCEPTANCE
+		}
+		bp2_hostage_dread_modifier = yes
+	}
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			scope:herd ?= yes
+			add = -1
+		}
+		modifier = {
+			scope:gold ?= yes
+			add = -1
+		}
+		modifier = {
+			scope:hook ?= yes
+			add = -1
+		}
+		modifier = {
+			scope:recipient = {
+				is_kurultai_trigger = yes
+			}
+			add = 100
+		}
+	}
+	
+	cooldown_against_recipient = { years = 10 }
+	
+	ai_targets = { # They will try to get a Stable Succession
+		ai_recipients = councillors
+	}
+
+	on_accept = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = mpo_demand_obedience_interaction_toast
+				left_icon = scope:recipient
+				# Pay what you need to pay first
+				if = {
+					limit = { scope:hook = yes }
+					use_hook = scope:recipient
+				}
+				if = {
+					limit = { scope:gold = yes }
+					pay_short_term_gold = {
+						target = scope:recipient
+						gold = medium_gold_value
+					}
+				}
+				if = {
+					limit = { scope:herd = yes }
+					if = {
+						limit = { exists = scope:recipient.domicile }
+						pay_herd = {
+							target = scope:recipient
+							value = domicile.medium_herd_value
+						}
+					}
+					else = { # For a nice tooltip
+						show_as_tooltip = {
+							pay_herd = {
+								target = scope:recipient
+								value = domicile.medium_herd_value
+							}
+						}
+						hidden_effect = { domicile = { change_herd = medium_herd_loss } }
+					}
+				}
+				scope:recipient = {
+					add_opinion = {
+						target = scope:actor
+						modifier = obedience_opinion
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/character_interactions/09_mpo_interactions.txt
+++ b/common/character_interactions/09_mpo_interactions.txt
@@ -1588,6 +1588,13 @@
 					}
 				}
 			}
+			#Unop Use the hook on the recipient
+			scope:actor = {
+				if = {
+					limit = { scope:hook = yes }
+					use_hook = scope:recipient
+				}
+			}
 		}
 	}
 
@@ -2415,6 +2422,11 @@ inspire_conversion_interaction = {
 					}
 				}
 			}
+			#Unop Use the hook on the recipient
+			if = {
+				limit = { scope:hook = yes }
+				use_hook = scope:recipient
+			}
 		}
 	}
 
@@ -2979,9 +2991,9 @@ migration_interaction = {
 		}
 		# Relative Herd
 		modifier = {
-			trigger_if = {
+			#trigger_if = { #Unop ck3-tiger
 				exists = scope:recipient.domicile # Herders won't have a domicile
-			}
+			#}
 			add = 25
 			domicile.herd >= scope:recipient.domicile.herd
 			desc = MIGRATION_INTERACTION_HERD_ACCEPTANCE
@@ -2997,9 +3009,9 @@ migration_interaction = {
 		}
 		modifier = {
 			add = 50
-			trigger_if = {
+			#trigger_if = { #Unop ck3-tiger
 				exists = situation:the_great_steppe
-			}
+			#}
 			scope:actor = {
 				this = situation:the_great_steppe.situation_top_herd
 			}
@@ -4665,7 +4677,7 @@ mpo_ask_for_herd_interaction = {
 				is_imprisoned = yes
 				is_at_war = yes
 				is_a_faction_member = yes
-				custom_description = {
+				custom_tooltip = { #Unop ck3-tiger No trigger localization
 					text = ask_for_herd_not_enough_herd
 					domicile.herd < scope:recipient.domicile.ask_for_herd_base_value
 					government_has_flag = government_is_nomadic
@@ -4873,7 +4885,9 @@ mpo_ask_for_herd_interaction = {
 								}
 							}
 							scope:actor = {
-								change_herd = major_herd_gain
+								domicile = { #Unop ck3-tiger Fix scope
+									change_herd = major_herd_gain
+								}
 								add_legitimacy = minor_legitimacy_loss
 							}
 							scope:recipient.primary_title = {
@@ -4921,6 +4935,11 @@ mpo_ask_for_herd_interaction = {
 						}
 					}
 				}
+			}
+			#Unop Use the hook on the recipient
+			if = {
+				limit = { scope:hook = yes }
+				use_hook = scope:recipient
 			}
 		}
 	}
@@ -5145,6 +5164,11 @@ mpo_demand_obedience_interaction = {
 						}
 					}
 				}
+			}
+			#Unop Use the hook on the recipient
+			if = {
+				limit = { scope:hook = yes }
+				use_hook = scope:recipient
 			}
 		}
 	}
@@ -6810,7 +6834,7 @@ mpo_retrieve_land_from_herder_interaction = {
 	popup_on_receive = yes
 	pause_on_receive = yes
 
-	interface_priority = 60
+	#interface_priority = 60 #Unop ck3-tiger Duplicate
 	ai_min_reply_days = 4
 	ai_max_reply_days = 9
 
@@ -6934,6 +6958,13 @@ mpo_retrieve_land_from_herder_interaction = {
 			}
 			scope:actor = { remove_character_flag = flag_hostile_actions_disabled_delay }
 		}
+		#Unop Use the hook on the recipient
+		scope:actor = {
+			if = {
+				limit = { scope:hook = yes }
+				use_hook = scope:recipient
+			}
+		}
 	}
 
 	auto_accept = yes
@@ -7043,6 +7074,11 @@ mpo_vassal_to_tributary_interaction = {
 			}
 		}
 		scope:actor = {
+			#Unop Use the hook on the recipient
+			if = {
+				limit = { scope:hook = yes }
+				use_hook = scope:recipient
+			}
 			trigger_event = mpo_interactions_events.0010
 		}
 	}


### PR DESCRIPTION
6 interactions in `common/character_interactions/09_mpo_interactions.txt` allow a hook to be used, but don't consume it if used. I noticed this for "Demand Herd" in the game, and the rest by looking into the code. This change fixes it.

In addition:
* Fix `ck3-tiger` errors in the newly added file
* Fix conditions in `common/character_interactions/00_tributary_interactions.txt`