### PR TITLE
Prevent adultery.0001 if you are in an army

### DIFF
--- a/events/relations_events/adultery_events.txt
+++ b/events/relations_events/adultery_events.txt
@@ -72,6 +72,7 @@ adultery.0001 = {
 
 	trigger = {
 		basic_is_valid_for_yearly_events_trigger = yes
+		is_in_army = no #Unop Avoid this event if you are currently in an army
 		NOT = { has_trait = trusting }
 
 		# Is there someone to suspect at all

--- a/events/relations_events/adultery_events.txt
+++ b/events/relations_events/adultery_events.txt
@@ -1,0 +1,3434 @@
+﻿#Events fired by any kind of adultery going on/suspicion about adultery
+
+namespace = adultery
+
+#ADULTERY OVERVIEW
+#Adultery events can be triggered based on a number of different conditions:
+
+#Lover secret (last updated 2018-11-08)
+#When a lover secret is revealed or exposed to a lover or a consort, it triggers the story cycle infidelity_confrontation_story
+#When a lover secret exists, adultery.0001 has increased chance of triggering (via yearly_playable_pulse), which lets character confront their spouse
+
+#Had_sex_with_effect
+
+
+#Bastards
+
+
+#0001		- Spouse suspects spouse/soulmate of having lover (can be true or false)
+#1001-1999 - Suspicious Pregnancy
+#2001-2999 - Suspecting your Child's Parentage
+#3001-3999 - Misc Bastard Child Events
+#4001-		extramarital_sex_exposure_consequences_effect events
+
+
+
+
+
+#############################################
+# Spouse suspects spouse/soulmate of having lover (can be true or false) #
+# Triggered through "yearly_playable_pulse" pulse  #
+#############################################
+
+#By Linnéa Thimrén & Mathilda Bjarnehed
+scripted_trigger adultery_0001_unfaithful_trigger = {
+	save_temporary_scope_as = unfaithful
+	OR = {
+		any_relation = { 
+			type = lover 
+			NOR = {
+				any_consort = { this = scope:unfaithful }
+				has_relation_soulmate = scope:unfaithful
+			}
+		}
+		any_secret = {
+			secret_type = secret_lover
+			secret_target = {
+				NOR = {
+					any_consort = { this = scope:unfaithful }
+					has_relation_soulmate = scope:unfaithful
+				}
+			}
+		}
+		trigger_if = {
+			limit = { exists = var:had_recent_sex_with }
+			var:had_recent_sex_with ?= {
+				NOR = {
+					any_consort = { this = scope:unfaithful }
+					has_relation_soulmate = scope:unfaithful
+				}
+			}
+		}
+	}
+}
+
+scripted_trigger adultery_0001_valid_partner_trigger = {
+	is_physically_able_adult = yes
+	NOT = { has_character_flag = was_recently_suspected_of_adultery } # To avoid event spamming
+}
+
+adultery.0001 = {
+	hidden = yes
+
+	trigger = {
+		basic_is_valid_for_yearly_events_trigger = yes
+		NOT = { has_trait = trusting }
+
+		# Is there someone to suspect at all
+		OR = {
+			any_consort = {
+				adultery_0001_valid_partner_trigger = yes
+			}
+			any_relation = {
+				type = soulmate
+				adultery_0001_valid_partner_trigger = yes
+			}
+		}
+		OR = {
+			has_trait = paranoid
+			any_consort = {
+				adultery_0001_valid_partner_trigger = yes
+				OR = {
+					has_trait = lustful
+					has_trait = seducer
+					adultery_0001_unfaithful_trigger = yes
+				}
+			}
+			any_relation = {
+				type = soulmate
+				adultery_0001_valid_partner_trigger = yes
+				OR = {
+					has_trait = lustful
+					has_trait = seducer
+					adultery_0001_unfaithful_trigger = yes
+				}
+			}
+		}
+		NOT = { faith = { has_doctrine_parameter = no_unfaithfulness_penalty_active } }
+	}
+
+	immediate = {
+		save_scope_as = spouse
+
+		# Add all partners to list
+		every_consort = {
+			limit = { adultery_0001_valid_partner_trigger = yes }
+			add_to_list = partners
+		}
+		every_relation = {
+			type = soulmate
+			limit = { adultery_0001_valid_partner_trigger = yes }
+			add_to_list = partners
+		}
+
+		# Randomize a partner to check, weighted by most likely adulterer
+		random_in_list = {
+			list = partners
+			weight = {
+				base = 1
+				modifier = {
+					OR = {
+						has_trait = seducer
+						has_trait = lustful
+						has_trait = adulterer
+						has_trait = fornicator
+					}
+					add = 2
+				}
+				ai_honor_target_modifier = { VALUE = -2 }
+				modifier = {
+					adultery_0001_unfaithful_trigger = yes
+					add = 5
+				}
+			}
+			save_scope_as = lover_spouse
+		}
+
+		scope:lover_spouse = {
+			add_character_flag = { #To avoid spamming the event
+				flag = was_recently_suspected_of_adultery
+				years = 5
+			}
+
+			#SUSPICION!
+			scope:spouse = {
+				trigger_event = adultery.0002
+			}
+		}
+	}
+}
+
+
+#Suspecting that partner has an affair
+adultery.0002 = {
+	type = character_event
+	title = adultery.0002.t
+	desc = {	
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:lover_spouse = { is_consort_of = root } }
+				desc = adultery.0002.consort_start.desc
+			}
+			desc = adultery.0002.soulmate_start.desc
+		}
+		desc = adultery.0002.desc
+	}
+	theme = marriage
+	override_icon = {
+		trigger = { has_relation_soulmate = scope:lover_spouse }
+		reference = "gfx/interface/icons/event_types/type_love.dds"
+	}
+	override_background = { reference = bedchamber }
+	left_portrait = {
+		character = root
+		animation = worry
+		outfit_tags = { nightgown }
+	}
+	lower_right_portrait = scope:lover_spouse
+
+	trigger = {
+		NOR = {
+			faith = { has_doctrine_parameter = no_unfaithfulness_penalty_active }
+			reverse_has_opinion_modifier = {
+				target = scope:lover_spouse
+				modifier = unfaithful_spouse_exposed_opinion
+			}
+			reverse_has_opinion_modifier = {
+				target = scope:lover_spouse
+				modifier = unfaithful_spouse_discovered_opinion
+			}
+		}
+	}
+
+	option = { #Confront partner!
+		name = adultery.0002.a
+		custom_tooltip = adultery.0002.a.tt
+		scope:lover_spouse = {
+			trigger_event = {
+				id = adultery.0003
+			}
+		}
+		ai_chance = {
+			base = 50
+			ai_value_modifier = {
+				ai_boldness = 0.5
+			}
+		}
+	}
+
+	option = { #High intrigue - look into this yourself
+		name = adultery.0002.b
+		trigger = {
+			intrigue >= decent_skill_rating
+		}
+		skill = intrigue
+		duel = {
+			skill = intrigue
+			target = scope:lover_spouse
+			15 = { # SUCCESS
+				desc = adultery.0002.b.success
+				custom_tooltip = adultery.0002.b.tt
+				compare_modifier = {
+					value = scope:duel_value
+					multiplier = 0.5
+				}
+				hidden_effect = {
+					if = {
+						limit = {
+							scope:lover_spouse = { adultery_0001_unfaithful_trigger = yes }
+						}
+						#If there is a secret, reveal a secret...
+						if = {
+							limit = {
+								scope:lover_spouse = {
+									any_secret = {
+										secret_type = secret_lover
+										any_secret_knower = {
+											NOT = { this = root }
+										}
+									}
+								}
+							}
+							scope:lover_spouse = {
+								random_secret = {
+									limit = {
+										secret_type = secret_lover
+										any_secret_knower = {
+											NOT = { this = root }
+										}
+									}
+									set_variable = {
+										name = revealed_through_investigation_by_desc
+										value = root
+									}
+									reveal_to = root
+								}
+							}
+						}
+						#If there isn't, reveal that they had sex with someone else
+						else_if = {
+							limit = {
+								scope:lover_spouse = {
+									OR = {
+										has_variable = had_recent_sex
+										has_variable = had_recent_sex_with
+									}
+								}
+							}
+							trigger_event = adultery.0007
+						}
+					}
+					else = {
+						send_interface_toast = {
+							title = adultery.0002.b.success.innocent
+							left_icon = scope:lover_spouse
+						}
+					}
+				}
+			}
+			10 = { # FAILURE
+				desc = adultery.0002.b.failure
+				compare_modifier = {
+					value = scope:duel_value
+					multiplier = -0.5
+				}
+				send_interface_toast = {
+					title = adultery.0002.b.failure
+					left_icon = scope:lover_spouse
+					add_stress = medium_stress_gain
+				}
+			}
+		}
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	option = { #Spy on partner
+		name = adultery.0002.c
+		trigger = {
+			exists = cp:councillor_spymaster
+			cp:councillor_spymaster = {
+				trigger_if = {
+					limit = {
+						is_performing_council_task = task_find_secrets
+					}
+					trigger_if = {
+						limit = {
+							scope:lover_spouse = { is_landed = yes }
+						}
+						councillor_task_target = scope:lover_spouse
+					}
+					trigger_else = {
+						exists = scope:lover_spouse.liege
+						councillor_task_target = scope:lover_spouse.liege
+					}
+				}
+				trigger_else = {
+					trigger_if = {
+						limit = {
+							scope:lover_spouse = { is_landed = yes }
+						}
+						is_council_task_valid = {
+							task_type = task_find_secrets
+							target = scope:lover_spouse
+						}
+					}
+					trigger_else = {
+						exists = scope:lover_spouse.liege
+						is_council_task_valid = {
+							task_type = task_find_secrets
+							target = scope:lover_spouse.liege
+						}
+					}
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				scope:lover_spouse = { is_landed = yes }
+				NOT = {
+					cp:councillor_spymaster = {
+						is_performing_council_task = task_find_secrets
+						councillor_task_target = scope:lover_spouse
+					}
+				}
+				cp:councillor_spymaster = {
+					is_council_task_valid = {
+						task_type = task_find_secrets
+						target = scope:lover_spouse
+					}
+				}
+			}
+			cp:councillor_spymaster = {
+				set_council_task = {
+					task_type = task_find_secrets
+					target = scope:lover_spouse
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				exists = scope:lover_spouse.liege
+				NOR = {
+					scope:lover_spouse = { is_landed = yes }
+					cp:councillor_spymaster = {
+						is_performing_council_task = task_find_secrets
+						councillor_task_target = scope:lover_spouse.liege
+					}
+				}
+				cp:councillor_spymaster = {
+					is_council_task_valid = {
+						task_type = task_find_secrets
+						target = scope:lover_spouse.liege
+					}
+				}
+			}
+			cp:councillor_spymaster = {
+				set_council_task = {
+					task_type = task_find_secrets
+					target = scope:lover_spouse.liege
+				}
+			}
+		}
+		else = {
+			custom_tooltip = adultery.0002.c.tt
+		}
+
+
+		ai_chance = {
+			base = 50
+		}
+	}
+	
+	option = { #Do nothing
+		name = {
+			text = {
+				first_valid = {
+					triggered_desc = {
+						trigger = { is_spouse_of = scope:lover_spouse }
+						desc = adultery.0002.d
+					}
+					desc = adultery.0002.d.concubine_or_soulmate
+				}
+			}
+		}
+		stress_impact = {
+			paranoid = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 50
+			ai_value_modifier = {
+				ai_compassion = 0.25
+			}
+			modifier = {
+				has_trait = paranoid
+				add = -50
+			}
+			opinion_modifier = {
+				opinion_target = scope:lover_spouse
+			}
+		}
+	}
+}
+
+
+#My partner is confronting me about having a lover!
+adultery.0003 = {
+	type = character_event
+	title = adultery.0003.t
+	desc = adultery.0003.desc
+	theme = marriage
+	override_icon = {
+		trigger = { has_relation_soulmate = scope:lover_spouse }
+		reference = "gfx/interface/icons/event_types/type_love.dds"
+	}
+	left_portrait = {
+		character = root
+		animation = war_over_win
+	}
+	right_portrait = {
+		character = scope:spouse
+		animation = worry
+	}
+	override_background = { reference = bedchamber }
+
+	immediate = {
+		scope:spouse = {
+			if = {
+				limit = { root = { is_ai = no }	}
+				assign_quirk_effect = yes
+			}
+		}
+		hidden_effect = {
+			random_secret = {
+				limit = {
+					secret_type = secret_lover
+					NOR = {
+						secret_target = scope:spouse
+						is_known_by = scope:spouse
+					}
+				}
+				save_scope_as = secret_to_reveal
+				secret_target = {
+					save_scope_as = adultery_lover
+				}
+			}
+			if = {
+				limit = {
+					NOT = { exists = scope:secret_to_reveal }
+					has_variable = had_recent_sex_with
+				}
+				var:had_recent_sex_with = {
+					save_scope_as = adultery_lover
+				}
+			}
+		}
+	}
+
+	option = { #Deny
+		name = adultery.0003.a
+		flavor = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						adultery_0001_unfaithful_trigger = yes
+					}
+					desc = adultery.0003.a.tt_lie
+				}
+				desc = adultery.0003.a.tt_truth
+			}
+		}
+		scope:spouse = { #Response for spouse
+			random = {
+				chance = 25
+				modifier = {
+					add = 25
+					has_trait = paranoid
+				}
+				add_opinion = {
+					target = scope:lover_spouse
+					modifier = suspicion_opinion
+					opinion = -10
+				}
+			}
+			trigger_event = {
+				id = adultery.0004
+				days = { 2 4 }
+			}
+		}
+		ai_chance = {
+			base = 75
+			ai_value_modifier = {
+				ai_vengefulness = 0.25
+			}
+			modifier = {
+				add = 50
+				has_trait = deceitful
+			}
+		}
+	}
+
+	option = { #Confess
+		name = adultery.0003.b
+		trigger = {
+			adultery_0001_unfaithful_trigger = yes
+			# Extra block just in case one's soulmate is married to another and you're the one they slept with
+			exists = scope:adultery_lover  
+			scope:adultery_lover = { NOT = { this = scope:spouse } }
+		}
+
+		if = {
+			limit = { exists = scope:secret_to_reveal }
+			show_as_tooltip = {
+				scope:secret_to_reveal = {
+					reveal_to = scope:spouse
+				}
+			}
+			scope:spouse = {
+				trigger_event = {
+					id = adultery.0005 #Reveals lover secret
+					days = { 2 4 }
+				}
+			}
+		}
+		else = {
+			if = {
+				limit = {
+					has_relation_soulmate = scope:spouse
+					soulmate_relation_is_exclusive_trigger = yes
+				}
+				reverse_add_opinion = {
+					target = scope:spouse
+					modifier = betrayed_our_promise
+				}
+			}
+
+			scope:spouse = {
+				trigger_event = {
+					id = adultery.0006 #Reveals that they slept with someone
+					days = { 2 4 }
+				}
+			}
+		}
+		
+
+		flavor = adultery.0003.b.tt
+
+		ai_chance = {
+			base = 10
+			ai_value_modifier = {
+				min = -10
+				ai_honor = 0.75
+			}
+			modifier = {
+				add = 50
+				has_trait = honest
+			}
+			opinion_modifier = {
+				min = -10
+				opinion_target = scope:spouse
+			}
+		}
+	}
+}
+
+
+#My spouse denied that they have a lover
+adultery.0004 = {
+	type = character_event
+	title = adultery.0002.t
+	desc = adultery.0004.desc
+	theme = marriage
+	override_icon = {
+		trigger = { has_relation_soulmate = scope:lover_spouse }
+		reference = "gfx/interface/icons/event_types/type_love.dds"
+	}
+	left_portrait = {
+		character = root
+		animation = war_over_win
+	}
+	right_portrait = {
+		character = scope:lover_spouse
+		animation = disapproval
+	}
+	override_background = { reference = bedchamber }
+
+	immediate = {
+		scope:lover_spouse = {
+			add_opinion = {
+				target = scope:spouse
+				modifier = insult_opinion
+				opinion = -10
+			}
+		}
+	}
+
+	option = { #I'll let it be.
+		name = adultery.0004.b
+		flavor = {
+			triggered_desc = {
+				trigger = {
+					has_personality_malicious_trigger = yes
+				}
+				desc = adultery.0004.b.malicious
+			}
+		}
+	}
+}
+
+#Confession of lover
+adultery.0005 = { #by Mathilda Bjarnehed
+	type = character_event
+	hidden = yes
+	
+	#All reveals of lover secrets are handled by the infidelity_confrontation_story. It will have special desc when triggered from here.
+	immediate = {
+		scope:secret_to_reveal = {
+			set_variable = {
+				name = revealed_through_confession_to_desc #To get special texts in infidelity_confrontation.1000
+				value = root
+			}
+			reveal_to = root
+		}
+	}
+}
+
+scripted_trigger adultery_0006_apologetic_trigger = {
+	scope:lover_spouse = {
+		OR = {
+			ai_compassion >= medium_positive_ai_value
+			opinion = {
+				target = root
+				value >= low_positive_opinion
+			}
+		}
+	}
+}
+
+#My partner confessed that they slept with someone else (not lover)
+adultery.0006 = { #by Mathilda Bjarnehed
+	type = character_event
+	title = adultery.0002.t
+	desc = {	
+		first_valid = {
+			#Apologetic
+			triggered_desc = {
+				trigger = {
+					adultery_0006_apologetic_trigger = yes
+				}
+				desc = {
+					desc = adultery.0006.apologetic_start.desc
+					first_valid = {
+						triggered_desc = {
+							trigger = {
+								exists = scope:sex_partner
+								scope:lover_spouse = { is_close_or_extended_family_of = scope:sex_partner }
+							}
+							desc = adultery.0006.my_lovername.desc
+						}
+						triggered_desc = {
+							trigger = {
+								exists = scope:sex_partner
+							}
+							desc = adultery.0006.your_lovername.desc
+						}
+						triggered_desc = {
+							trigger = { scope:lover_spouse = { var:had_recent_sex = flag:male } }
+							desc = adultery.0006.male_lover.desc
+						}
+						triggered_desc = {
+							trigger = { scope:lover_spouse = { var:had_recent_sex = flag:female } }
+							desc = adultery.0006.female_lover.desc
+						}
+					}
+					desc = adultery.0006.apologetic_end.desc
+				}
+			}
+			#Unapologetic
+			desc = {
+				desc = adultery.0006.unapologetic_start.desc
+				first_valid = {
+					triggered_desc = {
+						trigger = {
+							exists = scope:sex_partner
+							scope:lover_spouse = { is_close_or_extended_family_of = scope:sex_partner }
+						}
+						desc = adultery.0006.my_lovername.desc
+					}
+					triggered_desc = {
+						trigger = {
+							exists = scope:sex_partner
+						}
+						desc = adultery.0006.your_lovername.desc
+					}
+					triggered_desc = {
+						trigger = { scope:lover_spouse = { var:had_recent_sex = flag:male } }
+						desc = adultery.0006.male_lover.desc
+					}
+					triggered_desc = {
+						trigger = { scope:lover_spouse = { var:had_recent_sex = flag:female } }
+						desc = adultery.0006.female_lover.desc
+					}
+				}
+				desc = adultery.0006.unapologetic_end.desc
+			}
+		}
+	}
+	theme = marriage
+	override_icon = {
+		trigger = { has_relation_soulmate = scope:lover_spouse }
+		reference = "gfx/interface/icons/event_types/type_love.dds"
+	}
+	left_portrait = {
+		character = root
+		animation = disbelief
+	}
+	right_portrait = {
+		character = scope:lover_spouse
+		triggered_animation = {
+			trigger = {
+				adultery_0006_apologetic_trigger = no
+			}
+			animation = schadenfreude
+		}
+		triggered_animation = {
+			trigger = { always = yes }
+			animation = idle
+		}
+	}
+	lower_right_portrait = scope:sex_partner
+	override_background = { reference = bedchamber }
+
+	immediate = {
+		play_music_cue = mx_cue_death
+		scope:lover_spouse = {
+			if = {
+				limit = { has_variable = had_recent_sex_with }
+				var:had_recent_sex_with = {
+					save_scope_as = sex_partner
+				}
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:sex_partner
+			}
+			hidden_effect = {
+				mother_of_young_child_has_lover_variable_effect = {
+					SPOUSE = root
+					LOVER_1 = scope:lover_spouse
+					LOVER_2 = scope:sex_partner
+				}
+			}
+		}
+	}
+	
+	#Reveal it to everyone & break up if soulmate
+	option = {
+		name = adultery.0006.a
+		
+		if = {
+			limit = { has_relation_soulmate = scope:lover_spouse }
+			show_as_tooltip = { remove_relation_soulmate = scope:lover_spouse }
+		}
+
+		scope:lover_spouse = {
+			if = {
+				limit = { has_variable = had_recent_sex_with }
+				show_as_tooltip = { extramarital_sex_exposure_consequences_with_target_effect = { TARGET = scope:sex_partner SPOUSE_EVENT = no } }
+			}
+			else = {
+				show_as_tooltip = { extramaritial_sex_exposure_consequences_with_had_recent_sex_var_effect = { SPOUSE_EVENT = no } }
+			}	
+			trigger_event = adultery.0008 #Runs extramaritial effects here
+		}
+
+		#Lover tooltip (if relevant ) + event
+		if = {
+			limit = { exists = scope:sex_partner }
+			scope:sex_partner = {
+				if = {
+					limit = { is_of_major_or_minor_interest_trigger = { CHARACTER = root } }
+					show_as_tooltip = { extramarital_sex_exposure_consequences_with_target_effect = { TARGET = scope:lover_spouse SPOUSE_EVENT = no } }
+				}
+				trigger_event = adultery.0008 #Runs extramaritial effects here
+			}
+		}
+
+
+		reverse_add_opinion = {
+			target = scope:lover_spouse
+			modifier = angry_opinion
+			opinion = -15
+		}
+
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_vengefulness = 3
+				ai_compassion = -1
+				ai_boldness = 1
+			}
+			modifier = {
+				any_secret = {
+					secret_type = secret_lover
+					secret_target = scope:lover_spouse
+				}
+				add = -75 # Dangerous to make a spectacle, if we're secret soulmates
+			}
+		}
+	}
+
+	#Break up if soulmate
+	option = {
+		trigger = { has_relation_soulmate = scope:lover_spouse }
+		name = adultery.0006.c
+
+		if = {
+			limit = { has_relation_soulmate = scope:lover_spouse }
+			show_as_tooltip = { remove_relation_soulmate = scope:lover_spouse }
+		}
+
+		scope:lover_spouse = {
+			trigger_event = adultery.0009
+		}
+
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_compassion = 1
+				ai_vengefulness = 1
+			}
+		}
+	}
+
+	#Let it go
+	option = {
+		name = adultery.0006.b
+
+		if = {
+			limit = {
+				scope:lover_spouse = { is_ai = yes }
+				can_add_hook = {
+					target = scope:lover_spouse
+					type = favor_hook
+				}
+			}
+			add_hook = {
+				target = scope:lover_spouse
+				type = favor_hook
+			}
+		}
+
+		reverse_add_opinion = {
+			target = scope:lover_spouse
+			modifier = grateful_opinion
+			opinion = 30
+		}
+
+		ai_chance = {
+			base = -1000
+
+			opinion_modifier = {
+				opinion_target = scope:lover_spouse
+			}
+			ai_value_modifier = {
+				ai_compassion = 1
+				ai_vengefulness = -1
+			}
+		}
+	}
+
+
+	after = {
+		scope:lover_spouse = {
+			if = {
+				limit = {
+					has_variable = had_recent_sex_with
+				}
+				if = {
+					limit = {
+						var:had_recent_sex_with = { is_alive = yes }
+					}
+					var:had_recent_sex_with = { remove_variable = had_recent_sex_with }
+				}
+				remove_variable = had_recent_sex_with
+			}
+			else = {
+				remove_variable = had_recent_sex
+			}
+		}
+	}
+}
+
+
+#I discovered that my partner slept with someone else (not lover, but a one time thing: a character or an unknown person)
+adultery.0007 = { #by Mathilda Bjarnehed
+	type = character_event
+	title = adultery.0002.t
+	desc = {	
+		desc = adultery.0007.start.desc
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					exists = scope:sex_partner
+					scope:sex_partner = { has_RelationToMe_relation = { CHARACTER = scope:lover_spouse } }
+				}
+				desc = adultery.0007.lover_herhis.desc
+			}
+			triggered_desc = {
+				trigger = {
+					exists = scope:sex_partner
+				}
+				desc = adultery.0007.lover_my.desc
+			}
+			triggered_desc = {
+				trigger = { scope:lover_spouse = { var:had_recent_sex = flag:male } }
+				desc = adultery.0007.male_lover.desc
+			}
+			triggered_desc = {
+				trigger = { scope:lover_spouse = { var:had_recent_sex = flag:female } }
+				desc = adultery.0007.female_lover.desc
+			}
+		}
+		desc = adultery.0007.end.desc
+	}
+	theme = marriage
+	override_icon = {
+		trigger = { has_relation_soulmate = scope:lover_spouse }
+		reference = "gfx/interface/icons/event_types/type_love.dds"
+	}
+	left_portrait = {
+		character = root
+		animation = disbelief
+	}
+	right_portrait = {
+		character = scope:lover_spouse
+		triggered_animation = {
+			trigger = {
+				adultery_0006_apologetic_trigger = no
+			}
+			animation = schadenfreude
+		}
+		triggered_animation = {
+			trigger = { always = yes }
+			animation = idle
+		}
+	}
+	lower_right_portrait = scope:sex_partner
+	override_Background = { reference = bedchamber }
+
+	immediate = {
+		play_music_cue = mx_cue_death
+		scope:lover_spouse = {
+			if = {
+				limit = { has_variable = had_recent_sex_with }
+				var:had_recent_sex_with = { save_scope_as = sex_partner }
+			}
+		}
+		if = {
+			limit = { exists = scope:sex_partner }
+			hidden_effect = {
+				mother_of_young_child_has_lover_variable_effect = {
+					SPOUSE = root
+					LOVER_1 = scope:lover_spouse
+					LOVER_2 = scope:sex_partner
+				}
+			}
+		}
+		hidden_effect = {
+			if = {
+				limit = {
+					has_relation_soulmate = scope:lover_spouse
+					soulmate_relation_is_exclusive_trigger = yes
+				}
+				add_opinion = {
+					target = scope:lover_spouse
+					modifier = betrayed_our_promise
+				}
+			}
+		}
+	}
+	
+	#Reveal it to everyone & break up if soulmates
+	option = {
+		name = adultery.0006.a
+	
+		if = {
+			limit = { has_relation_soulmate = scope:lover_spouse }
+			show_as_tooltip = { remove_relation_soulmate = scope:lover_spouse }
+		}
+
+		#Spouse effect tooltips + event
+		scope:lover_spouse = {
+			if = {
+				limit = { has_variable = had_recent_sex_with }
+				show_as_tooltip = { extramarital_sex_exposure_consequences_with_target_effect = { TARGET = scope:sex_partner SPOUSE_EVENT = no } }
+			}
+			else = {
+				show_as_tooltip = { extramaritial_sex_exposure_consequences_with_had_recent_sex_var_effect = { SPOUSE_EVENT = no } }
+			}	
+			trigger_event = adultery.0008 #Runs extramaritial effects here
+		}
+
+		#Lover tooltip (if relevant ) + event
+		if = {
+			limit = { exists = scope:sex_partner }
+			scope:sex_partner = {
+				if = {
+					limit = { is_of_major_or_minor_interest_trigger = { CHARACTER = root } }
+					show_as_tooltip = { extramarital_sex_exposure_consequences_with_target_effect = { TARGET = scope:lover_spouse SPOUSE_EVENT = no } }
+				}
+				trigger_event = adultery.0008 #Runs extramaritial effects here
+			}
+		}
+
+
+		reverse_add_opinion = {
+			target = scope:lover_spouse
+			modifier = angry_opinion
+			opinion = -15
+		}
+
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_vengefulness = 3
+				ai_compassion = -1
+				ai_boldness = 1
+			}
+			modifier = {
+				any_secret = {
+					secret_type = secret_lover
+					secret_target = scope:lover_spouse
+				}
+				add = -75 # Dangerous to make a spectacle, if we're secret soulmates
+			}
+		}
+	}
+
+	#Break up if soulmate
+	option = {
+		trigger = { has_relation_soulmate = scope:lover_spouse }
+		name = adultery.0006.c
+
+		if = {
+			limit = { has_relation_soulmate = scope:lover_spouse }
+			show_as_tooltip = { remove_relation_soulmate = scope:lover_spouse }
+		}
+
+		scope:lover_spouse = {
+			trigger_event = adultery.0009
+		}
+
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_compassion = 1
+				ai_vengefulness = 1
+			}
+		}
+	}
+
+	#Let it go
+	option = {
+		name = adultery.0006.b
+
+		if = {
+			limit = {
+				scope:lover_spouse = { is_ai = yes }
+				can_add_hook = {
+					target = scope:lover_spouse
+					type = favor_hook
+				}
+			}
+			add_hook = {
+				target = scope:lover_spouse
+				type = favor_hook
+			}
+		}
+
+		reverse_add_opinion = {
+			target = scope:lover_spouse
+			modifier = grateful_opinion
+			opinion = 30
+		}
+
+		ai_chance = {
+			base = 0
+
+			opinion_modifier = {
+				opinion_target = scope:lover_spouse
+			}
+			ai_value_modifier = {
+				ai_compassion = 1
+				ai_vengefulness = -1
+			}
+		}
+	}
+
+	after = {
+		scope:lover_spouse = {
+			if = {
+				limit = { has_variable = had_recent_sex_with }
+				if = {
+					limit = { var:had_recent_sex_with = { is_alive = yes } }
+					var:had_recent_sex_with = { remove_variable = had_recent_sex_with }
+				}
+				remove_variable = had_recent_sex_with
+			}
+			else = {
+				remove_variable = had_recent_sex
+			}
+		}
+	}
+}
+
+#I had sex with someone (once, not lovers) and my/their partner revealed it to everyone
+adultery.0008 = { #by Mathilda Bjarnehed
+	type = character_event
+	title = adultery.0008.t
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { exists = scope:sex_partner }
+				desc = adultery.0008.sex_partner.desc
+			}
+			desc = adultery.0008.no_sex_partner.desc
+		}
+	}
+	theme = marriage
+	override_icon = {
+		trigger = { has_relation_soulmate = scope:lover_spouse }
+		reference = "gfx/interface/icons/event_types/type_love.dds"
+	}
+	left_portrait = {
+		character = root
+		animation = stress
+	}
+	right_portrait = {
+		character = scope:spouse
+		animation = anger
+	}
+	lower_right_portrait = scope:sex_partner
+	override_background = { reference = bedchamber }
+	
+	immediate = {
+		play_music_cue = mx_cue_death
+		#There is a character partner
+		if = {
+			limit = { exists = scope:sex_partner }
+			#I am the sex partner..
+			if = {
+				limit = {
+					scope:sex_partner = root
+				}
+				scope:lover_spouse = { save_scope_as = sex_partner } #save the lover_spouse instead for portraits + text
+
+				#Add effects and tell my partner (because they're not the revealer)
+				extramarital_sex_exposure_consequences_with_target_effect = { TARGET = scope:sex_partner SPOUSE_EVENT = yes }
+			}
+			#I am not the sex partner, so run the effect silently (my spouse already knows)
+			else = {
+				extramarital_sex_exposure_consequences_with_target_effect = { TARGET = scope:sex_partner SPOUSE_EVENT = no }
+			}
+		}
+		#I had sex with an unknown character, just run that effect
+		else = {
+			extramaritial_sex_exposure_consequences_with_had_recent_sex_var_effect = { SPOUSE_EVENT = no }
+		}
+	}
+
+	option = {
+		name = adultery.0008.a
+	}
+}
+
+
+# My soulmate broke up with me over dalliance
+adultery.0009 = { #by Mathilda Bjarnehed
+	type = character_event
+	title = adultery.0003.t
+	desc = adultery.0009.desc
+	theme = marriage
+	override_icon = {
+		trigger = { has_relation_soulmate = scope:spouse }
+		reference = "gfx/interface/icons/event_types/type_love.dds"
+	}
+	left_portrait = {
+		character = root
+		animation = stress
+	}
+	right_portrait = {
+		character = scope:spouse
+		animation = grief
+	}
+	lower_right_portrait = scope:sex_partner
+	
+	immediate = {
+		play_music_cue = mx_cue_death
+		remove_relation_soulmate = scope:spouse
+	}
+
+	option = {
+		name = adultery.0009.a
+	}
+}
+
+
+
+
+
+###############################
+# Suspicious Pregnancy Events
+# 1001 - 1999
+# by Petter Vilberg
+###############################
+
+#Father suspects something about the pregnancy
+
+adultery.1001 = {
+	type = character_event
+	title = adultery.1001.t
+	desc = {
+		desc = adultery.1001.opening
+		first_valid = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						OR = {
+							AND = {
+								has_opinion_modifier = {
+									modifier = love_opinion
+									target = scope:mother
+								}
+								opinion = {
+									target = scope:mother
+									value >= 0
+								}
+							}
+							opinion = {
+								target = scope:mother
+								value > 50
+							}
+						}
+					}
+					desc = adultery.1001.hard_to_believe
+				}
+				triggered_desc = {
+					trigger = {
+						OR = {
+							AND = {
+								has_opinion_modifier = {
+									modifier = hate_opinion
+									target = scope:mother
+								}
+								opinion = {
+									target = scope:mother
+									value < 0
+								}
+							}
+							opinion = {
+								target = scope:mother
+								value < -50
+							}
+						}
+					}
+					desc = adultery.1001.easy_to_believe
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = sadistic
+						}
+					}
+					desc = adultery.1001.desc_sadistic
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = lustful
+						}
+					}
+					desc = adultery.1001.desc_lustful
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = deceitful
+						}
+					}
+					desc = adultery.1001.desc_deceitful
+				}
+				triggered_desc = {
+					trigger = {
+						has_trait = trusting
+					}
+					desc = adultery.1001.desc_root_trusting
+				}
+				triggered_desc = {
+					trigger = {
+						has_trait = lunatic
+					}
+					desc = adultery.1001.desc_root_lunatic
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = lunatic
+						}
+					}
+					desc = adultery.1001.desc_lunatic
+				}
+			}
+			desc = adultery.1001.default
+		}
+	}
+	left_portrait = scope:mother
+	theme = pregnancy
+
+	immediate = {
+		save_scope_as = adultery_spouse
+	}
+	
+	option = { #Confront Mother
+		name = adultery.1001.a
+		custom_tooltip = adultery.1001.a.tt
+		hidden_effect = {
+			scope:mother = {
+				trigger_event = {
+					id = adultery.1002
+					days = { 1 3 }
+				}
+			}
+		}
+		stress_impact = {
+			trusting = minor_stress_impact_gain
+			patient = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_boldness = 1
+			}
+		}
+	}
+
+	option = { #Try to figure it out
+		name = adultery.1001.b
+		
+		spy_on_mother_pregnancy_adultery_effect = yes
+
+		stress_impact = {
+			trusting = major_stress_impact_gain
+		}
+
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_rationality = 0.5
+			}
+		}
+	}
+	
+	option = { #Do nothing
+		name = adultery.1001.c
+		custom_tooltip = adultery.1001.c.tt
+		stress_impact = {
+			vengeful = minor_stress_impact_gain
+			impatient = minor_stress_impact_gain
+			cynical = minor_stress_impact_gain
+			paranoid = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 0
+			ai_value_modifier = {
+				ai_energy = -1
+			}
+			opinion_modifier = {
+				opinion_target = scope:mother
+				multiplier = 0.5
+			}
+		}
+	}
+}
+
+
+#Mother: Spouse suspects something about the pregnancy
+scripted_effect adultery_1002_reveal_lover_secret_effect = {
+	scope:mother = {
+		random_secret = {
+			limit = {
+				secret_type = secret_lover
+				secret_target = scope:real_father
+				NOT = { is_known_by = scope:adultery_spouse }
+			}
+			reveal_to = scope:adultery_spouse
+		}
+	}
+}
+
+adultery.1002 = {
+	type = character_event
+	title = adultery.1002.t
+	desc = {
+		first_valid = {
+			random_valid = {
+				triggered_desc = {
+					trigger = {
+						scope:adultery_spouse = {
+							has_trait = paranoid
+						}
+					}
+					desc = adultery.1002.desc_paranoid
+				}
+				triggered_desc = {
+					trigger = {
+						scope:adultery_spouse = {
+							OR = {
+								has_trait = chaste
+								has_trait = zealous
+							}
+						}
+					}
+					desc = adultery.1002.desc_chaste
+				}
+				triggered_desc = {
+					trigger = {
+						scope:adultery_spouse = {
+							OR = {
+								has_trait = craven
+								has_trait = shy
+							}
+						}
+					}
+					desc = adultery.1002.desc_craven
+				}
+				triggered_desc = {
+					trigger = {
+						scope:adultery_spouse = {
+							OR = {
+								has_trait = vengeful
+								has_trait = wrathful
+							}
+						}
+					}
+					desc = adultery.1002.desc_vengeful
+				}
+				triggered_desc = {
+					trigger = {
+						scope:adultery_spouse = {
+							has_trait = sadistic
+						}
+					}
+					desc = adultery.1002.desc_sadistic
+				}
+				triggered_desc = {
+					trigger = {
+						scope:adultery_spouse = {
+							has_trait = lunatic
+						}
+					}
+					desc = adultery.1002.desc_lunatic
+				}
+				triggered_desc = {
+					trigger = {
+						scope:adultery_spouse = {
+							OR = {
+								has_trait = compassionate
+								AND = {
+									NOR = {
+										has_trait = callous
+										has_trait = sadistic
+									}
+									has_opinion_modifier = {
+										modifier = love_opinion
+										target = root
+									}
+									opinion = {
+										target = root
+										value > 0
+									}
+								}
+							}
+						}
+					}
+					desc = adultery.1002.desc_compassionate
+				}
+			}
+			desc = adultery.1002.worried
+		}
+		desc = adultery.1002.conclusion
+	}
+	theme = pregnancy
+	
+	left_portrait = {
+		character = scope:adultery_spouse
+		triggered_animation = {
+			trigger = {
+				scope:adultery_spouse = {
+					OR = {
+						has_trait = paranoid
+						has_trait = lunatic
+					}
+				}
+			}
+			animation = paranoia
+		}
+		triggered_animation = {
+			trigger = {
+				scope:adultery_spouse = {
+					OR = {
+						has_trait = craven
+						has_trait = shy
+					}
+				}
+			}
+			animation = fear
+		}
+		triggered_animation = {
+			trigger = {
+				scope:adultery_spouse = {
+					OR = {
+						has_trait = vengeful
+						has_trait = wrathful
+					}
+				}
+			}
+			animation = anger
+		}
+		triggered_animation = {
+			trigger = {
+				scope:adultery_spouse = {
+					has_trait = sadistic
+				}
+			}
+			animation = schadenfreude
+		}
+		triggered_animation = {
+			trigger = { always = yes }
+			animation = personality_cynical
+		}
+	}
+
+	trigger = {
+		scope:mother = {
+			has_trait = pregnant
+			NOT = { has_character_flag = pregnancy_real_father_of_bastard_is_known_flag }
+		}
+	}
+
+	immediate = {
+		get_quirk_character_effect = yes
+		pregnancy_real_father = {
+			save_scope_as = real_father
+		}
+	}
+	
+	option = { #Confess
+		name = adultery.1002.a
+		trigger = {
+			has_character_flag = bastard_pregnancy
+			is_pregnant = yes
+			NOT = { pregnancy_real_father = scope:adultery_spouse }
+		}
+		custom_tooltip = adultery.1002.a.confession_tt
+
+		show_as_tooltip = {
+			adultery_1002_reveal_lover_secret_effect = yes
+		}
+		scope:adultery_spouse = {
+			debug_log = "adultery.1002 firing adultery.1004"
+			trigger_event = {
+				id = adultery.1004
+				days = { 1 3 }
+			}
+		}
+		stress_impact = {
+			eccentric = minor_stress_impact_loss
+			deceitful = major_stress_impact_gain
+			shy = minor_stress_impact_gain
+			stubborn = minor_stress_impact_gain
+			craven = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_honor = 0.5
+				ai_rationality = -0.5
+				ai_compassion = -0.25
+				ai_boldness = 0.5
+			}
+		}
+	}
+
+	option = { #Insist on innocence
+		name = adultery.1002.b
+		trigger = {
+			has_character_flag = bastard_pregnancy
+		}
+		custom_tooltip = adultery.1002.b.tt
+		scope:adultery_spouse = {
+			trigger_event = {
+				id = adultery.1003
+				days = { 1 3 }
+			}
+		}
+		stress_impact = {
+			honest = major_stress_impact_gain
+			trusting = minor_stress_impact_gain
+			eccentric = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	option = { #Insist on innocence
+		name = adultery.1002.c
+		trigger = {
+			NOT = {
+				has_character_flag = bastard_pregnancy
+			}
+		}
+		custom_tooltip = adultery.1002.c.tt
+		scope:adultery_spouse = {
+			trigger_event = {
+				id = adultery.1003
+				days = { 1 3 }
+			}
+		}
+	}
+}
+
+
+#Spouse: Mother insists the child is yours
+adultery.1003 = {
+	type = character_event
+	title = adultery.1002.t
+	desc = adultery.1003.desc
+	left_portrait = scope:mother
+	theme = pregnancy
+	
+	trigger = {
+		scope:mother = {
+			has_trait = pregnant
+			is_pregnant = yes # In case this fires at the same time as the pregnancy ends, before backup trait removal
+			NOT = { has_character_flag = pregnancy_real_father_of_bastard_is_known_flag }
+		}
+	}
+
+	immediate = {
+		if = {
+			limit = { is_ai = no }
+			scope:mother = {
+				assign_quirk_effect = yes
+			}
+		}
+	}
+
+	option = { #I only needed to hear you say it
+		name = adultery.1003.a
+		custom_tooltip = adultery.1003.a.tt
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_compassion = 0.5
+			}
+			opinion_modifier = {
+				opinion_target = scope:mother
+				multiplier = 0.5
+			}
+		}
+	}
+
+	option = { #Hm, I don't believe it
+		name = adultery.1003.b
+		spy_on_mother_pregnancy_adultery_effect = yes
+
+		stress_impact = {
+			trusting = major_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 200
+				has_trait = paranoid
+			}
+			modifier = {
+				add = -100
+				has_trait = trusting
+			}
+			ai_value_modifier = {
+				ai_energy = 0.5
+				ai_vengefulness = 0.25
+			}
+		}
+	}
+}
+
+
+#Spouse: Mother confesses to a bastard pregnancy
+
+adultery.1004 = {
+	type = character_event
+	title = adultery.1002.t
+	desc = {
+		first_valid = {
+			random_valid = {
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = callous
+						}
+					}
+					desc = adultery.1004.reaction_callous
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = sadistic
+						}
+					}
+					desc = adultery.1004.reaction_sadistic
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = gluttonous
+						}
+					}
+					desc = adultery.1004.reaction_gluttonous
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = deceitful
+						}
+					}
+					desc = adultery.1004.reaction_deceitful
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = compassionate
+						}
+					}
+					desc = adultery.1004.reaction_compassionate
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = honest
+						}
+					}
+					desc = adultery.1004.reaction_honest
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							has_trait = lunatic
+						}
+					}
+					desc = adultery.1004.reaction_lunatic
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							opinion = {
+								target = root
+								value > 60
+							}
+						}
+					}
+					desc = adultery.1004.reaction_positive_opinion
+				}
+				triggered_desc = {
+					trigger = {
+						scope:mother = {
+							opinion = {
+								target = root
+								value < -30
+							}
+						}
+					}
+					desc = adultery.1004.reaction_negative_opinion
+				}
+			}
+			desc = adultery.1004.default_reaction
+		}
+		desc = adultery.1004.default_admission
+	}
+	left_portrait = {
+		character = scope:mother
+		triggered_animation = {
+			trigger = {
+				scope:mother = {
+					OR = {
+						has_trait = callous
+						scope:mother = {
+							opinion = {
+								target = root
+								value < -30
+							}
+						}
+					}
+				}
+			}
+			animation = idle
+		}
+		triggered_animation = {
+			trigger = {
+				scope:mother = {
+					has_trait = sadistic
+				}
+			}
+			animation = schadenfreude
+		}
+		triggered_animation = {
+			trigger = { always = yes }
+			animation = sadness
+		}
+	}
+	right_portrait = scope:real_father
+	theme = bastardy
+
+	trigger = {
+		is_consort_of = scope:mother
+		scope:mother = {
+			is_pregnant = yes
+			OR = {
+				has_character_flag = unmarried_bastard_pregnancy
+				has_character_flag = bastard_pregnancy
+			}
+			NOT = { pregnancy_real_father = root }
+			NOT = { has_character_flag = pregnancy_real_father_of_bastard_is_known_flag }
+		}
+	}
+	
+	immediate = {
+		play_music_cue = mx_cue_death
+		scope:mother = {
+			pregnancy_real_father = {
+				save_scope_as = real_father
+			}
+			add_character_flag = pregnancy_spouse_knows_of_bastardy
+		}
+
+		adultery_1002_reveal_lover_secret_effect = yes
+	}
+
+	option = { #Leave it be
+		name = adultery.1004.a
+		trigger = {
+			scope:mother = {
+				NOT = {
+					has_character_flag = pregnancy_spouse_knows_of_bastardy
+				}
+			}
+		}
+		flavor = adultery.1004.a.tt
+
+		scope:mother = {
+			add_character_flag = pregnancy_spouse_knows_of_bastardy
+			trigger_event = {
+				id = adultery.1006
+				days = { 1 5 }
+			}
+		}
+		stress_impact = {
+			vengeful = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_rationality = 0.5
+				ai_compassion = 0.25
+			}
+			opinion_modifier = {
+				opinion_target = scope:mother
+				multiplier = 0.5
+			}
+		}
+	}
+
+	option = { #Leave it be
+		name = adultery.1004.b
+		trigger = {
+			scope:mother = {
+				has_character_flag = pregnancy_spouse_knows_of_bastardy
+			}
+		}
+		scope:mother = {
+			trigger_event = {
+				id = adultery.1006
+				days = { 1 5 }
+			}
+		}
+		flavor = adultery.1004.a.tt
+		stress_impact = {
+			vengeful = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_rationality = 0.5
+				ai_compassion = 0.25
+			}
+			opinion_modifier = {
+				opinion_target = scope:mother
+				multiplier = 0.5
+			}
+		}
+	}
+
+	option = { #The world will know!
+		name = adultery.1004.c
+		bastardy_pregnancy_announcement_effect = yes
+		if = {
+			limit = { scope:real_father = root }
+			debug_log = "scope:real_father was also root in adultery.1004! Why??"
+		}
+		scope:mother = {
+			if = {
+				limit = {
+					exists = scope:real_father
+					NOT = { scope:real_father = pregnancy_assumed_father }
+				}
+			}
+			expose_lover_secret_or_run_consequence_effect = {
+				TARGET = scope:real_father
+				EXPOSER = root
+			}
+		}
+		stress_impact = {
+			content = medium_stress_impact_gain
+			forgiving = medium_stress_impact_gain
+			compassionate = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_vengefulness = 1
+				ai_boldness = 0.5
+			}
+		}
+	}
+}
+
+
+
+#Mother: Spouse confronts Mother with the illegitimacy of the pregnancy, but it remains a Secret
+adultery.1006 = {
+	type = character_event
+	title = adultery.1006.t
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					opinion = {
+						target = scope:adultery_spouse
+						value > 50
+					}
+				}
+				desc = adultery.1006.very_positive_opinion
+			}
+			triggered_desc = {
+				trigger = {
+					OR = {
+						opinion = {
+							target = scope:adultery_spouse
+							value < -40
+						}
+						has_trait = sadistic
+					}
+					NOT = {
+						has_trait = compassionate
+					}
+				}
+				desc = adultery.1006.very_negative_opinion
+			}
+			desc = adultery.1006.fallback
+		}
+		desc = adultery.1006.conclusion
+	}
+	theme = pregnancy
+	left_portrait = scope:adultery_spouse
+	right_portrait = scope:real_father
+	
+
+	trigger = {
+		scope:mother = {
+			has_trait = pregnant
+			OR = {
+				has_character_flag = unmarried_bastard_pregnancy
+				has_character_flag = bastard_pregnancy
+			}
+			NOT = { has_character_flag = pregnancy_real_father_of_bastard_is_known_flag }
+		}
+	}
+
+	option = {
+		name = adultery.1006.a
+	}
+}
+
+
+#Spouse has been spying on a mother suspected of carrying a bastard, but found nothing
+adultery.1009 = {
+	type = character_event
+	title = adultery.1009.t
+	desc = adultery.1009.desc
+	left_portrait = scope:mother
+	right_portrait = scope:spymaster
+	theme = pregnancy
+	
+	trigger = {
+		scope:mother = {
+			is_alive = yes
+			NOT = { has_character_flag = pregnancy_real_father_of_bastard_is_known_flag }
+		}
+	}
+
+	immediate = {
+		if = {
+			limit = {
+				exists = cp:councillor_spymaster
+				NOT = { cp:councillor_spymaster = scope:mother }
+			}
+			cp:councillor_spymaster = {
+				save_scope_as = spymaster
+			}
+		}
+	}
+
+	option = {
+		name = adultery.1009.a
+		flavor = {
+			desc = adultery.1009.a.flavor_tt
+		}
+		reverse_add_opinion = {
+			target = scope:mother
+			modifier = spied_on_me_opinion
+		}
+	}
+}
+
+
+
+#Set up either confession or suspicion chance for real_father
+adultery.1101 = {
+	hidden = yes
+
+	trigger = {
+		is_pregnant = yes
+		OR = {
+			has_character_flag = unmarried_bastard_pregnancy
+			has_character_flag = bastard_pregnancy
+		}
+		NOR = {
+			has_character_flag = pregnancy_real_father_of_bastard_is_known_flag
+			has_character_flag = pregnancy_spouse_knows_of_bastardy
+		}
+	}
+
+	immediate = {
+		#If something has gone terribly wrong, apply the Pregnant trait to make sure it's there:
+		if = {
+			limit = {
+				is_pregnant = yes #Double check that the Pregnant trait will never be added to someone who is not pregnant
+				NOT = { has_trait = pregnant }
+			}
+			add_trait = pregnant
+		}
+		if = {
+			limit = { #Mother has decided to tell
+				has_character_flag = planning_to_confess_to_real_father
+			}
+			if = {
+				limit = {
+					any_consort = { count = 0 }
+				}
+				scope:real_father = {
+					if = {
+						limit = {
+							#checking spouse instead of consort as the follow-up event pregnancy 3004 specifically refers to a mariage
+							any_spouse = { count = 0 }
+						}
+						trigger_event = pregnancy.3003
+					}
+					else = {
+						trigger_event = pregnancy.3004
+					}
+				}
+			}
+			else = {
+				scope:real_father = {
+					trigger_event = pregnancy.3002
+				}
+			}
+		}
+		else = {
+			bastard_real_father_suspicion_chance_effect = yes
+		}
+	}
+}
+
+
+
+#####################################
+# Suspecting your Child's Parentage #
+# 2001 - 2999						#
+#####################################
+
+
+#Is the father suspicious of child or not?
+adultery.2001 = {
+	type = character_event
+	title = adultery.2001.t
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					NOT = { exists = scope:adultery_spouse }
+				}
+				desc = adultery.2001.desc_dislike
+			}
+			triggered_desc = {
+				trigger = {
+					exists = scope:adultery_spouse
+					scope:adultery_spouse = {
+						OR = {
+							any_relation = {
+								type = lover
+								count >= 1
+								NOR = {
+									has_secret_relation_lover = scope:adultery_spouse
+									this = root
+								}
+							}
+							any_secret = {
+								secret_type = secret_lover
+								any_secret_knower = { this = root }
+							}
+						}
+					}
+				}
+				desc = adultery.2001.desc_mother_lover
+			}
+			triggered_desc = {
+				trigger = {
+					exists = scope:adultery_spouse
+					OR = {
+						scope:adultery_spouse = {
+							OR = {
+								has_trait = intellect_bad_1
+								has_trait = intellect_bad_2
+								has_trait = intellect_bad_3
+							}
+						}
+						has_trait = intellect_good_1
+						has_trait = intellect_good_2
+						has_trait = intellect_good_3
+						has_trait = paranoid
+					}
+				}
+				desc = adultery.2001.desc_suspicious_mother
+			}
+			desc = adultery.2001.desc_fallback
+		}
+		desc = adultery.2001.desc_end
+	}
+	
+	theme = marriage
+	left_portrait = scope:adultery_child
+	right_portrait = scope:adultery_spouse
+	
+	trigger = {
+		any_child = {
+			is_landed = no
+			father = root
+			NOR = {
+				has_character_flag = cleared_of_bastardy_suspicion
+				has_trait = bastard
+				has_trait = wild_oat
+				has_trait = legitimized_bastard
+			}
+			exists = mother
+			mother = { is_alive = yes }
+			mother = {
+				is_consort_of = root
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 0
+		modifier = {
+			add = 0
+			any_child = {
+				is_landed = no
+				father = root
+				NOR = {
+					has_character_flag = cleared_of_bastardy_suspicion
+					has_trait = bastard
+					has_trait = legitimized_bastard
+				}
+				exists = mother
+				save_temporary_scope_as = child_check
+			}
+		}
+		#The smarter the father is, the more likely it is that he'll suspect a bastard child
+		modifier = {
+			add = 0.1
+			has_trait = intellect_good_1
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = 0.3
+			has_trait = intellect_good_2
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = 0.5
+			has_trait = intellect_good_3
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = -0.1
+			has_trait = intellect_bad_1
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = -0.3
+			has_trait = intellect_bad_2
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = -0.5
+			has_trait = intellect_bad_3
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		#The smarter the mother is, the less likely it is that he'll suspect a bastard child
+		modifier = {
+			add = -0.1
+			scope:child_check.mother = {
+				has_trait = intellect_good_1
+			}
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = -0.3
+			scope:child_check.mother = {
+				has_trait = intellect_good_2
+			}
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = -0.5
+			scope:child_check.mother = {
+				has_trait = intellect_good_3
+			}
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = 0.1
+			scope:child_check.mother = {
+				has_trait = intellect_bad_1
+			}
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = 0.3
+			scope:child_check.mother = {
+				has_trait = intellect_bad_2
+			}
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = {
+			add = 0.5
+			scope:child_check.mother = {
+				has_trait = intellect_bad_3
+			}
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		#The less you like the child the more likely you are to suspect them
+		modifier = {
+			opinion = {
+				target = scope:child_check
+				value < 20
+			}
+			add = {
+				value = 0.1
+				if = {
+					limit = {
+						opinion = {
+							target = scope:child_check
+							value < 10
+						}
+					}
+					add = 0.1
+				}
+				if = {
+					limit = {
+						opinion = {
+							target = scope:child_check
+							value < 0
+						}
+					}
+					add = 0.1
+				}
+				if = {
+					limit = {
+						opinion = {
+							target = scope:child_check
+							value < -10
+						}
+					}
+					add = 0.1
+				}
+				if = {
+					limit = {
+						opinion = {
+							target = scope:child_check
+							value < -20
+						}
+					}
+					add = 0.1
+				}
+			}
+		}
+		modifier = { #More likely if they actually are a bastard
+			add = 0.5
+			scope:child_check = {
+				real_father = { NOT = { this = root } }
+			}
+		}
+		modifier = { #More likely if mother has a known lover
+			add = 0.8
+			scope:child_check.mother = {
+				any_relation = {
+					type = lover
+					NOR = {
+						has_secret_relation_lover = prev
+						this = root
+					}
+				}
+			}
+		}
+		modifier = { #Much more likely if mother has young child and a known lover
+			add = 5
+			exists = var:mother_of_young_child_has_lover
+		}
+		modifier = {
+			add = 0.5
+			has_trait = paranoid
+		}
+	}
+
+	immediate = {
+		random_child = {
+			limit = {
+				NOT = { has_character_flag = cleared_of_bastardy_suspicion }
+				is_landed = no
+				father = root
+				exists = mother
+				mother = { 
+					is_alive = yes 
+					is_consort_of = root
+				}
+				NOR = {
+					has_trait = bastard
+					has_trait = legitimized_bastard
+				}
+				#If a suspicious child exists, pick them
+				root = { exists = var:mother_of_young_child_has_lover }
+				mother = root.var:mother_of_young_child_has_lover
+			}
+			alternative_limit = {
+				NOT = { has_character_flag = cleared_of_bastardy_suspicion }
+				is_landed = no
+				father = root
+				exists = mother
+				mother = { 
+					is_alive = yes 
+					is_consort_of = root
+				}
+				NOR = {
+					has_trait = bastard
+					has_trait = legitimized_bastard
+				}
+			}
+			add_character_flag = {
+				flag = cleared_of_bastardy_suspicion
+				days = 3650
+			}
+			save_scope_as = adultery_child
+			mother = { save_scope_as = adultery_spouse }
+		}
+	}
+
+	option = { #Spy on kid/spouse
+		name = adultery.2001.a
+		custom_tooltip = adultery.2001.a.tt
+		show_as_tooltip = {
+			duel = {
+				skill = intrigue
+				target = scope:adultery_spouse
+				60 = {
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = 0.5
+					}
+					desc = adultery.2001.a.duel_success
+					custom_tooltip = adultery.2001.a.duel_success.tooltip
+				}
+	
+				40 = {
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = -0.5
+					}
+					desc = adultery.2001.a.duel_failure
+					if = {
+						limit = {
+							exists = scope:adultery_spouse
+						}
+						reverse_add_opinion = {
+							target = scope:adultery_spouse
+							modifier = spied_on_me_opinion
+						}
+					}
+					
+				}
+			}
+		}
+		hidden_effect = {
+			duel = {
+				skill = intrigue
+				target = scope:adultery_spouse
+				60 = {
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = 0.5
+					}
+					trigger = {
+						NOT = { scope:adultery_child.real_father = root }
+					}
+					trigger_event = {
+						id = adultery.2008
+						days = { 10 20 }
+					}
+				}
+	
+				40 = {
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = -0.5
+					}
+					trigger_event = {
+						id = adultery.2002
+						days = { 10 20 }
+					}
+				}
+			}				
+		}
+		if = {
+			limit = {
+				scope:adultery_child = {
+					real_father = root
+				}
+			}
+			set_variable = {
+				name = adultery_scheme_child
+				value = scope:adultery_child
+			}
+		}
+	}
+
+	option = { #Do nothing
+		name = adultery.2001.b
+	}
+}
+
+
+#Spy on failure - There was nothing to find about the child
+adultery.2002 = {
+	type = character_event
+	title = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					OR = {
+						exists = scope:adultery_spouse
+						scope:adultery_spouse = {
+							is_pregnant = yes
+							has_character_flag = father_suspects_this_pregnancy
+						}
+						NOT = { exists = scope:adultery_child }
+					}
+				}
+				desc = adultery.2002.t_a
+			}
+			desc = adultery.2001.t
+		}
+	}
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					exists = scope:adultery_spouse
+					scope:adultery_spouse = {
+						is_pregnant = yes
+						has_character_flag = father_suspects_this_pregnancy
+					}
+				}
+				desc = adultery.2002.desc_not_born
+			}
+			triggered_desc = {
+				trigger = {
+					NOT = { exists = scope:adultery_child }
+				}
+				desc = adultery.2002.desc_no_child
+			}
+			triggered_desc = {
+				trigger = {
+					exists = scope:adultery_spouse
+				}
+				desc = adultery.2002.desc_spouse
+			}
+			desc = adultery.2002.desc
+		}
+	}
+	
+	theme = marriage
+	left_portrait = scope:adultery_child
+	right_portrait = scope:adultery_spouse
+	
+	trigger = {
+		exists = scope:adultery_spouse
+		scope:adultery_spouse = { is_alive = yes }
+		exists = scope:adultery_child.father
+		scope:adultery_child.father = root
+		scope:adultery_spouse = {
+			NOT = {
+				any_secret = {
+					secret_type = secret_disputed_heritage
+					secret_target = scope:adultery_child
+					is_known_by = root
+				}
+			}
+		}
+	}
+
+	immediate = {
+		reverse_add_opinion = {
+			target = scope:adultery_spouse
+			modifier = spied_on_me_opinion
+		}
+	}
+
+	option = { #Keep spying on kid!
+		name = adultery.2002.a
+		custom_tooltip = adultery.2001.a.tt
+		show_as_tooltip = {
+			duel = {
+				skill = intrigue
+				target = scope:adultery_spouse
+
+				60 = {
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = 0.5
+					}
+					desc = adultery.2001.a.duel_success
+					custom_tooltip = adultery.2001.a.duel_success.tooltip
+				}
+
+				40 = {
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = -0.5
+					}
+					desc = adultery.2001.a.duel_failure
+					reverse_add_opinion = {
+						target = scope:adultery_spouse
+						modifier = insult_opinion
+						opinion = -20
+					}
+					reverse_add_opinion = {
+						target = scope:adultery_child
+						modifier = angry_opinion
+						opinion = -30
+					}
+				}
+			}	
+		}
+		hidden_effect = {
+			duel = {
+				skill = intrigue
+				target = scope:adultery_spouse
+
+				60 = {
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = 0.5
+					}
+					trigger = {
+						NOT = {
+							scope:adultery_child.real_father = root
+						}
+					}
+					trigger_event = {
+						id = adultery.2003
+						days = { 10 20 }
+					}
+				}
+
+				40 = {
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = -0.5
+					}
+					trigger_event = {
+						id = adultery.2009
+						days = { 10 20 }
+					}
+				}
+			}				
+		}
+	}
+
+	option = { #They seem legit enough
+		name = adultery.2002.b
+		if = {
+			limit = {
+				exists = scope:scheme
+			}
+			scope:scheme = {
+				end_scheme = yes
+			}
+		}
+		remove_variable = adultery_scheme_child
+	}
+}
+
+#Spy on success - Child confesses that they know that they are a Bastard
+adultery.2003 = {
+	type = character_event
+	title = adultery.2001.t
+	desc = adultery.2003.desc
+	
+	theme = marriage
+	left_portrait = scope:adultery_child
+	right_portrait = scope:adultery_spouse
+	
+	trigger = {
+		scope:adultery_child = {
+			is_child_of = root
+			any_known_secret = {
+				secret_type = secret_disputed_heritage
+				secret_target = prev
+			}
+		}
+	}
+
+	immediate = {
+		scope:target = {
+			random_known_secret = {
+				limit = {
+					secret_type = secret_disputed_heritage
+					secret_target = scope:adultery_child
+				}
+				save_scope_as = secret
+				if = {
+					limit = {
+						secret_owner = {
+							NOT = {
+								this = scope:adultery_child
+							}
+							is_parent_of = scope:adultery_child
+						}
+					}
+					secret_owner = {
+						save_scope_as = adultery_spouse
+					}
+				}
+			}
+		}
+		scope:adultery_child = {
+			real_father = {
+				save_scope_as = real_father
+			}
+		}
+		
+		scope:adultery_child = {
+			trigger_event = adultery.2006 #Response event for child
+		}
+
+		if = { #To remove the saved child scope
+			limit = {
+				exists = var:suspect_this_child_of_illegitimacy
+			}
+			remove_variable = suspect_this_child_of_illegitimacy
+		}
+	}
+
+	option = {
+		name = adultery.2003.a
+		scope:secret = {
+			reveal_to = root
+		}
+		hidden_effect = {
+			if = {
+				limit = {
+					exists = scope:scheme
+				}
+				scope:scheme = {
+					end_scheme = yes
+				}
+			}
+		}
+	}
+}
+
+
+#Reaction event for child, father knows that I'm a bastard!
+adultery.2006 = {
+	type = character_event
+	title = adultery.2006.t
+	desc = adultery.2006.desc
+	
+	theme = marriage
+	left_portrait = scope:owner
+	right_portrait = scope:adultery_spouse
+	lower_right_portrait = scope:real_father
+
+	immediate = {
+		play_music_cue = mx_cue_death
+	}
+
+	option = {
+		name = adultery.2006.a
+		show_as_tooltip ={
+			scope:owner = {
+				scope:secret = {
+					reveal_to = root
+				}
+			}
+		}
+	}
+}
+
+
+adultery.2008 = {
+	type = character_event
+	title = adultery.2008.t
+	desc = adultery.2008.desc
+	left_portrait = scope:adultery_spouse
+	lower_left_portrait = scope:adultery_child
+	right_portrait = scope:real_father
+	theme = bastardy
+	
+	trigger = {
+		scope:adultery_spouse = {
+			any_secret = {
+				secret_type = secret_disputed_heritage
+				secret_target = scope:adultery_child
+				NOT = {
+					is_known_by = root
+				}
+			}
+		}
+	}
+
+	immediate = {
+		play_music_cue = mx_cue_death
+		scope:adultery_spouse = {
+			random_secret = {
+				limit = {
+					secret_type = secret_disputed_heritage
+					secret_target = scope:adultery_child
+					NOT = {
+						is_known_by = root
+					}
+				}
+				save_scope_as = secret
+			}
+		}
+		scope:adultery_child.real_father = {
+			save_scope_as = real_father
+		}
+	}
+
+	option = {
+		name = adultery.2008.a
+		scope:secret = {
+			expose_secret = root
+		}
+	}
+
+	option = {
+		name = adultery.2008.b
+		custom_tooltip = adultery.2008.b.tt
+	}
+}
+
+#Even after spying on your child, you find nothing
+adultery.2009 = {
+	type = character_event
+	title = adultery.2009.t
+	desc = adultery.2009.desc
+	left_portrait = {
+		character = scope:adultery_child
+		animation = anger
+	}
+	lower_left_portrait = scope:adultery_spouse
+	theme = bastardy
+	
+	trigger = {
+		scope:adultery_child.father = root
+	}
+
+	option = {
+		name = adultery.2009.a
+		reverse_add_opinion = {
+			target = scope:adultery_spouse
+			modifier = insult_opinion
+			opinion = -20
+		}
+		reverse_add_opinion = {
+			target = scope:adultery_child
+			modifier = angry_opinion
+			opinion = -30
+		}
+	}
+}
+
+#############################
+# Misc Bastard Child Events #
+# 3001 - 3999				#
+#############################
+
+#Mother tells child their secret
+adultery.3001 = {
+	type = character_event
+	title = adultery.3001.t
+	desc = {
+		desc = adultery.3001.desc
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					exists = scope:father
+				}
+				desc = adultery.3001.desc_father
+			}
+			desc = adultery.3001.desc_no_father
+		}
+	}
+	left_portrait = {
+		character = scope:parent_with_secret
+		animation = grief
+	}
+	right_portrait = scope:real_father
+	lower_right_portrait = scope:father
+	theme = pregnancy
+
+	trigger = {
+		any_parent = { #ai parent and child is NOT a secret knower
+			is_ai = yes
+			OR = {
+				any_secret = {
+					secret_type = secret_disputed_heritage
+					secret_target = root
+					NOT = {
+						any_secret_knower = { this = root }
+					}
+				}
+				any_secret = {
+					secret_type = secret_unmarried_illegitimate_child
+					secret_target = root
+					NOT = {
+						any_secret_knower = { this = root }
+					}
+				}
+			}
+		}
+	}
+
+	weight_multiplier = { #more likely if mother likes child/child dislikes father
+		base = 0.5
+		modifier = {
+			add = 5
+			exists = father
+			exists = mother
+			NOR = {
+				real_father = father
+				has_trait = bastard
+			}
+			opinion = {
+				target = father
+				value <= neutral_opinion
+			}
+			reverse_opinion = {
+				target = mother
+				value > neutral_opinion
+			}
+		}
+		modifier = {
+			add = 10
+			exists = father
+			exists = mother
+			NOR = {
+				real_father = father
+				has_trait = bastard
+			}
+			opinion = {
+				target = father
+				value <= low_negative_opinion
+			}
+			reverse_opinion = {
+				target = mother
+				value > neutral_opinion
+			}
+		}
+		modifier = {
+			add = 5
+			exists = father
+			exists = mother
+			mother = {
+				is_ai = yes
+				any_secret = {
+					secret_type = secret_disputed_heritage
+					secret_target = root
+					NOT = {
+						any_secret_knower = { this = root }
+					}
+				}
+				opinion = {
+					target = root.father
+					value <= 0
+				}
+			}
+		}
+		modifier = {
+			add = 10
+			exists = father
+			exists = mother
+			mother = {
+				is_ai = yes
+				any_secret = {
+					secret_type = secret_disputed_heritage
+					secret_target = root
+					NOT = {
+						any_secret_knower = { this = root }
+					}
+				}
+				opinion = {
+					target = root.father
+					value <= -20
+				}
+			}
+		}
+	}
+
+	immediate = {
+		play_music_cue = mx_cue_death
+		if = {
+			limit = {
+				any_parent = {
+					is_ai = yes
+					any_secret = {
+						secret_type = secret_disputed_heritage
+						secret_target = root
+						NOT = {
+							any_secret_knower = { this = root }
+						}
+					}
+					any_secret = {
+						secret_type = secret_disputed_heritage
+						secret_target = root
+						NOT = {
+							any_secret_knower = { this = root }
+						}
+					}
+				}
+			}
+			random_parent = {
+				limit = {
+					is_ai = yes
+					any_secret = {
+						secret_type = secret_disputed_heritage
+						secret_target = root
+						NOT = {
+							any_secret_knower = { this = root }
+						}
+					}
+				}
+				save_scope_as = parent_with_secret
+				random_secret = {
+					limit = {
+						secret_type = secret_disputed_heritage
+						secret_target = root
+						NOT = {
+							any_secret_knower = { this = root }
+						}
+					}
+					save_scope_as = secret
+				}
+			}
+		}
+		else = {
+			random_parent = {
+				limit = {
+					is_ai = yes
+					any_secret = {
+						secret_type = secret_unmarried_illegitimate_child
+						secret_target = root
+						NOT = {
+							any_secret_knower = { this = root }
+						}
+					}
+				}
+				save_scope_as = parent_with_secret
+				random_secret = {
+					limit = {
+						secret_type = secret_unmarried_illegitimate_child
+						secret_target = root
+						NOT = {
+							any_secret_knower = { this = root }
+						}
+					}
+					save_scope_as = secret
+				}
+			}
+		}
+		if = {
+			limit = {
+				exists = father
+				father = {
+					is_alive = yes
+				}
+			}
+			father = {
+				save_scope_as = father
+			}
+		}
+		if = {
+			limit = {
+				real_father = {
+					is_alive = yes
+				}
+			}
+			real_father = {
+				save_scope_as = real_father
+			}
+		}
+	}
+
+	option = {
+		name = adultery.3001.a
+		custom_tooltip = adultery.3001.a.tt
+		scope:secret = {
+			reveal_to_without_events_effect = { CHARACTER = root }
+		}
+	}
+}
+
+
+###############################################
+# extramarital_sex_exposure_consequences_effect events #
+###############################################
+
+#My spouse had sex with someone (not lovers)
+scripted_trigger adultery_4001_can_be_imprisoned_trigger = {
+	save_temporary_scope_as = imprisonment_check
+	root = { allowed_to_imprison_character_trigger = { CHARACTER = scope:imprisonment_check } }
+	trigger_if = {
+		limit = {
+			exists = scope:sex_partner
+			this = scope:sex_partner
+		}
+		NOT = { exists = scope:unsuccessful_sex_attempt }
+		sexual_activity_with_partner_is_criminal_in_faith_trigger = { PARTNER = scope:adultery_spouse FAITH = root.faith }
+	}
+}
+
+adultery.4001 = { #by Mathilda Bjarnehed
+	type = character_event
+	title = adultery.4001.t
+	desc = {
+		desc = adultery.4001.start.desc
+		first_valid = {
+			#Unsuccessful seduction attempt
+			triggered_desc = {
+				trigger = {
+					exists = scope:sex_partner
+					exists = scope:unsuccessful_sex_attempt
+				}
+				desc = {
+					desc = adultery.4001.unsuccessful_sex_attempt.desc
+					random_valid = {
+						desc = adultery.4001.fur.desc
+						desc = adultery.4001.laugh.desc
+						desc = adultery.4001.threw.desc
+					}
+				}
+			}
+			#Had sex with someone (known or unknown)
+			desc = {
+				#Who? Known, servant or commoner?
+				random_valid = {
+					triggered_desc = {
+						trigger = { exists = scope:sex_partner }
+						desc = adultery.4001.sex_partner.desc
+					}
+					triggered_desc = {
+						trigger = { NOT = { exists = scope:sex_partner } }
+						desc = adultery.4001.commoner.desc
+					}
+					triggered_desc = {
+						trigger = { NOT = { exists = scope:sex_partner } }
+						desc = adultery.4001.servant.desc
+					}
+				}
+				#Where? Or specify gender if a) unknown b) same gender as spouse and c) homosexuality isn't accepted/not gay/bi yourself
+				first_valid = {
+					triggered_desc = { #Homosexuality
+						trigger = {
+							NOT = { exists = scope:sex_partner }
+							scope:adultery_spouse = { sex_same_as = scope:unknown_sex_partner }
+							faith = { NOT = { has_doctrine_parameter = homosexuality_accepted } }
+							NOR = {
+								has_sexuality = homosexual
+								has_sexuality = bisexual
+							}
+						}
+						desc = adultery.4001.another_gender.desc
+					}
+					desc = { #Location
+						random_valid = {
+							desc = adultery.4001.bed.desc
+							triggered_desc = {
+								trigger = { scope:adultery_spouse = { is_female = yes } }
+								desc = adultery.4001.mare.desc
+							}
+							triggered_desc = {
+								trigger = { scope:adultery_spouse = { is_male = yes } }
+								desc = adultery.4001.stallion.desc
+							}
+							triggered_desc = {
+								trigger = { capital_province = { geographical_region = world_europe } }
+								desc = adultery.4001.deer.desc
+							}
+							triggered_desc = {
+								trigger = {
+									capital_province = {
+										OR = {
+											geographical_region = world_india
+											geographical_region = world_africa_west
+											geographical_region = world_africa_east
+										}
+									}
+								}
+								desc = adultery.4001.elephant.desc
+							}
+							desc = adultery.4001.desk.desc
+							desc = adultery.4001.alley.desc
+							desc = adultery.4001.table
+							desc = adultery.4001.kitchen.desc
+							desc = adultery.4001.privy.desc
+						}
+					}
+				}
+			}
+		}
+		desc = adultery.4001.end.desc
+	}
+	
+	theme = marriage
+	left_portrait = scope:adultery_spouse
+	right_portrait = scope:sex_partner
+
+	immediate = {
+		play_music_cue = mx_cue_combat_stinger
+		show_as_tooltip = {
+			scope:adultery_spouse = {
+				add_adulterer_fornicator_trait_or_nothing_effect = yes
+				if = {
+					limit = {
+						OR = {
+							AND = {
+								exists = scope:sex_partner
+								relation_with_character_is_sodomy_in_my_or_lieges_faith_trigger = { CHARACTER = scope:sex_partner }
+							}
+							AND = {
+								exists = scope:unknown_sex_partner
+								relation_with_character_is_sodomy_in_my_or_lieges_faith_trigger = { CHARACTER = scope:unknown_sex_partner }
+							}
+						}
+					}
+					add_trait = sodomite
+				}
+				if = {
+					limit = {
+						exists = scope:sex_partner
+						relation_with_character_is_incestuous_in_my_or_lieges_faith_trigger = { CHARACTER = scope:sex_partner }
+					}
+					add_trait = incestuous
+				}
+			}
+		}
+	}	
+
+	#Ok (not liege or above/not illegal)
+	option = {
+		trigger = {
+			NOR = {
+				scope:adultery_spouse = { adultery_4001_can_be_imprisoned_trigger = yes }
+				trigger_if = {
+					limit = { exists = scope:sex_partner }
+					scope:sex_partner = { adultery_4001_can_be_imprisoned_trigger = yes }
+				}
+			}
+		}
+		name = adultery.4001.a
+	}
+
+	#Liege or above: imprison
+	option = {
+		trigger = {
+			OR = {
+				scope:adultery_spouse = { adultery_4001_can_be_imprisoned_trigger = yes }
+				trigger_if = {
+					limit = { exists = scope:sex_partner }
+					scope:sex_partner = { adultery_4001_can_be_imprisoned_trigger = yes }
+				}
+			}
+		}
+		
+		name = {
+			text = {
+				first_valid = {
+					#Only imprison spouse
+					triggered_desc = {
+						trigger = {
+							scope:adultery_spouse = { adultery_4001_can_be_imprisoned_trigger = yes }
+							OR = {
+								NOT = { exists = scope:sex_partner }
+								scope:sex_partner = { adultery_4001_can_be_imprisoned_trigger = no }
+							}
+						}
+						desc = adultery.4001.b
+					}
+					#You can imprison both/just the partner
+					desc = adultery.4001.b2
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				scope:adultery_spouse = {
+					target_is_liege_or_above = root
+					is_imprisoned = no
+				}
+			}
+			imprison_character_effect = {
+				TARGET = scope:adultery_spouse
+				IMPRISONER = root
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:sex_partner
+				NOT = { exists = scope:unsuccessful_sex_attempt }
+				scope:sex_partner = {
+					target_is_liege_or_above = root
+					is_imprisoned = no
+					sexual_activity_with_partner_is_criminal_in_faith_trigger = { PARTNER = scope:adultery_spouse FAITH = root.faith }
+				}
+			}
+			imprison_character_effect = {
+				TARGET = scope:sex_partner
+				IMPRISONER = root
+			}
+		}
+
+		stress_impact = {
+			forgiving = minor_stress_impact_gain
+		}
+
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_zeal = low_chance_impact_positive_ai_value
+			}
+			modifier = {
+				has_trait = zealous
+				add = 100
+			}
+			modifier = {
+				OR = {
+					opinion = {
+						target = scope:adultery_spouse
+						value < 0
+					}
+				}
+				add = 100
+			}
+			modifier = {
+				OR = {
+					is_close_family_of = scope:adultery_spouse
+					has_relation_friend = scope:adultery_spouse
+				}
+				add = -100
+			}
+		}
+	}
+	
+	#Liege or above: forgive
+	option = {
+		trigger = {
+			OR = {
+				scope:adultery_spouse = { adultery_4001_can_be_imprisoned_trigger = yes }
+				trigger_if = {
+					limit = { exists = scope:sex_partner }
+					scope:sex_partner = { adultery_4001_can_be_imprisoned_trigger = yes }
+				}
+			}
+		}
+		name = adultery.4001.c
+		
+		reverse_add_opinion = {
+			target = scope:adultery_spouse
+			modifier = grateful_opinion
+			opinion = 20
+		}
+		if = {
+			limit = {
+				exists = scope:sex_partner
+				NOT = { exists = scope:unsuccessful_sex_attempt }
+				scope:sex_partner = { target_is_liege_or_above = root }
+			}
+			reverse_add_opinion = {
+				target = scope:sex_partner
+				modifier = grateful_opinion
+				opinion = 20
+			}
+		}
+
+		add_piety = medium_piety_loss
+
+		stress_impact = {
+			paranoid = medium_stress_impact_gain
+			vengeful = medium_stress_impact_gain
+		}
+
+		ai_chance = {
+			base = 10
+			ai_value_modifier = {
+				ai_compassion = low_chance_impact_positive_ai_value
+			}
+			modifier = {
+				has_trait = cynical
+				add = 100
+			}
+			modifier = {
+				scope:adultery_spouse = { is_ai = no }
+				add = 50
+			}
+		}
+	}
+}
+
+


### PR DESCRIPTION
I had `adultery.0002` ("Someone Else") fire a number of times while my character was in an army and not really able to confront their spouse with adultery suspicions. It seems being in army is not covered by `basic_is_valid_for_yearly_events_trigger`.