### PR TITLE
Pharaox fix ck3 tiger errors 5

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -334,6 +334,11 @@ filter = {
 				text = "`councillor_spouse_learning_2603_scope_save_effect` expects scope:spymaster to be set"
 			}
 		}
+		NAND = { # Redefining accessory layouts should be fine, it's happening a lot especially between eras
+			key = duplicate-item
+			text = "accessory variation layout is redefined by another accessory variation layout"
+			file = gfx/portraits/accessory_variations
+		}
 
 		# New in CK3 1.16
 		NAND = { # "scope:recipient.tier_difference(scope:actor)" > 1 seems valid

--- a/common/character_interactions/00_tribal_interactions.txt
+++ b/common/character_interactions/00_tribal_interactions.txt
@@ -450,7 +450,7 @@ support_feudalize_tribal_holding_interaction = {
 			}
 			trigger_else = {
 				custom_description = {
-					text = "feudalize_tribal_holding_interaction_title_not_county_or_below"
+					text = "feudalize_holding_interaction_title_not_county_or_below" #Unop ck3-tiger Fix non-existing trigger localization
 					always = no
 				}
 			}

--- a/common/decisions/dlc_decisions/mpo/mpo_decisions.txt
+++ b/common/decisions/dlc_decisions/mpo/mpo_decisions.txt
@@ -1893,7 +1893,7 @@ mpo_decision_introduce_heir = {
 		}
 		
 		player_heir = {
-			custom_description = {
+			custom_tooltip = { #Unop ck3-tiger Change to custom_tooltip as there is no such trigger localization
 				text = player_heir_num_friends_tt
 				num_of_relation_friend < 3
 			}
@@ -6168,7 +6168,7 @@ confederation_kingdom_decision = {
 	is_valid = {
 		prestige_level >= 3
 		is_independent_ruler = yes
-		custom_description = {
+		custom_tooltip = { #Unop ck3-tiger Change to custom_tooltip as there is no such trigger localization
 			text = confederation_kingdom_decision_vassal_req
 			confederation = {
 				any_confederation_member = {

--- a/common/decisions/dlc_decisions/mpo/mpo_flavor_decision.txt
+++ b/common/decisions/dlc_decisions/mpo/mpo_flavor_decision.txt
@@ -83,7 +83,7 @@ mpo_pleasure_dome_decision = {
                 }
             }
         }
-		#tiger-ignore(key=missing-item) #Unop Using mpo_pleasure_dome_barony_decision_tt works here without any issues
+        #tiger-ignore(key=missing-item) #Unop Using mpo_pleasure_dome_barony_decision_tt works here without any issues
         custom_description_no_bullet = { text = mpo_pleasure_dome_barony_decision_tt }
         
         set_global_variable = {

--- a/common/decisions/dlc_decisions/mpo/mpo_flavor_decision.txt
+++ b/common/decisions/dlc_decisions/mpo/mpo_flavor_decision.txt
@@ -83,6 +83,7 @@ mpo_pleasure_dome_decision = {
                 }
             }
         }
+		#tiger-ignore(key=missing-item) #Unop Using mpo_pleasure_dome_barony_decision_tt works here without any issues
         custom_description_no_bullet = { text = mpo_pleasure_dome_barony_decision_tt }
         
         set_global_variable = {

--- a/common/effect_localization/00_custom_effects.txt
+++ b/common/effect_localization/00_custom_effects.txt
@@ -1,0 +1,124 @@
+﻿custom_seize_title_and_below_de_jure = {
+	global = CUSTOM_SEIZE_TITLE_AND_BELOW_DE_JURE_EFFECT
+	global_past = CUSTOM_SEIZE_TITLE_AND_BELOW_DE_JURE_EFFECT_PAST
+	first = CUSTOM_SEIZE_TITLE_AND_BELOW_DE_JURE_EFFECT_FIRST
+	first_past = CUSTOM_SEIZE_TITLE_AND_BELOW_DE_JURE_EFFECT_FIRST_PAST
+	third = CUSTOM_SEIZE_TITLE_AND_BELOW_DE_JURE_EFFECT_THIRD
+	third_past = CUSTOM_SEIZE_TITLE_AND_BELOW_DE_JURE_EFFECT_THIRD_PAST
+}
+
+custom_seize_title = {
+	global = CUSTOM_SEIZE_TITLE_EFFECT
+	global_past = CUSTOM_SEIZE_TITLE_EFFECT_PAST
+	first = CUSTOM_SEIZE_TITLE_EFFECT_FIRST
+	first_past = CUSTOM_SEIZE_TITLE_EFFECT_FIRST_PAST
+	third = CUSTOM_SEIZE_TITLE_EFFECT_THIRD
+	third_past = CUSTOM_SEIZE_TITLE_EFFECT_THIRD_PAST
+}
+
+feast_main_befriend.2002.because_of_hospitality_tenet = {
+	first = feast_main_befriend.2002.because_of_hospitality_tenet
+}
+
+raise_runestone_decision_warning = {
+	first = raise_runestone_decision_warning
+}
+
+weapon_inspiration_cost_tt = {
+	global = weapon_inspiration_cost_tt
+}
+
+armor_inspiration_cost_tt = {
+	global = armor_inspiration_cost_tt
+}
+
+book_inspiration_cost_tt = {
+	global = book_inspiration_cost_tt
+}
+
+weaver_inspiration_cost_tt = {
+	global = weaver_inspiration_cost_tt
+}
+
+adventure_inspiration_cost_tt = {
+	global = adventure_inspiration_cost_tt
+}
+
+artisan_inspiration_cost_tt = {
+	global = artisan_inspiration_cost_tt
+}
+
+smith_inspiration_cost_tt = {
+	global = smith_inspiration_cost_tt
+}
+
+alchemy_inspiration_cost_tt = {
+	global = alchemy_inspiration_cost_tt
+}
+
+stewardship_haggle_cheap_trinket_tt = {
+	global = stewardship_haggle_cheap_trinket_tt
+}
+
+stewardship_haggle_expensive_trinket_tt = {
+	global = stewardship_haggle_expensive_trinket_tt
+}
+
+stewardship_haggle_helpful_trinket_tt = {
+	global = stewardship_haggle_helpful_trinket_tt
+}
+
+fp2_struggle_hostility_list_tt = { # Pick one or both of the following for FP2 Hositility ending
+	global = fp2_struggle_hostility_list_tt
+	first = fp2_struggle_hostility_list_tt
+}
+
+fp2_struggle_secure_iberian_foothold_list_tt = {
+	global = fp2_struggle_secure_iberian_foothold_list_tt
+}
+
+fp2_struggle_house_tt = {
+	global = fp2_struggle_house_tt
+	first = fp2_struggle_house_tt
+}
+
+murder_outcome_murdered_rival_tt = {
+	global = murder_outcome_murdered_rival_tt
+}
+
+active_unity_level_description_tt = {
+	global = active_unity_level_description_tt
+}
+
+ep2_tournament_maysir_tt = {
+	global = ep2_tournament_maysir_tt
+}
+
+admin_confirmation_decision_tt_if_accepted = {
+	global = admin_confirmation_decision.tt.if_accepted
+	first = admin_confirmation_decision.tt.if_accepted
+}
+
+mpo_gok_war_of_submission_victory_tt = {
+	global = mpo_gok_war_of_submission_victory_tt
+	first = mpo_gok_war_of_submission_victory_tt
+}
+
+mpo_gok_war_of_submission_will_happen_tt = {
+	global = mpo_gok_war_of_submission_will_happen_tt
+	first = mpo_gok_war_of_submission_will_happen_tt
+}
+mpo_gok_war_of_submission_defeat_tt = {
+	global = mpo_gok_war_of_submission_defeat_tt
+	first = mpo_gok_war_of_submission_defeat_tt
+}
+
+gok_gov_switch_options_tt = {
+	global = gok_gov_switch_options_tt
+	first = gok_gov_switch_options_tt
+}
+
+gok_gov_if_super_nomadic_tt = {
+	global = gok_gov_if_super_nomadic_tt
+	first = gok_gov_if_super_nomadic_tt
+}

--- a/gfx/portraits/portrait_modifiers/00_custom_hair.txt
+++ b/gfx/portraits/portrait_modifiers/00_custom_hair.txt
@@ -510,7 +510,7 @@ custom_hair = {
 
 	add_accessory_modifiers = {
 		gene = hairstyles
-		template = byzantine_hairstyles
+		template = byzantine_hairstyles_afro #Unop ck3-tiger Fix missing hairstyle template
 
 		weight = {
 			base = 0
@@ -520,7 +520,29 @@ custom_hair = {
 
 	add_accessory_modifiers = {
 		gene = hairstyles
-		template = sub_saharan_hairstyles
+		template = sub_saharan_hairstyles_wavy #Unop ck3-tiger Fix missing hairstyle template
+
+		weight = {
+			base = 0
+			portrait_african_clothing_modifier = yes
+		}
+	}
+
+	#Unop ck3-tiger Add modifiers for sub_saharan_hairstyles_curly hairstyle template
+	add_accessory_modifiers = {
+		gene = hairstyles
+		template = sub_saharan_hairstyles_curly
+
+		weight = {
+			base = 0
+			portrait_african_clothing_modifier = yes
+		}
+	}
+
+	#Unop ck3-tiger Add modifiers for sub_saharan_hairstyles_straight hairstyle template
+	add_accessory_modifiers = {
+		gene = hairstyles
+		template = sub_saharan_hairstyles_straight
 
 		weight = {
 			base = 0
@@ -530,7 +552,7 @@ custom_hair = {
 
 	add_accessory_modifiers = {
 		gene = hairstyles
-		template = indian_hairstyles
+		template = indian_hairstyles_afro #Unop ck3-tiger Fix missing hairstyle template
 
 		weight = {
 			base = 0
@@ -540,7 +562,7 @@ custom_hair = {
 
 	add_accessory_modifiers = {
 		gene = hairstyles
-		template = northern_hairstyles
+		template = northern_hairstyles_afro #Unop ck3-tiger Fix missing hairstyle template
 
 		weight = {
 			base = 0
@@ -550,7 +572,7 @@ custom_hair = {
 
 	add_accessory_modifiers = {
 		gene = hairstyles
-		template = steppe_hairstyles
+		template = steppe_hairstyles_afro #Unop ck3-tiger Fix missing hairstyle template
 
 		weight = {
 			base = 0


### PR DESCRIPTION
Fix ck3-tiger errors in recently added files.

For hairstyles, I believe we should replace the missing templates with the `_afro` ones, and only for sub-saharan add all except `_afro`. In this way, we would be adding modifiers for all templates that actually exist.

`ck3-tigger` now supports suppressing errors via comments. I used this in one place where I verified that the error is a false positive. If you agree, we could use this style for suppressing such errors in the future as well.