### PR TITLE
Fix has_winter_trigger

### DIFF
--- a/common/scripted_triggers/00_weather_triggers.txt
+++ b/common/scripted_triggers/00_weather_triggers.txt
@@ -47,8 +47,11 @@ has_winter_trigger = {
 		has_province_modifier = winter_normal_modifier
 		has_province_modifier = winter_harsh_modifier
 		#Unop Use_zud_season_in_county_trigger correctly
-		county = { save_temporary_scope_as = county }
-		has_zud_season_in_county_trigger = { COUNTY = scope:county }
+		AND = {
+			exists = county
+			county = { save_temporary_scope_as = county }
+			has_zud_season_in_county_trigger = { COUNTY = scope:county }
+		}
 	}
 }
 


### PR DESCRIPTION
Fix my previous fix. I noticed quite a number of messages in the error log indicating a scope issue in `location_has_winter_trigger`, and realized that there are events that don't properly check if this is a land location, or check it only after using this trigger. Even worse, the previous logic used `county = { save_temporary_scope_as = county }` inside the OR and that might have always returned true (not sure here?). Now enclosed this in an AND and added a county existence check.