### PR TITLE
Fix "Offer Courtier" and "Offer Concubine" for LAAMPs

### DIFF
--- a/common/character_interactions/00_marriage_interactions.txt
+++ b/common/character_interactions/00_marriage_interactions.txt
@@ -3218,6 +3218,19 @@ offer_concubine = {
 				allowed_more_concubines = yes
 			}
 		}
+		#Unop Limit range for landless adventurers
+		trigger_if = {
+			limit = {
+				scope:actor = {
+					is_landless_adventurer = yes
+				}
+			}
+			#Has to be used instead of diplo range checks in laamp to landed interactions
+			ep3_laamp_diplo_range_trigger = {
+				TARGET = scope:recipient
+				LAAMP = scope:actor
+			}
+		}
 	}
 
 	can_be_picked = {

--- a/common/character_interactions/00_tributary_interactions.txt
+++ b/common/character_interactions/00_tributary_interactions.txt
@@ -1303,6 +1303,19 @@ offer_courtier_interaction = {
 				}
 			}
 		}
+		#Unop Limit range for landless adventurers
+		trigger_if = {
+			limit = {
+				scope:actor = {
+					is_landless_adventurer = yes
+				}
+			}
+			#Has to be used instead of diplo range checks in laamp to landed interactions
+			ep3_laamp_diplo_range_trigger = {
+				TARGET = scope:recipient
+				LAAMP = scope:actor
+			}
+		}
 	}
 
 	can_be_picked = {


### PR DESCRIPTION
The interactions "Offer Courtier" (newly introduced in 1.16) and "Offer Concubine" (existing before 1.16) can be sent by landless adventurers to rulers in their diplo range. I believe this is an omission, these interactions should be restricted only to nearby rulers, similarly to most other interactions when the actor is a landless adventurers.