### PR TITLE
Fix falconry animal type selection if there is a sighting

### DIFF
--- a/events/activities/hunt_activity/hunt_events.txt
+++ b/events/activities/hunt_activity/hunt_events.txt
@@ -2199,8 +2199,10 @@ hunt.0530 = {
 						value = scope:activity.activity_location.county.var:animal_type
 					}
 				}
-				hidden_effect = {
-					hunt_activity_falconry_game_effect = { PROVINCE = scope:activity.activity_location }
+				else = { #Unop Only select random game if no sighting
+					hidden_effect = {
+						hunt_activity_falconry_game_effect = { PROVINCE = scope:activity.activity_location }
+					}
 				}
 			}
 			hunt_activity_random_subordinate_participant_effect = {


### PR DESCRIPTION
If there is a "sighting" in the province, the hunt event animal type selection logic should pick the sighting animal as the default `animal_type` (suggested as first and obvious choice), and only resort to random game selection if there is no sighting. This is ok for regular hunts, see `hunt.500`.

For falconry, the logic in the event `hunt.0530` misses an else, and so random game is selected even if there is a sighting. As a result, the player doesn't get the increased success chance from the sighting, unless the randomly selected animal happens to be the sighting one.