### PR TITLE
Fix "Summon Wealthy Visitors" decisions

### DIFF
--- a/common/decisions/00_artifact_decisions.txt
+++ b/common/decisions/00_artifact_decisions.txt
@@ -24,7 +24,7 @@
 			}
 			custom_tooltip = {
 				text = commission_artifact_decision.nomad_requirements
-				NOR = {
+				OR = { #Unop Enable this decision only if materials are available
 					has_character_modifier = mpo_artifact_material_modifier
 					culture ?= {
 						has_cultural_parameter = nomadic_metal_artifact_unlock
@@ -155,9 +155,9 @@
 					}
 					custom_tooltip = {
 						text = commission_artifact_decision.nomad_requirements
-						NOT = {
+						#NOT = { #Unop Enable this option only if materials are available
 							has_character_modifier = mpo_artifact_material_modifier
-						}			
+						#}			
 					}
 				}
 			}
@@ -191,9 +191,9 @@
 					}
 					custom_tooltip = {
 						text = commission_artifact_decision.nomad_requirements
-						NOT = {
+						#NOT = { #Unop Enable this option only if materials are available
 							has_character_modifier = mpo_artifact_material_modifier
-						}
+						#}
 					}			
 				}
 			}
@@ -238,9 +238,9 @@
 					}
 					custom_tooltip = {
 						text = commission_artifact_decision.nomad_requirements
-						NOT = {
+						#NOT = { #Unop Enable this option only if materials are available
 							has_character_modifier = mpo_artifact_material_modifier
-						}			
+						#}			
 					}
 				}
 			}
@@ -282,9 +282,9 @@
 					}
 					custom_tooltip = {
 						text = commission_artifact_decision.nomad_requirements
-						NOT = {
+						#NOT = { #Unop Enable this option only if materials are available
 							has_character_modifier = mpo_artifact_material_modifier
-						}			
+						#}			
 					}
 				}
 			}

--- a/common/decisions/00_artifact_decisions.txt
+++ b/common/decisions/00_artifact_decisions.txt
@@ -1,0 +1,507 @@
+﻿commission_artifact_decision = {
+	picture = {
+		trigger = { government_has_flag = government_is_nomadic }
+		reference = "gfx/interface/illustrations/event_scenes/mpo_hunt_steppe.dds"
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_smith.dds"
+	}
+	cooldown = { days = standard_commission_artifact_cooldown_time }
+	sort_order = 100
+	
+	is_shown = {
+		is_landed_or_landless_administrative = yes
+		highest_held_title_tier >= tier_county
+		exists = capital_province
+	}
+	
+	is_valid_showing_failures_only = {
+		# Only valid for characters with an antiquarian.
+		employs_court_position = antiquarian_court_position
+		trigger_if = {
+			limit = {
+				government_has_flag = government_is_nomadic
+			}
+			custom_tooltip = {
+				text = commission_artifact_decision.nomad_requirements
+				NOR = {
+					has_character_modifier = mpo_artifact_material_modifier
+					culture ?= {
+						has_cultural_parameter = nomadic_metal_artifact_unlock
+					}
+				}			
+			}
+		}
+	}
+
+	minimum_cost = {
+		# Matches the cost defined in 00_inspirations.txt
+		gold = {
+			value = basic_fund_inspiration_cost
+			if = {
+				limit = { # Estate discount bonus
+					domicile ?= { has_domicile_parameter = estate_reduce_commission_artifact_cost }
+				}
+				multiply = estate_reduce_commission_artifact_cost_value
+			}
+			if = {
+				limit = {
+					has_character_modifier = mpo_artifact_material_modifier
+				}
+				multiply = 0
+			}
+		}
+	}
+
+    widget = {
+    	gui = "decision_view_widget_commission_artifact"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "COMMISSION_ARTIFACT_DECISION_NEXT_STEP_BUTTON" 
+
+
+		# Personal Artifacts are always valid to commission
+		item = {
+			value = commission_weapon
+			current_description = {
+				desc = commission_artifact_decision_option_weapon_desc
+			}
+			localization  = {
+				desc = commission_artifact_decision_option_weapon
+			}
+			icon = "gfx/interface/icons/artifact/artifact_sword.dds"
+
+			ai_chance = {
+				value = 0 
+				if = {
+					limit = {
+						# Only make this choice if we don't already have an artifact of this type.
+						NOT = {
+							any_character_artifact = {
+								artifact_slot_type = primary_armament
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+
+		item = {
+			value = commission_armor
+			current_description = {
+				desc = commission_artifact_decision_option_armor_desc
+			}
+			localization = {
+				desc = commission_artifact_decision_option_armor
+			}
+			icon = "gfx/interface/icons/artifact/artifact_armor.dds"
+
+			ai_chance = {
+				value = 0 
+				if = {
+					limit = {
+						# Only make this choice if we don't already have an artifact of this type.
+						NOT = {
+							any_character_artifact = {
+								artifact_slot_type = armor
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+
+		item = {
+			value = commission_crown
+			current_description = {
+				desc = commission_artifact_decision_option_crown_desc
+			}
+			localization = {
+				desc = commission_artifact_decision_option_crown
+			}
+			icon = "gfx/interface/icons/artifact/artifact_crown.dds"
+
+			ai_chance = {
+				value = 0 
+				if = {
+					limit = {
+						# Only make this choice if we don't already have an artifact of this type.
+						NOT = {
+							any_character_artifact = {
+								artifact_slot_type = helmet
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+
+		item = {
+			value = commission_regalia
+			current_description = {
+				desc = commission_artifact_decision_option_regalia_desc
+			}
+			localization = {
+				desc = commission_artifact_decision_option_regalia
+			}
+			icon = "gfx/interface/icons/artifact/artifact_regalia.dds"
+
+			is_valid = {
+				trigger_if = {
+					limit = {
+						government_has_flag = government_is_nomadic
+					}
+					custom_tooltip = {
+						text = commission_artifact_decision.nomad_requirements
+						NOT = {
+							has_character_modifier = mpo_artifact_material_modifier
+						}			
+					}
+				}
+			}
+
+			ai_chance = {
+				value = 0 
+				if = {
+					limit = {
+						# Only make this choice if we don't already have an artifact of this type.
+						NOT = {
+							any_character_artifact = {
+								artifact_slot_type = regalia
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+
+		# Court Artifacts only appear if you have the Royal Court DLC, and are only valid if you have an active Royal Court
+		
+		item = {
+			value = commission_tapestry
+			is_shown = { has_dlc_feature = royal_court }
+			is_valid = {
+				has_royal_court = yes
+				trigger_if = {
+					limit = {
+						government_has_flag = government_is_nomadic
+					}
+					custom_tooltip = {
+						text = commission_artifact_decision.nomad_requirements
+						NOT = {
+							has_character_modifier = mpo_artifact_material_modifier
+						}
+					}			
+				}
+			}
+			current_description = {
+				desc = commission_artifact_decision_option_tapestry_desc
+			}
+
+			localization = {
+				desc = commission_artifact_decision_option_tapestry
+			}
+			icon = "gfx/interface/icons/artifact/artifact_tapestry.dds"
+
+			ai_chance = {
+				value = 0 
+				if = {
+					limit = {
+						has_royal_court = yes
+						has_dlc_feature = court_artifacts
+						# Only make this choice if we don't already have an artifact of this type.
+						NOR = {
+							any_character_artifact = {
+								artifact_slot_type = wall_big
+							}
+							any_character_artifact = {
+								artifact_slot_type = wall_small
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+
+		item = {
+			value = commission_furniture
+			is_shown = { has_dlc_feature = royal_court  }
+			is_valid = {
+				has_royal_court = yes
+				trigger_if = {
+					limit = {
+						government_has_flag = government_is_nomadic
+					}
+					custom_tooltip = {
+						text = commission_artifact_decision.nomad_requirements
+						NOT = {
+							has_character_modifier = mpo_artifact_material_modifier
+						}			
+					}
+				}
+			}
+			current_description = {
+				desc = commission_artifact_decision_option_furniture_desc
+			}
+
+			localization = {
+				desc = commission_artifact_decision_option_furniture
+			}
+			icon = "gfx/interface/icons/artifact/artifact_cabinet.dds"
+
+			ai_chance = {
+				value = 0 
+				if = {
+					limit = {
+						has_royal_court = yes
+						has_dlc_feature = court_artifacts
+						# Only make this choice if we don't already have an artifact of this type.
+						NOT = {
+							any_character_artifact = {
+								artifact_slot_type = sculpture
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+
+		item = {
+			value = commission_book
+			is_shown = { has_dlc_feature = royal_court  }
+			is_valid = {
+				has_royal_court = yes
+				trigger_if = {
+					limit = {
+						government_has_flag = government_is_nomadic
+					}
+					custom_tooltip = {
+						text = commission_artifact_decision.nomad_requirements
+						NOT = {
+							has_character_modifier = mpo_artifact_material_modifier
+						}			
+					}
+				}
+			}
+			current_description = {
+				desc = commission_artifact_decision_option_book_desc
+			}
+			localization = {
+				desc = commission_artifact_decision_option_book
+			}
+			icon = "gfx/interface/icons/artifact/artifact_book.dds"
+
+			ai_chance = {
+				value = 0 
+				if = {
+					limit = {
+						has_royal_court = yes
+						has_dlc_feature = court_artifacts
+						# Only make this choice if we don't already have an artifact of this type.
+						NOT = {
+							any_character_artifact = {
+								artifact_slot_type = book
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+
+		#Alchemy isn't included here since that inspiration is much more tied to the pursuit of knowledge initiated by the inspired person
+	}
+
+	effect = {
+		if = {
+			limit = {
+				any_court_position_holder = {
+					type = antiquarian_court_position
+				}
+			}
+			random_court_position_holder = {
+				type = antiquarian_court_position
+				save_scope_as = antiquarian
+			}
+		}
+		# Explanatory Tooltips
+		custom_tooltip = commission_artifact_decision_effect
+		if = {
+			limit = { has_dlc_feature = royal_court }
+			custom_description_no_bullet = {
+				text = commission_artifact_decision_warning_effect
+			}
+		}
+
+		if = {
+			limit = {
+				any_pool_character = {
+					province = root.capital_province
+					has_no_particular_noble_roots_trigger = yes
+					is_available_healthy_ai_adult = yes
+					NOR = {
+						exists = inspiration
+						has_trait = peasant_leader
+					}
+				}
+			}
+			random_pool_character = {
+				province = root.capital_province
+				limit = {
+					has_no_particular_noble_roots_trigger = yes
+					is_available_healthy_ai_adult = yes
+					NOR = {
+						exists = inspiration
+						has_trait = peasant_leader
+					}
+				}
+				save_scope_as = local_artisan
+				hidden_effect = {
+					add_character_modifier = local_artisan_modifier
+				}
+			}
+		}
+		else = {
+			# Artisan Generation
+			hidden_effect = {
+				create_character = {
+					template = local_artisan_template
+					location = root.capital_province
+					gender_female_chance = root_faith_dominant_gender_adjusted_female_chance
+					save_scope_as = local_artisan
+				}
+				scope:local_artisan = {
+					hidden_effect = {
+						add_character_modifier = local_artisan_modifier
+					}
+				}
+			}
+		}
+
+		hidden_effect = {
+			if = {
+				# Conditional exists to avoid false-positives during tooltip generation, but 'local_artisan' should always exist on execution!
+				limit = { exists = scope:local_artisan }
+				root = { add_courtier = scope:local_artisan	}
+				scope:local_artisan = {
+					add_character_flag = local_artisan
+					if = {
+						limit = { scope:commission_weapon = yes }
+						create_inspiration = weapon_inspiration
+					}
+					else_if = {
+						limit = { scope:commission_armor = yes }
+						set_variable = {
+							name = force_armor
+							value = flag:force_armor_true
+						}
+						create_inspiration = armor_inspiration
+					}
+					else_if = {
+						limit = { scope:commission_crown = yes }
+						set_variable = {
+							name = artifact_smith_type
+							value = flag:smith_type_crown
+						}
+						create_inspiration = smith_inspiration
+					}
+					else_if = {
+						limit = { scope:commission_regalia = yes }
+						set_variable = {
+							name = artifact_smith_type
+							value = flag:smith_type_regalia
+						}
+						create_inspiration = smith_inspiration
+					}
+					else_if = {
+						limit = { scope:commission_tapestry = yes }
+						root = {
+							trigger_event = fund_inspiration.0044
+						}
+					}
+					else_if = {
+						limit = { scope:commission_furniture = yes }
+						create_inspiration = artisan_inspiration
+					}
+					else_if = {
+						limit = { scope:commission_book = yes }
+						create_inspiration = book_inspiration
+					}
+					if = {
+						limit = { exists = inspiration }
+						inspiration = { save_scope_as = this_inspiration }
+						root = { sponsor_inspiration = scope:this_inspiration }
+					}
+				}
+			}
+		}
+	}
+
+	ai_check_interval = 36
+	
+	ai_potential = {
+		is_at_war = no
+		ai_greed < medium_positive_ai_value
+		short_term_gold > ai_war_chest_desired_gold_value
+		war_chest_gold >= halved_ai_war_chest_gold_maximum
+		ai_has_conqueror_personality = no
+		ai_should_focus_on_building_in_their_capital = no
+	}
+
+	ai_will_do = {
+		base = 100
+
+		modifier = {
+			factor = 0
+			has_royal_court = yes
+			any_character_artifact = {
+				artifact_slot_type = primary_armament
+			}
+			any_character_artifact = {
+				artifact_slot_type = armor
+			}
+			any_character_artifact = {
+				artifact_slot_type = helmet
+			}
+			any_character_artifact = {
+				artifact_slot_type = regalia
+			}
+			OR = {
+				any_character_artifact = {
+					artifact_slot_type = wall_big
+				}
+				any_character_artifact = {
+					artifact_slot_type = wall_small
+				}
+			}
+			any_character_artifact = {
+				artifact_slot_type = sculpture
+			}
+			any_character_artifact = {
+				artifact_slot_type = book
+			}
+		}
+
+		modifier = {
+			factor = 0
+			has_royal_court = no
+			any_character_artifact = {
+				artifact_slot_type = primary_armament
+			}
+			any_character_artifact = {
+				artifact_slot_type = armor
+			}
+			any_character_artifact = {
+				artifact_slot_type = helmet
+			}
+			any_character_artifact = {
+				artifact_slot_type = regalia
+			}
+		}
+	}
+}

--- a/common/decisions/dlc_decisions/mpo/mpo_flavor_decision.txt
+++ b/common/decisions/dlc_decisions/mpo/mpo_flavor_decision.txt
@@ -346,7 +346,7 @@ mpo_call_for_merchants_small_decision = {
         }
     }
 
-    cooldown = { years = 8 }
+    cooldown = { years = 4 } #Unop Use the same cooldown of 4 years for both decisions
 
     effect = {
         trigger_event = mpo_decisions_events.2139

--- a/common/schemes/scheme_types/befriend_scheme.txt
+++ b/common/schemes/scheme_types/befriend_scheme.txt
@@ -15,7 +15,7 @@
 	# Parameters
 	speed_per_skill_point = -2.5
 	spymaster_speed_per_skill_point = 0	
-	uses_resistance = no
+	# uses_resistance = no #Unop ck3-tiger Duplicated from above
 	base_progress_goal = 365
 	base_maximum_success = 95
 	minimum_success = 5
@@ -747,6 +747,10 @@
 		}
 	}
 	on_monthly = {
+		#Unop ck3-tiger Save scopes as they are needed by player_target_available_for_personal_scheme_ongoing_events_trigger
+		save_scope_as = scheme
+		scheme_owner = { save_scope_as = owner }
+		scheme_target_character = { save_scope_as = target }
 		#Fickleness
 		if = {
 			limit = {

--- a/common/schemes/scheme_types/befriend_scheme.txt
+++ b/common/schemes/scheme_types/befriend_scheme.txt
@@ -1,0 +1,854 @@
+﻿befriend = {
+	# Basic Setup
+	skill = diplomacy
+	desc = befriend_desc_general
+	success_desc = "BEFRIEND_SUCCESS_DESC"
+	icon = icon_scheme_befriend
+	illustration = "gfx/interface/illustrations/event_scenes/corridor.dds"
+	category = personal
+	target_type = character
+	is_secret = no
+	is_basic = yes
+	uses_resistance = no
+	cooldown = { years = 30 }
+
+	# Parameters
+	speed_per_skill_point = -2.5
+	spymaster_speed_per_skill_point = 0	
+	uses_resistance = no
+	base_progress_goal = 365
+	base_maximum_success = 95
+	minimum_success = 5
+	
+	# Core Triggers
+	allow = {
+		can_use_befriend_scheme_trigger = { TARGET = scope:target }
+		is_adult = yes
+		is_imprisoned = no
+		scope:target = {
+			is_adult = yes
+			is_imprisoned = no
+		}
+		NOT = {	this = scope:target }
+
+		is_below_ai_friend_soft_cap_trigger = yes
+		trigger_if = {
+			limit = { is_ai = yes }
+			scope:target = {
+				is_below_ai_friend_soft_cap_trigger = yes
+				NOT = {
+					any_targeting_scheme = {
+						scheme_type = befriend
+					}
+				}
+			}
+		}
+	}
+	valid = {
+		is_incapable = no
+		scope:target = {
+			is_adult = yes
+			is_imprisoned = no
+			exists = location
+		}
+		NOR = {
+			is_at_war_with = scope:target
+			custom_description = {
+				text = "befriend_already_lover"
+				object = scope:target
+				has_relation_lover = scope:target
+			}
+		}
+
+		#we're already friends
+		NOT = {
+			custom_description = {
+				text = befriend_already_friend
+				object = scope:target
+				has_relation_friend = scope:target
+			}
+		}
+	}
+
+	odds_prediction = {
+		add = base_odds_prediction_target_is_char_value
+		add = odds_skill_contribution_diplomacy_value
+		add = odds_befriend_scheme_misc_value
+		min = 0
+	}
+
+	# Base Chances
+	base_success_chance = {
+		base = 5
+		scheme_type_skill_success_chance_modifier = { SKILL = DIPLOMACY }
+		#SCHEME OWNER#
+		opinion_modifier = {
+			desc = SCHEME_BEFRIEND_THEIR_OPINION
+			who = scope:target
+			opinion_target = scope:owner
+			max = 30
+			min = -30
+			multiplier = 0.75
+		}
+		#Language
+		modifier = {
+			add = 4
+			desc = YOU_SPEAK_THE_LANGUAGE
+			scope:owner = { knows_language_of_culture = scope:target.culture }
+		}
+
+		# Countermeasures.
+		apply_opportunistic_scheme_success_chance_adjustments_modifier = yes
+		
+		# Their friend told you what they like
+		modifier = {
+			add = 15
+			desc = "SCHEME_WBANQUET_FRIEND_INSIGHT"
+			scope:owner = {
+				exists = var:wbanquet_friend_insight_var
+				var:wbanquet_friend_insight_var = scope:target
+			}
+		}
+		
+		#Owner Traits
+		modifier = {
+			add = 2
+			scope:owner = { has_trait = education_diplomacy_1 }
+			desc = "SCHEME_BEFRIEND_MY_EDUCATION"
+		}
+		modifier = {
+			add = 4
+			scope:owner = { has_trait = education_diplomacy_2 }
+			desc = "SCHEME_BEFRIEND_MY_EDUCATION"
+		}
+		modifier = {
+			add = 6
+			scope:owner = { has_trait = education_diplomacy_3 }
+			desc = "SCHEME_BEFRIEND_MY_EDUCATION"
+		}
+		modifier = {
+			add = 8
+			scope:owner = { has_trait = education_diplomacy_4 }
+			desc = "SCHEME_BEFRIEND_MY_EDUCATION"
+		}
+		modifier = {
+			add = 10
+			scope:owner = { has_trait = education_diplomacy_5 }
+			desc = "SCHEME_BEFRIEND_MY_EDUCATION"
+		}
+		modifier = {
+			scope:owner = {
+				OR = {
+					has_trait = diplomat
+					has_trait = family_first
+					has_trait = august
+				}
+			}
+			add = {
+				value = 0
+				if = {
+					limit = {
+						scope:owner = { has_trait = diplomat }
+					}
+					add = 4
+				}
+				if = {
+					limit = {
+						scope:owner = { has_trait = family_first }
+					}
+					add = 8
+				}
+				if = {
+					limit = {
+						scope:owner = { has_trait = august }
+					}
+					add = 12
+				}
+			}
+			desc = "SCHEME_BEFRIEND_MY_LIFESTYLE"
+		}
+		modifier = {
+			add = 4
+			scope:owner = {
+				has_trait = lifestyle_reveler
+				has_trait_xp = {
+					trait = lifestyle_reveler
+					value < 50
+				}
+			}
+			desc = "SCHEME_BEFRIEND_MY_REVELRY"
+		}
+		modifier = {
+			add = 6
+			scope:owner = {
+				has_trait = lifestyle_reveler
+				has_trait_xp = {
+					trait = lifestyle_reveler
+					value >= 50
+				}
+				has_trait_xp = {
+					trait = lifestyle_reveler
+					value < 100
+				}
+			}
+			desc = "SCHEME_BEFRIEND_MY_REVELRY"
+		}
+		modifier = {
+			add = 8
+			scope:owner = {
+				has_trait = lifestyle_reveler
+				has_trait_xp = {
+					trait = lifestyle_reveler
+					value = 100
+				}
+			}
+			desc = "SCHEME_BEFRIEND_MY_REVELRY"
+		}
+		modifier = {
+			add = -5
+			scope:owner = { has_trait = shy }
+			desc = "SCHEME_BEFRIEND_MY_SHYNESS"
+		}
+		modifier = {
+			add = 5
+			scope:owner = { has_trait = gregarious }
+			desc = "SCHEME_BEFRIEND_MY_GREGARIOUSNESS"
+		}
+		modifier = {
+			add = -4
+			scope:owner = { has_trait = callous }
+			desc = "SCHEME_BEFRIEND_MY_CALLOUSNESS"
+		}
+		#Target Traits
+		modifier = {
+			add = -5
+			scope:target = { has_trait = shy }
+			desc = "SCHEME_BEFRIEND_THEIR_SHYNESS"
+		}
+		modifier = {
+			add = 5
+			scope:target = { has_trait = gregarious }
+			desc = "SCHEME_BEFRIEND_THEIR_GREGARIOUSNESS"
+		}
+		modifier = {
+			add = -4
+			scope:target = { has_trait = callous }
+			desc = "SCHEME_BEFRIEND_THEIR_CALLOUSNESS"
+		}
+		modifier = {
+			add = -4
+			scope:target = { has_trait = paranoid }
+			desc = "SCHEME_BEFRIEND_THEIR_PARANOIA"
+		}
+		modifier = {
+			add = 4
+			scope:target = { has_trait = trusting }
+			desc = "SCHEME_BEFRIEND_THEIR_TRUST"
+		}
+		modifier = {
+			add = 4
+			scope:target = {
+				has_trait = lifestyle_reveler
+				has_trait_xp = {
+					trait = lifestyle_reveler
+					value < 50
+				}
+			}
+			desc = "SCHEME_BEFRIEND_MY_REVELRY"
+		}
+		modifier = {
+			add = 6
+			scope:target = {
+				has_trait = lifestyle_reveler
+				has_trait_xp = {
+					trait = lifestyle_reveler
+					value >= 50
+				}
+				has_trait_xp = {
+					trait = lifestyle_reveler
+					value < 100
+				}
+			}
+			desc = "SCHEME_BEFRIEND_MY_REVELRY"
+		}
+		modifier = {
+			add = 8
+			scope:target = {
+				has_trait = lifestyle_reveler
+				has_trait_xp = {
+					trait = lifestyle_reveler
+					value = 100
+				}
+			}
+			desc = "SCHEME_BEFRIEND_MY_REVELRY"
+		}
+		modifier = {
+			add = scope:target.var:recipient_stubborness_scheme
+			scope:target = {
+				has_trait = stubborn
+				exists = var:recipient_stubborness_scheme
+			}
+			desc = "SCHEME_BEFRIEND_THEIR_STUBBORNESS"
+		}
+		modifier = {
+			add = scope:target.var:recipient_fickleness_scheme
+			scope:target = {
+				has_trait = fickle
+				exists = var:recipient_fickleness_scheme
+				NOT = { var:recipient_fickleness_scheme = 0 }
+			}
+			desc = "SCHEME_BEFRIEND_THEIR_FICKLENESS"
+		}
+		
+		#Trait similarity to owner
+		compatibility_modifier = {
+			who = scope:target
+			compatibility_target = scope:owner
+			min = -50
+			max = 50
+			multiplier = 2
+		}
+		
+		#Rank tier difference (landed target/target whose liege doesn't care)
+		modifier = { #3 or more higher rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = 50
+			desc = "HIGHER_RANK_THAN_SCHEME_TARGET"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = no
+				NOT = {
+					is_theocratic_lessee = yes
+				}
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target
+					value >= 3
+				}
+			}
+		}
+		modifier = { #2 higher rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = 25
+			desc = "HIGHER_RANK_THAN_SCHEME_TARGET"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = no
+				NOT = {
+					is_theocratic_lessee = yes
+				}
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target
+					value = 2
+				}
+			}
+		}
+		modifier = { #1 higher rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = 10
+			desc = "HIGHER_RANK_THAN_SCHEME_TARGET"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = no
+				NOT = {
+					is_theocratic_lessee = yes
+				}
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target
+					value = 1
+				}
+			}
+		}
+		modifier = { #1 lower rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = -10
+			desc = "LOWER_RANK_THAN_SCHEME_TARGET"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = no
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target
+					value = -1
+				}
+			}
+		}
+		modifier = { #2 lower rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = -25
+			desc = "LOWER_RANK_THAN_SCHEME_TARGET"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = no
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target
+					value = -2
+				}
+			}
+		}
+		modifier = { #3 or less lower rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = -50
+			desc = "LOWER_RANK_THAN_SCHEME_TARGET"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = no
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target
+					value <= -3
+				}
+			}
+		}
+		#Rank tier difference (unlanded character)
+		modifier = { #3 or more higher rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = 15
+			desc = "HIGHER_RANK_THAN_SCHEME_TARGET_LIEGE"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = yes
+				NOT = {
+					is_theocratic_lessee = yes
+				}
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target.liege
+					value >= 3
+				}
+			}
+		}
+		modifier = { #2 higher rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = 10
+			desc = "HIGHER_RANK_THAN_SCHEME_TARGET_LIEGE"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = yes
+				NOT = {
+					is_theocratic_lessee = yes
+				}
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target.liege
+					value = 2
+				}
+			}
+		}
+		modifier = { #1 higher rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = 5
+			desc = "HIGHER_RANK_THAN_SCHEME_TARGET_LIEGE"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = yes
+				NOT = {
+					is_theocratic_lessee = yes
+				}
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target.liege
+					value = 1
+				}
+			}
+		}
+		modifier = { #1 lower rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = -5
+			desc = "LOWER_RANK_THAN_SCHEME_TARGET_LIEGE"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = yes
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target.liege
+					value = -1
+				}
+			}
+		}
+		modifier = { #2 lower rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = -10
+			desc = "LOWER_RANK_THAN_SCHEME_TARGET_LIEGE"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = yes
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target.liege
+					value = -2
+				}
+			}
+		}
+		modifier = { #3 or less lower rank
+			trigger = { personal_scheme_should_not_evaluate_tier_differences_trigger = yes }
+			add = -15
+			desc = "LOWER_RANK_THAN_SCHEME_TARGET_LIEGE"
+			scope:target = {
+				personal_scheme_success_compare_target_liege_tier_trigger = yes
+			}
+			scope:owner = {
+				tier_difference = {
+					target = scope:target.liege
+					value <= -3
+				}
+			}
+		}
+		#Extra rank bonus/penalty if target is arrogant/ambitious
+		modifier = {
+			desc = SCHEME_SOCIAL_CLIMBER_RANK_BONUS
+			add = 10
+			scope:target = {
+				OR = {
+					has_trait = arrogant
+					has_trait = ambitious
+					has_trait = greedy
+				}
+				NOT = {
+					is_theocratic_lessee = yes
+				}
+			}
+			OR = {
+				AND = {
+					scope:target = { personal_scheme_success_compare_target_liege_tier_trigger = yes }
+					scope:owner.highest_held_title_tier > scope:target.liege.highest_held_title_tier
+				}
+				AND = {
+					scope:target = { personal_scheme_success_compare_target_liege_tier_trigger = no }
+					scope:owner.highest_held_title_tier > scope:target.highest_held_title_tier
+				}
+			}
+		}
+		modifier = {
+			desc = SCHEME_SOCIAL_CLIMBER_RANK_PENALTY
+			add = -10
+			scope:target = {
+				OR = {
+					has_trait = arrogant
+					has_trait = ambitious
+					has_trait = greedy
+				}
+			}
+			OR = {
+				AND = {
+					scope:target = { personal_scheme_success_compare_target_liege_tier_trigger = yes }
+					scope:owner.highest_held_title_tier < scope:target.liege.highest_held_title_tier
+				}
+				AND = {
+					scope:target = { personal_scheme_success_compare_target_liege_tier_trigger = no }
+					scope:owner.highest_held_title_tier < scope:target.highest_held_title_tier
+				}
+			}
+		}
+		# Diarchs are better at schemes within their liege's realm
+		diarch_scheming_within_realm_bonus_modifier = yes
+		#Religious Heads
+		modifier = {
+			add = -50
+			desc = "SCHEME_VS_RELIGIOUS_HEAD"
+			scope:target = {
+				faith = scope:owner.faith
+				faith = {
+					exists = religious_head
+					religious_head = {
+			 			this = scope:target
+			 		}
+				}
+			}
+		}
+		modifier = { # Realm Priests care about Piety Level
+			add = {
+				add = 5
+				multiply = scope:owner.piety_level
+			}
+			desc = "I_AM_PIOUS"
+			scope:owner.piety_level > 1
+			scope:target = {
+				is_theocratic_lessee = yes
+			}
+		}
+		modifier = { # Realm Priests care about Piety Level
+			add = -50
+			desc = "I_AM_PIOUS"
+			scope:owner.piety_level < 0
+			scope:target = {
+				is_theocratic_lessee = yes
+			}
+		}
+
+		# Thicker Than Water Perk
+		modifier = {
+			add = thicker_than_water_bonus
+			desc = BEFRIEND_THICKER_THAN_WATER_PERK_DESC
+			scope:owner = {
+				has_perk = thicker_than_water_perk
+			}
+			scope:target = {
+				is_close_or_extended_family_of = scope:owner
+			}
+		}
+
+		# Dynasty Kin Personal Scheme Success Chance on Dynasty Perk
+		modifier = {
+			add = kin_legacy_4_success_chance
+			desc = KIN_LEGACY_DESC
+			exists = scope:owner.dynasty
+			scope:owner.dynasty = {
+				has_dynasty_perk = kin_legacy_4
+			}
+			scope:target.dynasty = scope:owner.dynasty
+		}
+
+		# House Personal Scheme Success Chance on Cultural Parameter
+		modifier = {
+			add = cultural_house_personal_scheme_success_chance
+			desc = KIN_PARAMETER_DESC
+			exists = scope:owner.house
+			exists = scope:target.house
+			scope:owner.culture = {
+				has_cultural_parameter = cultural_house_personal_scheme_success_chance
+			}
+			scope:target.house = scope:owner.house
+		}
+
+		#Rival penalty
+		modifier = {
+			add = -20
+			desc = sway_my_rival
+			scope:owner = { has_relation_rival = scope:target }
+		}
+
+		#Family Feud
+		house_feud_sway_scheme_success_modifier = yes
+
+		# Modifiers
+		modifier = {
+			scope:owner = { has_character_modifier = poet_for_diplo_schemes_modifier }
+			desc = poet_for_diplo_schemes_modifier
+			add = 15
+		}
+		# house_head_request_interaction
+		modifier = {
+			add = personal_scheme_variable_list_value
+			scope:owner = {
+				has_variable_list = supporting_personal_schemes
+			}
+			desc = HOUSE_HEAD_SCHEME_SUPPORT_DESC
+		}
+		modifier = {
+			add = -10
+			scope:owner = { has_character_modifier = personal_schemes_distracted_modifier }
+			desc = personal_schemes_distracted_modifier
+		}
+		# Estate
+		modifier = {
+			scope:owner.domicile ?= {
+				has_domicile_parameter = increased_success_personal_schemes_1
+			}
+			add = estate_increased_personal_scheme_success_1_value
+		}
+		modifier = {
+			scope:owner.domicile ?= {
+				has_domicile_parameter = increased_success_personal_schemes_2
+			}
+			add = estate_increased_personal_scheme_success_2_value
+		}
+		modifier = {
+			scope:owner.domicile ?= {
+				has_domicile_parameter = increased_success_personal_schemes_3
+			}
+			add = estate_increased_personal_scheme_success_3_value
+		}
+	}
+
+	# On Actions
+	on_start = {
+		set_variable = {
+			name = apply_countermeasures
+			value = flag:opportunistic
+		}
+	}
+	on_phase_completed = {
+		# Grab our scopes.
+		save_scope_as = scheme
+		scheme_target_character = { save_scope_as = target }
+		scheme_owner = { save_scope_as = owner }
+		#Outcome system by Mathilda Bjarnehed
+		scope:scheme.scheme_owner = {
+			trigger_event = befriend_outcome.0001 #Hidden event rolling success/failure, discover/no discovery and sending on_actions or player choice event
+		}
+	}
+	on_invalidated = {
+		save_scope_as = scheme
+		scheme_target_character = {
+			save_scope_as = target
+		}
+		scheme_owner = {
+			save_scope_as = owner
+		}
+		scope:owner = {
+			# Invalidation due to war.
+			if = {
+				limit = { is_at_war_with = scope:target }
+				trigger_event = befriend_ongoing.0903
+			}
+
+			if = {
+				limit = {
+					scope:target = { is_imprisoned = yes }
+				}
+				trigger_event = {
+					id = befriend_ongoing.0902
+					days = 2
+				}
+			}
+
+			# Invalidation due to death
+			if = {
+				limit = {
+					scope:target = { is_alive = no }
+					NOT = { block_death_event_trigger = { DEAD = scope:target } }
+				}
+				trigger_event = befriend_ongoing.0901
+			}
+		}
+		if = { #Already friends
+			limit = {
+				scope:owner = { has_relation_friend = scope:target }
+				NOT = { scheme_progress = scope:scheme.scheme_phase_duration }
+			}
+			scope:target = { save_scope_as = recipient } #For the message
+			scope:owner = {
+				send_interface_toast = {
+					type = event_toast_effect_neutral
+					title = befriend_invalidated_title
+					left_icon = scope:target
+					custom_tooltip = befriend_already_friend
+				}
+			}
+		}
+		if = {
+			limit = {
+				scope:target = { 
+					NOT = { in_diplomatic_range = scope:owner } 
+				}
+			}
+			scope:owner = {
+				send_interface_toast = {
+					type = event_generic_neutral
+					title = befriend_invalidated_title
+					left_icon = scope:target
+					custom_tooltip = befriend_invalid
+				}
+			}
+		}
+	}
+	on_monthly = {
+		#Fickleness
+		if = {
+			limit = {
+				scheme_target_character = {
+					has_trait = fickle
+					OR = {
+						NOT = { exists = var:recipient_fickleness_scheme }
+						var:recipient_fickleness_scheme >= 30 #Keep within reason.
+						var:recipient_fickleness_scheme <= -30
+					}
+				}
+			}
+			scheme_target_character = {
+				set_variable = {
+					name = recipient_fickleness_scheme
+					value = 10
+				}
+			}
+		}
+		if = {
+			limit = {
+				scheme_target_character = {
+					has_trait = fickle
+					exists = var:recipient_fickleness_scheme
+				}
+			}
+			scheme_target_character = {
+				random_list = {
+					70 = {
+					}
+					15 = {
+						change_variable = {
+							name = recipient_fickleness_scheme
+							add = -5
+						}
+					}
+					15 = {
+						change_variable = {
+							name = recipient_fickleness_scheme
+							add = 5
+						}
+					}
+					25 = {
+						trigger = {
+							var:recipient_fickleness_scheme >= 15
+						}
+						change_variable = {
+							name = recipient_fickleness_scheme
+							add = -10
+						}
+					}
+					25 = {
+						trigger = {
+							var:recipient_fickleness_scheme <= -15
+						}
+						change_variable = {
+							name = recipient_fickleness_scheme
+							add = 10
+						}
+					}
+				}
+			}
+		}
+		#Sending an ongoing event
+		if = {
+			limit = {
+				scheme_owner = { is_available = yes }
+				scheme_target_character = { is_available = yes }
+				player_target_available_for_personal_scheme_ongoing_events_trigger = {
+					OWNER = scope:owner
+					TARGET = scope:target
+				}
+			}
+			# Separate event sets for "Standard" and for a target that dislikes you strongly.
+			if = {
+				limit = {
+					scheme_target_character = {
+						has_relation_rival = scope:owner
+					}
+				}
+				scheme_owner = {
+					trigger_event = { on_action = befriend_rival_ongoing }
+				}
+			}
+			else_if = {
+				limit = {
+					scheme_target_character = {
+						opinion = {
+							target = scope:owner
+							value >= -20
+						}
+					}
+				}
+				scheme_owner = {
+					trigger_event = { on_action = befriend_ongoing }
+				}
+			}
+			else = {
+				scheme_owner = {
+					trigger_event = { on_action = befriend_dislike_ongoing }
+				}
+			}
+		}
+	}
+}

--- a/common/script_values/00_fixpack_values.txt
+++ b/common/script_values/00_fixpack_values.txt
@@ -122,3 +122,32 @@ unop_favour_the_countryside_basques_decision_counties_to_control_current_value =
 		add = 1
 	}
 }
+
+unop_paiza_merchant_distance_modifier_value = {
+	save_temporary_scope_as = merchant_origin_province
+	value = 0
+	if = {
+		limit = { "scope:merchant_origin_province.squared_distance(root.domicile.domicile_location)" <= squared_distance_small }
+		add = 200
+	}
+	else_if = {
+		limit = { "scope:merchant_origin_province.squared_distance(root.domicile.domicile_location)" <= squared_distance_medium }
+		add = 100
+	}
+	else_if = {
+		limit = { "scope:merchant_origin_province.squared_distance(root.domicile.domicile_location)" <= squared_distance_large }
+		add = 50
+	}
+	else_if = {
+		limit = { "scope:merchant_origin_province.squared_distance(root.domicile.domicile_location)" <= squared_distance_huge }
+		add = 20
+	}
+	else_if = {
+		limit = { "scope:merchant_origin_province.squared_distance(root.domicile.domicile_location)" <= squared_distance_almost_massive }
+		add = 10
+	}
+	else_if = {
+		limit = { "scope:merchant_origin_province.squared_distance(root.domicile.domicile_location)" <= squared_distance_massive }
+		add = 5
+	}
+}

--- a/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
+++ b/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
@@ -1505,7 +1505,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Merv
 			trigger = {
 				title:c_bukhara = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1516,6 +1516,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_bukhara.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_bukhara.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_bukhara = {
 				save_scope_as = merchant_origin
 			}
@@ -1523,7 +1527,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Nishapur
 			trigger = {
 				title:c_nishapur = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1534,6 +1538,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_nishapur.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_nishapur.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_nishapur = {
 				save_scope_as = merchant_origin
 			}
@@ -1541,7 +1549,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Khotan
 			trigger = {
 				title:c_khotan = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1552,6 +1560,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_khotan.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_khotan.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_khotan = {
 				save_scope_as = merchant_origin
 			}
@@ -1559,7 +1571,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Wroclaw
 			trigger = {
 				title:c_breslau = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1570,6 +1582,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_breslau.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_breslau.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_breslau = {
 				save_scope_as = merchant_origin
 			}
@@ -1577,7 +1593,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Krakow
 			trigger = {
 				title:c_krakowska = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1588,6 +1604,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_krakowska.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_krakowska.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_krakow = {
 				save_scope_as = merchant_origin
 			}
@@ -1595,7 +1615,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Novgorod
 			trigger = {
 				title:c_novgorod = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1606,6 +1626,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_novgorod.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_novgorod.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_novgorod  = {
 				save_scope_as = merchant_origin
 			}
@@ -1613,7 +1637,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Kyiv
 			trigger = {
 				title:c_kiev = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1624,6 +1648,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_kiev.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_kiev.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_kiev = {
 				save_scope_as = merchant_origin
 			}
@@ -1631,7 +1659,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Baghdad
 			trigger = {
 				title:c_baghdad = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1642,6 +1670,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_baghdad.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_baghdad.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_baghdad = {
 				save_scope_as = merchant_origin
 			}
@@ -1649,7 +1681,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Pisa
 			trigger = {
 				title:c_pisa = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1660,14 +1692,18 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_pisa.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_pisa.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_pisa = {
 				save_scope_as = merchant_origin
 			}
 		}
 		1 = { #Venice
 			trigger = {
-				title:c_baghdad = {
-					development_level >= 30
+				title:c_venezia = { #Unop: Venice
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1676,16 +1712,20 @@ mpo_find_suitable_merchant_effect = {
 				}
 			}
 			modifier = {
-				add = title:c_baghdad.development_level
+				add = title:c_venezia.development_level #Unop: Venice
 			}
-			title:b_baghdad = {
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_venezia.title_province.unop_paiza_merchant_distance_modifier_value
+			}
+			title:b_venezia = { #Unop: Venice
 				save_scope_as = merchant_origin
 			}
 		}
 		1 = { #Cairo
 			trigger = {
 				title:c_cairo = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1696,6 +1736,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_cairo.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_cairo.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_cairo = {
 				save_scope_as = merchant_origin
 			}
@@ -1703,7 +1747,7 @@ mpo_find_suitable_merchant_effect = {
 		1 = { #Genua
 			trigger = {
 				title:c_genoa = {
-					development_level >= 30
+					development_level >= 10 #Unop Increase the chance for other origins
 					NOT = {
 						holder.top_liege = {
 							government_has_flag = government_is_nomadic
@@ -1714,6 +1758,10 @@ mpo_find_suitable_merchant_effect = {
 			modifier = {
 				add = title:c_genoa.development_level
 			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_genoa.title_province.unop_paiza_merchant_distance_modifier_value
+			}
 			title:b_genoa = {
 				save_scope_as = merchant_origin
 			}
@@ -1722,6 +1770,10 @@ mpo_find_suitable_merchant_effect = {
 			#something has to be in constantinople
 			modifier = {
 				add = title:c_byzantion.development_level
+			}
+			#Unop Favor origins closer to root's domicile location
+			modifier = {
+				add = title:c_byzantion.title_province.unop_paiza_merchant_distance_modifier_value
 			}
 			title:b_constantinople = {
 				save_scope_as = merchant_origin

--- a/common/scripted_triggers/00_available_for_events_triggers.txt
+++ b/common/scripted_triggers/00_available_for_events_triggers.txt
@@ -1,0 +1,407 @@
+﻿###TRIGGER LIST
+#is_busy_in_events_unlocalised 						- already in an involved event chain
+#is_in_pseudo_activity_trigger	- character is involved in a pseudo-activity
+#has_contagious_deadly_disease_trigger
+#is_healthy
+#is_available
+#is_available_ai
+#is_available_adult
+#is_available_healthy_adult
+#is_available_ai_adult
+#is_available_healthy_ai_adult
+#is_capable_adult
+#is_capable_adult_ai
+#liege_is_boss_trigger
+#can_select_lifestyle_focus
+#can_marry
+#can_become_concubine
+#is_busy_in_events_localised
+
+# Despite the name, there are rare instances in which these may become visible to the player - if you add to this list, add localization also
+is_busy_in_events_unlocalised = {
+	OR = {
+		has_character_flag = is_in_diplomacy_foreign_special_event
+		has_character_flag = is_in_diplomacy_family_special_event
+		has_character_flag = is_in_diplomacy_majesty_special_event
+		has_character_flag = is_in_martial_special_event
+		has_character_flag = is_in_stewardship_domain_special_event
+		has_character_flag = is_in_stewardship_duty_special_event
+		has_character_flag = is_in_stewardship_wealth_special_event
+		has_character_flag = is_in_intrigue_special_event
+		has_character_flag = is_in_learning_special_event
+		has_character_flag = is_in_task_contract_event_chain
+		has_character_flag = migration_events_1060_rode_ahead
+	}
+}
+
+# For flags that *may* be seen by the player, and thus need to be cloaked in a custom description to look nice.
+is_busy_in_events_localised = {
+	custom_description = {
+		text = "yearly_1010_abducted"
+		NOT = { has_character_flag = yearly_1010_abducted }
+	}
+	custom_description = {
+		text = "yearly_1010_abductor"
+		NOT = { has_character_flag = yearly_1010_abductor }
+	}
+}
+
+has_contagious_deadly_disease_trigger = {
+	OR = {
+		has_trait = bubonic_plague
+		has_trait = smallpox
+		has_trait = typhus
+		has_trait = consumption
+		has_trait = measles
+		has_trait = dysentery
+	}
+}
+
+is_healthy = {
+	custom_tooltip = {
+		text = not_poor_health_tt
+		health >= fine_health
+	}
+	NOR = {
+		has_trait = infirm
+		has_trait = incapable
+		has_trait = wounded_2
+		has_trait = wounded_3
+	}
+	has_contagious_deadly_disease_trigger = no
+}
+
+basic_is_available_ai = {
+	is_alive = yes
+	is_imprisoned = no
+	is_ai = yes
+	is_incapable = no
+	has_contagious_deadly_disease_trigger = no
+}
+
+is_available_allow_travelling = {
+	is_alive = yes
+	is_in_army = no
+	is_imprisoned = no
+	is_incapable = no
+	has_contagious_deadly_disease_trigger = no
+	custom_description = {
+		text = ALREADY_IN_ACTIVITY
+		NOR = {
+			exists = involved_activity
+			has_variable = homage_liege_scope
+			has_character_flag = meditation_character_flag
+			has_character_flag = petition_liege_character_flag
+			has_character_flag = holding_court_character_flag
+			is_being_visited_on_tour_strict = yes
+		}
+	}
+	custom_description = {
+		text = ALREADY_PLANNING_ACTIVITY
+		NOT = { has_character_flag = planning_an_activity }
+	}
+	# Variable set within the adventure inspiration events
+	NOT = { has_variable = gone_adventuring }
+}
+
+is_available = {
+	is_travelling = no
+	is_available_allow_travelling = yes
+}
+
+is_available_travelling = {
+	is_alive = yes
+	is_in_army = no
+	is_imprisoned = no
+	is_incapable = no
+	is_travelling = yes
+	has_contagious_deadly_disease_trigger = no
+	NOT = { has_variable = gone_adventuring }
+	is_busy_in_events_unlocalised = no
+}
+
+is_available_travelling_adult = {
+	is_adult = yes
+	is_available_travelling = yes
+}
+
+is_available_travelling_ai_adult = {
+	is_adult = yes
+	is_ai = yes
+	is_available_travelling = yes
+}
+
+is_physically_able = {
+	is_alive = yes
+	is_imprisoned = no
+	is_incapable = no
+}
+
+is_physically_able_ai = {
+	is_ai = yes
+	is_alive = yes
+	is_imprisoned = no
+	is_incapable = no
+}
+
+is_physically_able_adult = {
+	is_adult = yes
+	is_physically_able = yes
+}
+
+is_physically_able_ai_adult = {
+	is_ai = yes
+	is_adult = yes
+	is_physically_able_adult = yes
+}
+
+is_available_ai = {
+	is_ai = yes
+	is_available = yes
+}
+
+is_available_child = {
+	is_adult = no
+	is_available = yes
+}
+
+is_available_child_allow_travel = {
+	is_adult = no
+	is_available_allow_travelling = yes
+}
+
+is_available_ai_child = {
+	is_adult = no
+	is_available = yes
+	is_ai = yes
+}
+
+is_available_healthy_child = {
+	is_available_child = yes
+	is_healthy = yes
+}
+
+is_available_healthy_ai_child = {
+	is_available_healthy_child = yes
+	is_ai = yes
+}
+
+is_available_adult = {
+	is_adult = yes
+	is_available = yes
+}
+
+is_available_ai_adult = {
+	is_available_adult = yes
+	is_ai = yes
+}
+
+is_available_healthy_adult = {
+	is_available_adult = yes
+	is_healthy = yes
+}
+
+is_available_healthy_ai_adult = {
+	is_available_healthy_adult = yes
+	is_ai = yes
+}
+
+is_available_adult_or_is_commanding = {
+	OR = {
+		is_commanding_army = yes
+		is_available_adult = yes
+	}
+}
+
+is_available_at_peace = {
+	is_at_war = no
+	is_available = yes
+	is_busy_in_events_unlocalised = no
+}
+
+is_available_at_peace_adult = {
+	is_at_war = no
+	is_available_adult = yes
+	is_busy_in_events_unlocalised = no
+}
+
+is_available_at_peace_ai_adult = {
+	is_available_at_peace_adult = yes
+	is_ai = yes
+}
+
+is_available_at_peace_adult_lenient = {
+	is_at_war = no
+	is_available_adult = yes
+}
+
+# Meaning you may be at war, but you're still located in your capital.
+is_available_even_at_war_adult = {
+	is_available_adult = yes
+	is_busy_in_events_unlocalised = no
+}
+
+is_capable_adult = {
+	is_adult = yes
+	is_incapable = no
+}
+
+is_capable_adult_ai = {
+	is_ai = yes
+	is_adult = yes
+	is_incapable = no
+}
+
+can_select_lifestyle_focus = {
+	is_capable_adult = yes
+	is_playable_character = yes
+}
+
+is_not_hostile_towards_root = {
+	NOR = {
+		is_a_faction_member = yes
+		any_scheme = {
+			hostile_scheme_trigger = yes
+			scheme_target_character = root
+		}
+		is_at_war_with = root
+	}
+}
+
+player_target_available_for_personal_scheme_ongoing_events_trigger = {
+	$TARGET$ = {
+		trigger_if = {
+			limit = {
+				is_ai = no
+				$OWNER$ = { is_ruler = no }
+			}
+			is_at_war =  no
+		}
+		trigger_else = {
+			always = yes
+		}
+	}
+}
+
+
+basic_is_valid_for_yearly_events_trigger = {
+	is_playable_character = yes
+	is_imprisoned = no
+	is_incapable = no
+	NOT = { exists = involved_activity }
+	OR = {
+		is_travelling = no
+		is_landless_adventurer = yes
+	}
+	is_busy_in_events_unlocalised = no
+}
+
+is_valid_for_narrow_yearly_events = {
+	is_at_war = no
+	is_commanding_army = no
+	basic_is_valid_for_yearly_events_trigger = yes
+}
+
+is_valid_for_narrow_yearly_events_adult = {
+	is_adult = yes
+	is_valid_for_narrow_yearly_events = yes
+}
+
+is_within_diplo_range = {
+	capital_province ?= {
+		save_temporary_scope_as = my_capital
+		$CHARACTER$.capital_province ?= {
+			squared_distance = {
+				target = scope:my_capital
+				value < 200000
+			}
+		}
+	}
+}
+
+# This trigger checks if a character is a Nomad
+is_nomad = {
+	government_has_flag = government_is_nomadic
+	is_ruler = yes
+}
+
+# This trigger checks if a character is a landed Nomad
+is_landed_nomad = {
+	government_has_flag = government_is_nomadic
+	is_landed = yes
+	is_ruler = yes
+}
+
+# Checks if a character is a landless nomad with a domicile
+is_landless_nomad = {
+	government_has_flag = government_is_nomadic
+	is_landed = no
+	has_domicile = yes
+}
+
+# This trigger checks if a character is a landless adventurer
+is_landless_adventurer = {
+	government_has_flag = government_is_landless_adventurer
+	is_landed = no
+	is_ruler = yes
+}
+
+# This trigger checks if a character is a governor in an admin realm (implying they are landed)
+is_governor = {
+	government_allows = administrative
+	is_landed = yes
+	is_independent_ruler = no
+	highest_held_title_tier >= tier_duchy
+}
+is_governor_or_admin_count = {
+	government_allows = administrative
+	is_landed = yes
+	is_independent_ruler = no
+	highest_held_title_tier >= tier_county
+}
+
+# Checks if a character is a landless house_head within an admin realm
+is_landless_administrative = {
+	government_allows = administrative
+	is_landed = no
+	is_house_head = yes
+	has_domicile = yes
+}
+
+# Checks if a character is either landed or an unlanded house head within an admin realm
+is_landed_or_landless_administrative = {
+	OR = {
+		is_landed = yes
+		is_landless_administrative = yes
+	}
+}
+
+# Checks if a character is either landed, a landless house head within an admin realm, a landless nomad, or a landless adventurer
+is_playable_character = {
+	OR = {
+		is_landed = yes
+		is_landless_administrative = yes
+		is_landless_adventurer = yes
+		is_landless_nomad = yes
+	}
+}
+
+roman_restoration_is_valid_roman_empire_trigger = {
+	is_ai = no
+	OR = {
+		has_title = title:e_byzantium
+		has_title = title:e_roman_empire
+	}
+	OR = {
+		religion = religion:christianity_religion #Either Christian
+		religion = religion:hellenism_religion #Or Hellenic
+	}
+	NOT = { has_ep3_dlc_trigger = yes }
+}
+
+is_eunuch_trigger = {
+	OR = {
+		has_trait = eunuch_1
+		has_trait = beardless_eunuch
+	}
+}

--- a/common/scripted_triggers/00_available_for_events_triggers.txt
+++ b/common/scripted_triggers/00_available_for_events_triggers.txt
@@ -102,6 +102,8 @@ is_available_allow_travelling = {
 	}
 	# Variable set within the adventure inspiration events
 	NOT = { has_variable = gone_adventuring }
+	#Unop Prevent paiza merchants from being selected in events
+	NOT = { has_variable = merchant_var }
 }
 
 is_available = {
@@ -244,6 +246,17 @@ is_available_even_at_war_adult = {
 is_capable_adult = {
 	is_adult = yes
 	is_incapable = no
+
+	#Unop: Prevent paiza merchants from being selected by pool character selectors
+	# To avoid modifying all such selectors, this is done here as this trigger is
+	# used by all of them; the additional checks limit it to the pool character selectors only
+	trigger_if = {
+		limit = {
+			is_pool_character = yes
+			exists = scope:base
+		}
+		NOT = { has_variable = merchant_var }
+	}
 }
 
 is_capable_adult_ai = {

--- a/common/scripted_triggers/00_courtier_guest_management_triggers.txt
+++ b/common/scripted_triggers/00_courtier_guest_management_triggers.txt
@@ -325,7 +325,7 @@ guest_allowed_to_arrive_trigger = {
 		$HOST$ = { highest_held_title_tier <= tier_county }
 	}
 
-	#Unop Prevent paiza merchants from arrving as guests
+	#Unop Prevent paiza merchants from arriving as guests
 	NOT = { has_variable = merchant_var }
 } #Note: this trigger used to contain opinion triggers but then some awful rulers could never get guests because everyone hates them
 

--- a/common/scripted_triggers/00_courtier_guest_management_triggers.txt
+++ b/common/scripted_triggers/00_courtier_guest_management_triggers.txt
@@ -324,6 +324,9 @@ guest_allowed_to_arrive_trigger = {
 		}
 		$HOST$ = { highest_held_title_tier <= tier_county }
 	}
+
+	#Unop Prevent paiza merchants from arrving as guests
+	NOT = { has_variable = merchant_var }
 } #Note: this trigger used to contain opinion triggers but then some awful rulers could never get guests because everyone hates them
 
 
@@ -531,6 +534,8 @@ can_recruit_character_to_court_trigger = {
 					}
 				}
 			}
+			#Unop Disable Invite to Court for paiza merchants
+			has_variable = merchant_var
 		}
 	}
 }
@@ -772,6 +777,8 @@ pool_character_is_pruneable_trigger = {
 			is_ai = no
 		}
 		has_character_flag = easteregg
+		#Unop Prevent pruning paiza merchants
+		has_variable = merchant_var
 	}
 	trigger_if = {
 		limit = {

--- a/common/scripted_triggers/00_courtier_guest_management_triggers.txt
+++ b/common/scripted_triggers/00_courtier_guest_management_triggers.txt
@@ -1,0 +1,829 @@
+﻿###TRIGGER LIST###
+
+#GUEST/COURTIER LEAVING/ARRIVING TRIGGERS:
+#any_child_not_in_traveling_family_trigger
+#any_consort_not_in_traveling_family_trigger
+#courtier_allowed_to_leave_trigger
+#guest_allowed_to_leave_trigger
+#guest_allowed_to_arrive_trigger
+
+#GUEST/COURTIER USEFULNESS:
+#courtier_or_guest_claim_trigger
+#useful_courtier_or_guest_claim_trigger
+#has_useful_potential_spouse_claim_trigger
+#guest_knight_candidate_trigger
+#guest_commander_candidate_trigger
+#guest_vassal_candidate_trigger
+#guest_physician_candidate_trigger
+#guest_male_female_balance_trigger
+#child_available_for_guest_marriage_trigger
+#guest_marriage_candidate_trigger
+
+#POOL CHARACTER TRIGGERS:
+#pool_character_is_pruneable_trigger
+
+
+####GUEST/COURTIER LEAVING/ARRIVING TRIGGERS###
+same_location_and_court_status_as = { # Same location and both are in court / are guests / are pool characters
+	exists = location
+	exists = $CHARACTER$.location
+	location = $CHARACTER$.location
+	OR = {
+		is_in_the_same_court_as = $CHARACTER$
+		trigger_if = {
+			limit = { $CHARACTER$ = { is_pool_guest = yes } }
+			is_pool_guest = yes
+		}
+		trigger_if = {
+			limit = { $CHARACTER$ = { is_pool_character = yes } }
+			is_pool_character = yes
+		}
+	}
+
+}
+
+any_child_not_in_traveling_family_trigger = {
+	save_temporary_scope_as = traveler
+	exists = location
+	any_child = {
+		is_adult = no
+		same_location_and_court_status_as = { CHARACTER = scope:traveler }
+		save_temporary_scope_as = checking_child
+		scope:traveler = {
+			NOT = {
+				any_traveling_family_member = { this = scope:checking_child }
+			}
+		}
+	}
+}
+
+any_consort_not_in_traveling_family_trigger = {
+	save_temporary_scope_as = traveler
+	exists = location
+	any_spouse = {
+		exists = location
+		same_location_and_court_status_as = { CHARACTER = scope:traveler }
+		save_temporary_scope_as = checking_consort
+		scope:traveler = {
+			NOT = {
+				any_traveling_family_member = { this = scope:checking_consort }
+			}
+		}
+	}
+}
+
+
+courtier_allowed_to_leave_trigger = {
+	save_temporary_scope_as = leaving_courtier
+	NOR = {
+		# Not blocked by script
+		has_character_flag = blocked_from_leaving
+		is_councillor_of = scope:liege
+		is_consort_of = scope:liege
+		scope:liege = {
+			player_heir_position = {
+				target = scope:leaving_courtier
+				value <= 2 #Not 1st, 2nd or 3rd player heir (0,1,2)
+			}
+		}
+		has_any_court_position = yes
+		has_relation_lover = scope:liege
+		is_knight_of = scope:liege
+		is_tax_collector_of = scope:liege
+		any_relation = {
+			type = ward
+			OR = {
+				this = scope:liege
+				AND = {
+					is_courtier_of = scope:liege
+					OR = {
+						NOT = { any_close_family_member = { this = scope:leaving_courtier } }
+						any_close_family_member = { this = scope:liege }
+					}
+				}
+			}
+		}
+		any_relation = {
+			type = guardian
+			OR = {
+				this = scope:liege
+				AND = {
+					is_courtier_of = scope:liege
+					OR = {
+						NOT = { any_close_family_member = { this = scope:leaving_courtier } }
+						any_close_family_member = { this = scope:liege }
+					}
+				}
+			}
+		}
+		any_relation = {
+			type = mentor
+			OR = {
+				this = scope:liege
+				AND = {
+					is_courtier_of = scope:liege
+					OR = {
+						NOT = { any_close_family_member = { this = scope:leaving_courtier } }
+						any_close_family_member = { this = scope:liege }
+					}
+				}
+			}
+		}
+		any_relation = {
+			type = student
+			OR = {
+				this = scope:liege
+				AND = {
+					is_courtier_of = scope:liege
+					OR = {
+						NOT = { any_close_family_member = { this = scope:leaving_courtier } }
+						any_close_family_member = { this = scope:liege }
+					}
+				}
+			}
+		}
+		has_epidemic_disease_trigger = yes
+		#Keep daughters/sons for marriages
+		AND = {
+			OR = {
+				is_child_of = scope:liege
+				is_grandchild_of = scope:liege
+				is_great_grandchild_of = scope:liege
+			}
+			NOT = { has_trait = bastard }
+			trigger_if = { #Daughters
+				limit = { is_female = yes }
+				scope:liege = {
+					OR = {
+						has_realm_law = male_only_law
+						has_realm_law = male_preference_law
+					}
+				}
+			}
+			trigger_else = { #Sons
+				scope:liege = {
+					OR = {
+						has_realm_law = female_only_law
+						has_realm_law = female_preference_law
+					}
+				}
+			}
+		}
+		#No children of liege can leave court while children
+		AND = {
+			OR = {
+				is_child_of = scope:liege
+				is_grandchild_of = scope:liege
+				is_great_grandchild_of = scope:liege
+			}
+			is_adult = no
+		}
+		#Claimant won't leave while claim is pressed...
+		scope:liege = { pressing_claim_of_character_trigger = { CHARACTER = scope:leaving_courtier } }
+		#Would be leaving without a child or consort
+		any_child_not_in_traveling_family_trigger = yes
+		any_consort_not_in_traveling_family_trigger = yes
+		#...Or while they have a promise for a claim getting pressed
+		has_character_flag = courtier_staying_for_claim
+
+		#...Or if they're involved in an ongoing event
+		has_variable = stewardship_duty_1062_employer
+
+		#...Or if someone is trying to elope with them
+		any_targeting_scheme = {
+			scheme_type = elope
+		}
+		
+		#Non-dominant spouses don't wander off
+		AND = {
+			is_married = yes
+			any_spouse = {
+				OR = {
+					AND = {
+						exists = liege
+						liege = scope:leaving_courtier.liege
+					}
+					AND = {
+						exists = host
+						exists = scope:leaving_courtier.host
+						liege = scope:leaving_courtier.host
+					}
+					is_in_the_same_court_as = scope:leaving_courtier
+				}
+			}
+			trigger_if = {
+				limit = { is_female = yes }
+				scope:liege = {
+					OR = {
+						has_realm_law = male_only_law
+						has_realm_law = male_preference_law
+					}
+				}
+			}
+			trigger_else = {
+				scope:liege = {
+					OR = {
+						has_realm_law = female_only_law
+						has_realm_law = female_preference_law
+					}
+				}
+			}
+		}
+
+		# Diarchs don't leave their court.
+		is_diarch = yes
+		is_designated_diarch = yes
+		
+		#Shieldmaidens stay till dismissed.
+		has_trait = shieldmaiden
+		
+		# Children taught a lesson won't leave
+		has_character_modifier = mellowed_spirit
+
+		# Courtiers with sponsored inspirations won't leave on their own.
+		AND = {
+			exists = inspiration
+			inspiration = {	exists = inspiration_sponsor }
+		}
+		
+		scope:liege = { government_has_flag = government_is_landless_adventurer }
+		is_obedient_to = scope:liege
+	}
+}
+
+
+guest_allowed_to_leave_trigger = {
+	NOR = {
+		# Not blocked by script
+		has_character_flag = blocked_from_leaving
+		#Agent in a local scheme
+		scope:host = {
+			any_courtier = {
+				any_targeting_scheme = {
+					any_scheme_agent_character = {
+						this = scope:guest
+					}
+				}
+			}
+		}
+		scope:host = {
+			any_targeting_scheme = {
+				any_scheme_agent_character = {
+					this = scope:guest
+				}
+			}
+		}
+		any_child = { # No child can be a known child of the host
+			is_adult = no
+			any_parent = { this = scope:host }
+		}
+		# Diarchs don't leave their court.
+		is_diarch = yes
+		is_designated_diarch = yes
+		#Too sick to travel
+		has_epidemic_disease_trigger = yes
+		#Would be leaving without spouse or underage child
+		any_child_not_in_traveling_family_trigger = yes
+		any_consort_not_in_traveling_family_trigger = yes
+		#Is waiting for inspiration funding
+		exists = inspiration
+	}
+}
+
+guest_allowed_to_arrive_trigger = {
+	trigger_if = {
+		limit = { exists = var:last_visited_ruler }
+		NOT = { var:last_visited_ruler = $HOST$ }
+	}
+	trigger_if = { # Make sure that they're not trying to go back to where they are right now
+		limit = { exists = host }
+		NOT = { host = $HOST$ }
+	}
+	has_epidemic_disease_trigger = no
+	NOT = { has_relation_rival = $HOST$ }
+	#Compatible faiths
+	faith = {
+		save_temporary_scope_as = potential_guest_faith
+		faith_hostility_level = {
+			target = $HOST$.faith
+			value < faith_evil_level
+		}
+	}
+	$HOST$.faith = {
+		faith_hostility_level = {
+			target = scope:potential_guest_faith
+			value < faith_evil_level
+		}
+	}
+	
+	#Isn't too good for host
+	NAND = {
+		OR = {
+			any_claim = { tier = tier_empire }
+			any_close_family_member = { highest_held_title_tier = tier_empire }
+		}
+		$HOST$ = { highest_held_title_tier <= tier_county }
+	}
+} #Note: this trigger used to contain opinion triggers but then some awful rulers could never get guests because everyone hates them
+
+
+#This is a localized trigger for checking that a character do not have a spouse that's employed or has some other circumstance blocking them from being recruited to a court
+can_recruit_character_to_court_trigger = {
+	$RECRUITER$ = { save_temporary_scope_as = recruiter }
+	$RECRUITEE$ = { save_temporary_scope_as = recruitee }
+	scope:recruitee = {
+		bp2_valid_for_standard_interactions_trigger = yes
+		NOR = {
+			custom_description = {
+				text = is_not_wandering_child
+				subject = scope:recruitee
+				AND = {
+					is_adult = no
+					NOT = { is_close_or_extended_family_of = scope:recruiter }
+				}
+			}
+			is_imprisoned = yes
+			is_theocratic_lessee = yes
+			is_diarch = yes
+			trigger_if = {
+				limit = {
+					exists = host
+					NOT = { is_player_heir_of = scope:recruiter }
+				}
+				is_player_heir_of = host
+			}
+			trigger_if = {
+				limit = { exists = host }
+				is_consort_of = host
+			}
+			trigger_if = {
+				limit = { exists = host }
+				host = {
+					pressing_claim_of_character_trigger = { CHARACTER = scope:recruitee }
+				}
+			}
+			trigger_if = {
+				limit = { exists = host }
+				#Are they employed?
+				is_councillor_of = scope:recruitee.host
+				is_knight_of = scope:recruitee.host
+				any_relation = {
+					type = ward
+					OR = {
+						this = scope:recruitee.host
+						is_close_family_of = scope:recruitee.host
+					}
+				}
+				any_relation = {
+					type = guardian
+					OR = {
+						this = scope:recruitee.host
+						is_close_family_of = scope:recruitee.host
+					}
+				}
+				any_relation = {
+					type = mentor
+					OR = {
+						this = scope:recruitee.host
+						is_close_family_of = scope:recruitee.host
+					}
+				}
+				any_relation = {
+					type = student
+					OR = {
+						this = scope:recruitee.host
+						is_close_family_of = scope:recruitee.host
+					}
+				}
+				any_court_position_employer = { this = scope:recruitee.host }
+			}
+			trigger_if = {
+				limit = {
+					scope:recruiter = { is_landless_adventurer = yes }
+				}
+				custom_tooltip = {
+					text = can_recruit_character_to_court_trigger.tt.laamps_invitation_restrictions
+					NOR = {
+						is_player_heir_of = scope:recruiter
+						has_relation_soulmate = scope:recruiter
+						has_relation_best_friend = scope:recruiter
+						is_consort_of = scope:recruiter
+						AND = {
+							is_pool_character = yes
+							OR = {
+								has_relation_friend = scope:recruiter
+								has_relation_lover = scope:recruiter
+								is_close_family_of = scope:recruiter
+							}
+						}
+					}
+				}
+			}
+			
+			#Do they have the "wrong" marriage type and the spouse is employed?
+			custom_description = {
+				text = is_married_matrilineally_and_spouse_is_dominant_partner
+				subject = scope:recruitee
+				any_spouse = {
+					is_female = yes
+					matrilinear_marriage = yes
+					exists = host
+					host = scope:recruitee.host
+					save_temporary_scope_as = spouse
+					OR = { #Is employed in some way
+						is_councillor_of = scope:recruitee.host
+						is_knight_of = scope:recruitee.host
+						any_relation = {
+							type = ward
+							OR = {
+								this = scope:recruitee.host
+								is_close_family_of = scope:recruitee.host
+							}
+						}
+						any_relation = {
+							type = guardian
+							OR = {
+								this = scope:recruitee.host
+								is_close_family_of = scope:recruitee.host
+							}
+						}
+						any_relation = {
+							type = mentor
+							OR = {
+								this = scope:recruitee.host
+								is_close_family_of = scope:recruitee.host
+							}
+						}
+						any_relation = {
+							type = student
+							OR = {
+								this = scope:recruitee.host
+								is_close_family_of = scope:recruitee.host
+							}
+						}
+						scope:spouse = {
+							any_court_position_employer = { this = scope:recruitee.host }
+						}
+					}
+				}
+			}
+			custom_description = {
+				text = is_married_patrilineally_and_spouse_is_dominant_partner
+				subject = scope:recruitee
+				any_spouse = {
+					is_male = yes
+					patrilinear_marriage = yes
+					exists = host
+					host = scope:recruitee.host
+					save_temporary_scope_as = spouse
+					OR = { #Is employed in some way
+						is_councillor_of = scope:recruitee.host
+						is_knight_of = scope:recruitee.host
+						any_relation = {
+							type = ward
+							OR = {
+								this = scope:recruitee.host
+								is_close_family_of = scope:recruitee.host
+							}
+						}
+						any_relation = {
+							type = guardian
+							OR = {
+								this = scope:recruitee.host
+								is_close_family_of = scope:recruitee.host
+							}
+						}
+						any_relation = {
+							type = mentor
+							OR = {
+								this = scope:recruitee.host
+								is_close_family_of = scope:recruitee.host
+							}
+						}
+						any_relation = {
+							type = student
+							OR = {
+								this = scope:recruitee.host
+								is_close_family_of = scope:recruitee.host
+							}
+						}
+						scope:spouse = {
+							any_court_position_employer = { this = scope:recruitee.host }
+						}
+					}
+				}
+			}
+			custom_description = {
+				text = "is_escaped_prisoner"
+				subject = scope:recruitee
+				OR = {
+					has_opinion_modifier = {
+						modifier = attempted_imprisonment_opinion
+						target = scope:recruiter
+					}
+					has_opinion_modifier = {
+						modifier = treasonous_imprison_refusal
+						target = scope:recruiter
+					}
+					AND = {
+						exists = var:escaped_imprisonment_from
+						var:escaped_imprisonment_from = scope:recruiter
+					}
+				}
+			}
+		}
+	}
+}
+
+
+###GUEST/COURTIER USEFULNESS TRIGGERS###
+courtier_or_guest_claim_trigger = {
+	exists = holder
+	NOT = {
+		holder = {
+			OR = {
+				this = $RULER$
+				target_is_liege_or_above = $RULER$
+			}
+		}
+	}
+}
+
+useful_courtier_or_guest_claim_trigger = {
+	courtier_or_guest_claim_trigger = { RULER = $RULER$ }
+	tier < $RULER$.highest_held_title_tier
+	$RULER$ = { is_landed = yes }
+	OR = { #For distance check
+		exists = title_province
+		exists = holder.capital_province
+	}
+	#The higher tier the ruler has, the longer distance is acceptable
+	#We prefer to measure against the title's province, but if there is none, check its holder
+	trigger_if = {
+		limit = { $RULER$ = { highest_held_title_tier = tier_empire } }
+		trigger_if = {
+			limit = { exists = title_province }
+			title_province = { squared_distance = { target = $RULER$.capital_province value <= squared_distance_almost_massive } }
+		}
+		trigger_else = {
+			holder.capital_province = { squared_distance = { target = $RULER$.capital_province value <= squared_distance_almost_massive } }
+		}
+	}
+	trigger_else_if = {
+		limit = { $RULER$ = { highest_held_title_tier = tier_kingdom } }
+		trigger_if = {
+			limit = { exists = title_province }
+			title_province = { squared_distance = { target = $RULER$.capital_province value <= squared_distance_huge } }
+		}
+		trigger_else = {
+			holder.capital_province = { squared_distance = { target = $RULER$.capital_province value <= squared_distance_huge } }
+		}
+	}
+	trigger_else_if = {
+		limit = { $RULER$ = { highest_held_title_tier = tier_duchy } }
+		trigger_if = {
+			limit = { exists = title_province }
+			title_province = { squared_distance = { target = $RULER$.capital_province value <= squared_distance_large } }
+		}
+		trigger_else = {
+			holder.capital_province = { squared_distance = { target = $RULER$.capital_province value <= squared_distance_large } }
+		}
+	}
+	trigger_else = {
+		trigger_if = {
+			limit = { exists = title_province }
+			title_province = { squared_distance = { target = $RULER$.capital_province value <= squared_distance_medium } }
+		}
+		trigger_else = {
+			holder.capital_province = { squared_distance = { target = $RULER$.capital_province value <= squared_distance_medium } }
+		}
+	}
+}
+
+neighboring_useful_courtier_or_guest_claim_trigger = {
+	courtier_or_guest_claim_trigger = { RULER = $RULER$ }
+	tier < $RULER$.highest_held_title_tier
+	exists = $RULER$.capital_province
+	holder = {
+		any_sub_realm_county = {
+			is_neighbor_to_realm = $RULER$		
+		}
+	}
+}
+
+has_useful_potential_spouse_claim_trigger = {
+	any_claim = {
+		pressed = yes
+		exists = holder
+		NOT = {
+			holder = {
+				OR = {
+					this = $RULER$
+					target_is_liege_or_above = $RULER$
+				}
+			}
+		}
+	}
+}
+
+guest_knight_candidate_trigger = {
+	can_be_knight_trigger = { ARMY_OWNER = $HOST$ }
+	age < 60
+	age >= 25
+	prowess > medium_skill_rating
+}
+
+guest_commander_candidate_trigger = {
+	can_be_combatant_based_on_gender_trigger = { ARMY_OWNER = $HOST$ }
+	age < 60
+	age >= 25
+	martial > medium_skill_rating
+}
+
+guest_vassal_candidate_good_traits_trigger = {
+	OR = { #Gives +opinion of liege
+		has_trait = content
+		has_trait = trusting
+		has_trait = humble
+	}
+}
+
+guest_vassal_candidate_bad_traits_trigger = {
+	OR = { #Gives -opinion of liege
+		has_trait = ambitious
+		has_trait = arrogant
+		has_trait = impatient
+	}
+}
+
+guest_vassal_candidate_trigger = {
+	age < 60
+	faith = scope:host.faith
+	culture = scope:host.culture
+	faith = {
+		has_dominant_ruling_gender = prev
+	}
+	guest_vassal_candidate_bad_traits_trigger = no
+	save_temporary_scope_as = vassal_candidate
+	is_eunuch_trigger = no
+	NOR = { #So they don't leave your realm through inheritance
+		any_heir_title = {
+			scope:guest = { is_primary_heir_of = scope:vassal_candidate }
+		}
+		any_child = { is_playable_character = yes }
+		has_trait = devoted
+		has_trait = order_member
+	}
+}
+
+guest_physician_candidate_trigger = {
+	age < 70
+	learning >= decent_skill_rating
+}
+
+guest_male_female_balance_trigger = { #are you interesting enough to get "upbalanced" to make up for lack of available positions due to your gender?
+	is_adult = yes
+	age <= 65
+	is_lowborn = no
+}
+	
+child_available_for_guest_marriage_trigger = {
+	is_married = no
+	is_betrothed = no
+	age >= 10
+	OR = {
+		is_vassal_of = scope:host
+		is_courtier_of = scope:host
+	}
+}	
+
+guest_marriage_candidate_trigger = {
+	save_temporary_scope_as = marriage_candidate
+	OR = {
+		is_male = yes
+		age <= 40
+	}
+	OR = {
+		AND = {
+			is_married = no
+			can_marry_character_trigger = { CHARACTER = scope:host }
+		}
+		scope:host = {
+			any_child = {
+				child_available_for_guest_marriage_trigger = yes
+				can_marry_character_trigger = { CHARACTER = scope:marriage_candidate }
+			}
+		}
+	}
+}
+
+###POOL TRIGGERS###
+is_visitable_relation_trigger = {
+	exists = capital_province
+	capital_province = { local_pool_is_full_trigger = no }
+	NOR = {
+		this = $CHARACTER$.host
+		has_relation_rival = $CHARACTER$
+	}
+	$CHARACTER$ = {
+		NAND = {
+			exists = var:last_visited_ruler
+			var:last_visited_ruler = prev
+		}
+	}
+}
+
+
+###########################
+# POOL CHARACTER TRIGGERS #
+###########################
+
+pool_character_is_pruneable_trigger = {
+	save_temporary_scope_as = pool_prune_check
+	is_adult = yes
+	NOR = {
+		has_trait = peasant_leader
+		has_trait = gallowsbait
+		has_trait = heresiarch
+		has_trait = populist_leader
+		has_trait = adventurer_follower
+		has_trait = adventurer
+		has_trait = historical_character
+		has_character_flag = ai_will_not_convert
+		is_married = yes
+		any_claim = { always = yes }
+		any_child = { is_adult = no }
+		num_of_good_genetic_traits >= 1
+		any_relation = {
+			type = lover
+			is_ruler = yes
+		}
+		any_relation = {
+			type = friend
+			is_ruler = yes
+		}
+		any_close_or_extended_family_member = { is_ruler = yes }
+		AND = { #Belongs to a dynasty with more than 1 member
+			exists = dynasty
+			dynasty = { any_dynasty_member = { NOT = { this = scope:pool_prune_check } } }
+		}
+		any_relation = {
+			type = rival
+			is_ai = no
+		}
+		has_character_flag = easteregg
+	}
+	trigger_if = {
+		limit = {
+			is_lowborn = no
+		}
+		NOR = {
+			diplomacy >= high_skill_rating
+			martial >= high_skill_rating
+			stewardship >= high_skill_rating
+			intrigue >= high_skill_rating
+			learning >= high_skill_rating
+			prowess >= high_skill_rating
+			any_relation = {
+				type = rival
+				is_ruler = yes
+			}
+			culture = {
+				has_cultural_tradition = tradition_diasporic
+			}
+		}
+	}
+}
+
+
+local_pool_is_full_trigger = {
+	number_of_characters_in_pool >= full_pool_size
+}
+
+guest_poet_candidate_trigger = {
+	age < 80
+	age >= 16
+	diplomacy > medium_skill_rating
+}
+
+is_courtier_or_knight_of_root = {
+	OR = {
+		is_courtier_of = root
+		is_knight_of = root
+	}
+}
+
+guest_herder_candidate_trigger = {
+	government_has_flag = government_is_herder
+	has_trait = lifestyle_seasoned_pastor
+	trigger_if = {
+		limit = { root.faith = { has_doctrine = doctrine_gender_male_dominated } }
+		is_male = yes
+	}
+	trigger_if = {
+		limit = { root.faith = { has_doctrine = doctrine_gender_female_dominated } }
+		is_female = yes
+	}
+	age < 45
+	age >= 25
+}

--- a/common/scripted_triggers/02_ep1_scripted_triggers.txt
+++ b/common/scripted_triggers/02_ep1_scripted_triggers.txt
@@ -1,0 +1,400 @@
+﻿#################################################
+# TRIGGER LIST 									#
+#################################################
+# ep1_is_valid_character_for_inspiration_trigger 	- Is the character valid to be used within the inspiration system? Character movement may break if these conditions are not true.
+
+ep1_is_valid_character_for_inspiration_trigger = {
+	is_adult = yes
+	is_imprisoned = no
+	NOT = { exists = inspiration }
+
+	trigger_if = {
+		limit = {
+			OR = {
+				is_pool_guest = yes
+				is_in_pool_at = location
+			}
+		}
+		# For simplicity, inspired characters travel solo for now.
+		any_traveling_family_member = {
+			count = 1
+		}
+	}
+}
+
+ep1_spare_courtier_trigger = { #Used for picking out courtiers in your own court.
+	is_available_healthy_ai_adult = yes
+	is_councillor = no
+	NOR = {
+		is_close_or_extended_family_of = root
+		is_spouse_of = root
+	}
+}
+
+# Court type trait 1 is unlocked by court_grandeur_level 5
+ep1_courtier_valid_for_court_trait_1_trigger = {
+	scope:cgv_value >= cgv_level_threshold_court_type_trait_1
+	NOT = { has_trait = $TYPE$_court }
+	is_adult = yes
+}
+
+# Court type trait 2 is unlocked by court_grandeur_level 8
+ep1_courtier_valid_for_court_trait_2_trigger = {
+	scope:cgv_value >= cgv_level_threshold_court_type_trait_2
+	NOT = { has_trait = $TYPE$_court_2 }
+	has_trait = $TYPE$_court_1
+	is_adult = yes
+}
+
+##############
+# INSPIRATION/ARTIFACT TRIGGERS
+##############
+
+ep1_can_sponsor_inspiration_basic = {
+	scope:inspiration_owner = {
+		is_imprisoned = no
+	}
+}
+
+ep1_is_sponsor_valid_inspiration_basic = {
+	trigger_if = {
+		limit = {
+			exists = scope:inspiration_sponsor
+		}
+		scope:inspiration_owner = {
+			is_courtier_of = scope:inspiration_sponsor
+			is_imprisoned = no
+		}
+	}
+}
+
+ep1_character_had_or_has_inspiration_type_trigger = {
+	OR = {
+		AND = {
+			exists = var:created_artifact_type
+			var:created_artifact_type = flag:$TYPE$
+		}
+		AND = {
+			exists = inspiration
+			inspiration = { has_inspiration_type = $TYPE$_inspiration }
+		}
+	}
+}
+
+ep1_no_artifact_decorations_trigger = {
+	OR = {
+		scope:wealth < 40
+		AND = {
+			exists = scope:inspiration_owner
+			scope:inspiration_owner = {	has_trait = humble }
+		}
+	}
+}
+
+ep1_simple_artifact_decorations_trigger = {
+	scope:wealth >= 5
+	scope:wealth < 70
+}
+
+ep1_advanced_artifact_decorations_trigger = {
+	scope:wealth >= 40
+	scope:wealth < 90
+}
+
+ep1_extravagant_artifact_decorations_trigger = {
+	scope:wealth >= 70
+}
+
+ep1_artifact_durability_lower_equal_percent_trigger = {
+	$PERCENT$ > {
+	 	value = 0
+	 	add = artifact_durability
+	 	divide = artifact_max_durability
+	}
+}
+
+ep1_artifact_durability_higher_equal_percent_trigger = {
+	$PERCENT$ < {
+	 	value = 0
+	 	add = artifact_durability
+	 	divide = artifact_max_durability
+	}
+}
+
+ep1_character_has_court_artifact_trigger = {
+	any_character_artifact = {
+		ep1_artifact_is_court_artifact_trigger = yes
+	}
+}
+
+ep1_artifact_is_court_artifact_trigger = {
+	OR = {
+		artifact_slot_type = wall_big
+		artifact_slot_type = wall_small
+		artifact_slot_type = sculpture
+		artifact_slot_type = book
+		artifact_slot_type = throne
+		artifact_slot_type = pedestal
+	}
+}
+
+
+##############
+# COURT POSITION TRIGGERS
+##############
+
+#Used to see if the scoped character has ANY court position that CHARACTER can hold
+character_can_be_employed_in_a_court_position_trigger = {
+	OR = {
+		AND = {
+			can_employ_court_position_type = court_physician_court_position
+			$CHARACTER$ = { can_be_employed_as = court_physician_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = master_of_horse_court_position
+			$CHARACTER$ = { can_be_employed_as = master_of_horse_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = master_of_hunt_court_position
+			$CHARACTER$ = { can_be_employed_as = master_of_hunt_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = keeper_of_swans_court_position
+			$CHARACTER$ = { can_be_employed_as = keeper_of_swans_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = travel_leader_court_position
+			$CHARACTER$ = { can_be_employed_as = travel_leader_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = court_jester_court_position
+			$CHARACTER$ = { can_be_employed_as = court_jester_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = high_almoner_court_position
+			$CHARACTER$ = { can_be_employed_as = high_almoner_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = seneschal_court_position
+			$CHARACTER$ = { can_be_employed_as = seneschal_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = court_tutor_court_position
+			$CHARACTER$ = { can_be_employed_as = court_tutor_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = cupbearer_court_position
+			$CHARACTER$ = { can_be_employed_as = cupbearer_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = chief_eunuch_court_position
+			$CHARACTER$ = { can_be_employed_as = chief_eunuch_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = antiquarian_court_position
+			$CHARACTER$ = { can_be_employed_as = antiquarian_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = royal_architect_court_position
+			$CHARACTER$ = { can_be_employed_as = royal_architect_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = lady_in_waiting_court_position
+			$CHARACTER$ = { can_be_employed_as = lady_in_waiting_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = court_poet_court_position
+			$CHARACTER$ = { can_be_employed_as = court_poet_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = court_musician_court_position
+			$CHARACTER$ = { can_be_employed_as = court_musician_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = bodyguard_court_position
+			$CHARACTER$ = { can_be_employed_as = bodyguard_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = champion_court_position
+			$CHARACTER$ = { can_be_employed_as = champion_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = food_taster_court_position
+			$CHARACTER$ = { can_be_employed_as = food_taster_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = executioner_court_position
+			$CHARACTER$ = { can_be_employed_as = executioner_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = garuda_court_position
+			$CHARACTER$ = { can_be_employed_as = garuda_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = wet_nurse_court_position
+			$CHARACTER$ = { can_be_employed_as = wet_nurse_court_position }
+		}
+		AND = {
+			can_employ_court_position_type = akolouthos_court_position
+			$CHARACTER$ = { can_be_employed_as = akolouthos_court_position }
+		}
+	}
+}
+
+
+#Used to check if the scoped character can hold any court position
+can_be_employed_in_any_court_position_trigger = {
+	OR = {
+		can_be_employed_as = court_physician_court_position
+		can_be_employed_as = master_of_horse_court_position
+		can_be_employed_as = master_of_hunt_court_position
+		can_be_employed_as = keeper_of_swans_court_position
+		can_be_employed_as = court_jester_court_position
+		can_be_employed_as = high_almoner_court_position
+		can_be_employed_as = seneschal_court_position
+		can_be_employed_as = court_tutor_court_position
+		can_be_employed_as = cupbearer_court_position
+		can_be_employed_as = chief_eunuch_court_position
+		can_be_employed_as = antiquarian_court_position
+		can_be_employed_as = royal_architect_court_position
+		can_be_employed_as = lady_in_waiting_court_position
+		can_be_employed_as = court_poet_court_position
+		can_be_employed_as = court_musician_court_position
+		can_be_employed_as = bodyguard_court_position
+		can_be_employed_as = champion_court_position
+		can_be_employed_as = food_taster_court_position
+		can_be_employed_as = executioner_court_position
+		can_be_employed_as = garuda_court_position
+		can_be_employed_as = travel_leader_court_position
+		can_be_employed_as = wet_nurse_court_position
+		can_be_employed_as = akolouthos_court_position
+	}
+}
+
+##### Hold court
+
+hold_court_8010_county_trigger = {
+	any_title_to_title_neighboring_county = {
+		holder.top_liege = {
+			NOR = {
+				THIS = ROOT
+				is_allied_to = ROOT
+				is_at_war_with = ROOT
+				is_close_or_extended_family_of = ROOT
+				max_military_strength < hold_court_8010_75_strength_value # 75% of ROOT's soldiers
+			}
+		}
+	}
+}
+
+target_of_powerful_faction_trigger = {
+	exists = yes
+	OR = {
+		faction_is_type = liberty_faction
+		faction_is_type = claimant_faction
+	}
+	OR = {
+		faction_power >= faction_power_threshold
+		faction_is_at_war = yes
+	}
+	trigger_if = {
+		limit = { exists = special_character }
+		NOT = { special_character = faction_target.liege }
+	}
+}
+
+province_has_no_holding_trigger = { # province has no holding
+	has_ongoing_construction = no
+	NOR = {
+		has_holding_type = castle_holding
+		has_holding_type = tribal_holding
+		has_holding_type = city_holding
+		has_holding_type = church_holding
+		has_holding_type = herder_holding
+		has_holding_type = nomad_holding
+	}
+}
+
+county_has_all_holding_types = { # county has all three holding types
+	any_county_province = { has_holding_type = castle_holding }
+	any_county_province = { has_holding_type = city_holding }
+	any_county_province = { has_holding_type = church_holding }
+}
+
+county_has_empty_province_trigger = {
+	tier = tier_county
+	any_county_province = { province_has_no_holding_trigger = yes }
+}
+
+county_has_no_city_trigger = { # No city in a county
+	NOT = {
+		any_county_province = { has_holding_type = city_holding }
+	}
+}
+
+county_has_no_church_trigger = { # No church in a county
+	NOT = {
+		any_county_province = { has_holding_type = church_holding }
+	}
+}
+
+##############
+# DECISION TRIGGERS
+##############
+
+order_mass_eviction_decision_evictable_courtier_trigger = {
+	NOR = {
+		is_of_major_or_minor_interest_trigger = { CHARACTER = root }
+		any_close_family_member = {
+			host = root
+			is_of_major_or_minor_interest_trigger = { CHARACTER = root }
+		}
+	}
+}
+
+# For technical reasons, this trigger can't be the same as ep1_decision_0111_list_builder_guts_trigger, but maintains (almost) technical parity with it.
+exoticise_a_grand_hall_decision_list_builder_guts_trigger = {
+	# Is the title presently active?
+	exists = holder
+	# Can the two communicate?
+	holder = {
+		# Filter out anyone who has the right rank but lacks a mechanical royal court.
+		has_royal_court = yes
+		has_dlc_feature = royal_court
+		# Can the two communicate?
+		in_diplomatic_range = root
+	}
+}
+
+##############
+# CHARACTER INTERACTIONS TRIGGERS
+##############
+
+indebt_guest_interaction_basic_checks_trigger = {
+	$ACTOR$ = {
+		# Gotta have a royal court.
+		has_royal_court = yes
+		has_dlc_feature = royal_court
+		# Gotta have maxed servants to help.
+		amenity_level = {
+			type = court_servants
+			value >= max_amenity_level
+		}
+	}
+}
+
+##############
+# BANNER TRIGGERS
+##############
+
+artifact_house_not_owns_or_claims_trigger = {
+	exists = scope:familial_banner
+	NOR = {
+		this = scope:familial_banner.artifact_owner.house
+		has_house_artifact_claim = scope:familial_banner
+	}
+	trigger_if = {
+		limit = { exists = scope:familial_banner.var:banner_dynasty }
+		house_head.dynasty = scope:familial_banner.var:banner_dynasty
+	}
+}

--- a/common/scripted_triggers/02_ep1_scripted_triggers.txt
+++ b/common/scripted_triggers/02_ep1_scripted_triggers.txt
@@ -20,6 +20,9 @@ ep1_is_valid_character_for_inspiration_trigger = {
 			count = 1
 		}
 	}
+
+	#Unop Prevent paiza merchants from becoming inspired
+	NOT = { has_variable = merchant_var }
 }
 
 ep1_spare_courtier_trigger = { #Used for picking out courtiers in your own court.

--- a/events/dlc/mpo/mpo_decisions_events.txt
+++ b/events/dlc/mpo/mpo_decisions_events.txt
@@ -3561,7 +3561,7 @@ scripted_effect send_merchant_on_first_voyage_effect = {
 		value = scope:merchant_origin
 	}
 	start_travel_plan = {
-		destination = var:merchant_employer.location
+		destination = var:merchant_employer.domicile.domicile_location #Unop Use domicile location
 		on_arrival_event = mpo_decisions_events.2140
 		on_arrival_destinations = first
 		return_trip = no
@@ -3643,11 +3643,11 @@ mpo_decisions_events.2140 = {
 				if = {
 					limit = {
 						NOT = {
-							root.location = location
+							root.location = domicile.domicile_location #Unop Use domicile location
 						}
 					}
 					root = {
-						set_location = { location = var:merchant_employer.location }
+						set_location = domicile.domicile_location #Unop Use domicile location
 					}
 				}
 				if = {
@@ -3821,16 +3821,25 @@ mpo_decisions_events.2141 = { #mpo_call_for_merchants_smol_decision initial even
 
 	trigger = {
 		is_available_adult = yes
-		scope:paiza_merchant.location = root.location
+		#Unop Avoid the merchant chasing root
+		#scope:paiza_merchant.location = root.location
 	}
 
 	on_trigger_fail = {
-		scope:paiza_merchant = {
-			set_location = { location = root.location }
-		}
+		#Unop Avoid the merchant chasing root
+		#scope:paiza_merchant = {
+		#	set_location = { location = root.location }
+		#}
 		trigger_event = {
 			id = mpo_decisions_events.2141
 			months = { 2 4 }
+		}
+	}
+
+	#Unop Avoid the merchant chasing root, and use domicile location
+	immediate = {
+		scope:paiza_merchant = {
+			set_location = root.domicile.domicile_location
 		}
 	}
 
@@ -3965,16 +3974,25 @@ mpo_decisions_events.0100 = { #mpo_call_for_merchants_decision initial event
 
 	trigger = {
 		is_available_adult = yes
-		scope:paiza_merchant.location = root.location
+		#Unop Avoid the merchant chasing root
+		#scope:paiza_merchant.location = root.location
 	}
 
 	on_trigger_fail = {
-		scope:paiza_merchant = {
-			set_location = { location = root.location }
-		}
+		#Unop Avoid the merchant chasing root
+		#scope:paiza_merchant = {
+		#	set_location = { location = root.location }
+		#}
 		trigger_event = {
 			id = mpo_decisions_events.0100
 			months = { 2 4 }
+		}
+	}
+
+	#Unop Avoid the merchant chasing root, and use domicile location
+	immediate = {
+		scope:paiza_merchant = {
+			set_location = root.domicile.domicile_location
 		}
 	}
 
@@ -4161,13 +4179,15 @@ mpo_decisions_events.0101 = { #the merchant is back
 
 	trigger = {
 		is_available_adult = yes
-		scope:paiza_merchant.location = root.location
+		#Unop Avoid the merchant chasing root
+		#scope:paiza_merchant.location = root.location
 	}
 
 	on_trigger_fail = {
-		scope:paiza_merchant = {
-			set_location = { location = root.location }
-		}
+		#Unop Avoid the merchant chasing root (moved to immediate)
+		#scope:paiza_merchant = {
+		#	set_location = { location = root.location }
+		#}
 		trigger_event = {
 			id = mpo_decisions_events.0101
 			months = { 2 4 }
@@ -4177,6 +4197,11 @@ mpo_decisions_events.0101 = { #the merchant is back
 	immediate = {
 		mpo_paiza_deal_grade_effect = yes
 		mpo_yurts_paiza_bonuses_effect = yes
+
+		#Unop Avoid the merchant chasing root, and use domicile location
+		scope:paiza_merchant = {
+			set_location = root.domicile.domicile_location
+		}
 	}
 
 
@@ -4461,11 +4486,11 @@ mpo_decisions_events.0102 = {
 				if = {
 					limit = {
 						NOT = {
-							root.location = location
+							root.location = domicile.domicile_location #Unop Use domicile location
 						}
 					}
 					root = {
-						set_location = { location = var:merchant_employer.location }
+						set_location = domicile.domicile_location #Unop Use domicile location
 					}
 				}
 				trigger_event = mpo_decisions_events.0101
@@ -4758,7 +4783,7 @@ mpo_decisions_events.0112 = { #mpo_abuse_authority_paiza_decision consequences d
 						is_ai = yes
 						is_adult = yes
 					}
-					save_scope_as = paiza_abuser_1		
+					save_scope_as = paiza_abuser_1
 				}
 			}
 			random_equipped_character_artifact = {

--- a/events/dlc/mpo/mpo_decisions_events.txt
+++ b/events/dlc/mpo/mpo_decisions_events.txt
@@ -3615,10 +3615,11 @@ mpo_decisions_events.2139 = {
 				}
 			}
 			add_trait = lifestyle_traveler
-			add_gold = {
-				value = root.tiny_gold_value
-				multiply = 21.37
-			}
+			#Unop The same amount of gold is already added in mpo_find_suitable_merchant_effect
+			#add_gold = {
+			#	value = root.tiny_gold_value
+			#	multiply = 21.37
+			#}
 			send_merchant_on_first_voyage_effect = yes
 		}
 	}
@@ -3629,7 +3630,7 @@ mpo_decisions_events.2140 = {
 	hidden = yes
 
 	immediate = {
-		remove_variable = merchant_var # Used only to send the death notification message
+		# remove_variable = merchant_var # Used only to send the death notification message #Unop Only remove the merchant variable after the entire event chain is over
 		save_scope_as = paiza_merchant
 		var:merchant_origin = {
 			save_scope_as = merchant_origin
@@ -4260,6 +4261,8 @@ mpo_decisions_events.0101 = { #the merchant is back
 				target = root
 				gold = root.var:trade_gold_value
 			}
+
+			remove_variable = merchant_var #Unop Remove the merchant variable here
 		}	
 	}
 }

--- a/localization/replace/english/unop_fixed_keys_l_english.yml
+++ b/localization/replace/english/unop_fixed_keys_l_english.yml
@@ -272,3 +272,6 @@
  ra_kurultai_1_desc: "You have a [kurultai|E] [council|E] as a ruler in the [the_great_steppe|E]. \n\nYou might already be familiar with having a Council, but when playing as a [nomad|E] you will have a new type of administrators that will focus more on supporting your [county_fertility|E] growth or [herd|E]."
  # [ROOT.Char.WealthGodName] > [ROOT.Char.GetFaith.WealthGodName]
  hunt.8020.b:0 ""These riches belong to [ROOT.Char.GetFaith.WealthGodName].""
+
+ mpo_call_for_merchants_decision.merchant_will_arrive_generic: "A wealthy foreigner will travel to your court, leading a caravan bound for the well-developed, settled cities. Upon their return, you may receive the following benefits:\n$BULLET_WITH_TAB$[artifact|E] creation materials that unlock the #V $commission_artifact_decision$#! [decision|E]\n$BULLET_WITH_TAB$Armaments for your [horde|E] and [archer_cavalry|E]"
+ mpo_call_for_merchants_decision.merchant_will_arrive: "$mpo_call_for_merchants_decision.merchant_will_arrive_generic$\n$BULLET_WITH_TAB$Around #P 40%#! of your [gold|E] investement\n$BULLET_WITH_TAB$Random [innovation|E] progress"


### PR DESCRIPTION
The "Summon Wealthy Visitors" decisions have a number of issues:

* The merchant is sent traveling to the employer's location, rather than their domicile location. Since there is no availability check in the decision, the employer could be traveling or leading an army at this time.
* Upon arriving, the events check whether the employer is available, and the merchant has arrived in their location. If the latter fails, the merchant is teleported to their location, and the event is re-triggered in 2 to 4 months. However, by the time the event fires the employer can be again in an entirely different place, resulting in the merchant "chasing" the employer sometimes for quite a while.
* The journey takes quite long, so the merchant pool character may not arrive for a number of reasons: arriving as a guest in another court, dying "in an accident" (actually being pruned by the game), being selected by a pool selector as a minor ruler, etc.
* If the merchant dies after the first journey is over, the player won't get notified about their death.
* Even though there is a list of origin cities, there is also a check for `development_level >= 30` which only true for Constantinople at game start, so many players only see Constantinople being selected.
* The Artifact Materials modifier gained after the second journey **disables** the *Commission Artifact* decision rather than enabling it. I guess nobody complained because nobody got that far.
* There are 2 decisions, "Local Offers" and "Paiza" depending on whether the Paiza system is established, for whatever reason with different cooldowns, 8 and 4 years.

I changed the above so that:

* The merchant is sent to the employer's domicile location.
* Upon arriving, if the employer is available, the merchant is immediately teleported to their domicile location (which is the employer's location as well in this case), and the event takes place. If not, the event is re-triggered in 2 to 4 months as before. The merchant will still have to wait until the employer is available, but will not have to chase them so the event will happen sooner.
* The merchant is now prevented from being selected by pool selectors, participating in events, arriving as a guest, being pruned, or becoming inspired, until the second journey is over. Also, if they die for whatever reason, the player will be notified appropriately.
* The development level check has been changed to `development_level >= 10` so most origin cities are now possible at any time.
* Added an additional modifier to origin city selection that make cities closer to root's domicile location more likely to be selected.
* Fixed the Artifact Materials modifier to enable the *Commission Artifact* decision and all its options.
* The cooldown for both decisions is now 4 years.

In addition, I fixed a few other issues that `ck3-tiger` reported in the newly added files.