### PR TITLE
Fix "Demand Conversion" hook not increasing acceptance for LAAMPs

### DIFF
--- a/common/scripted_modifiers/00_religion_scripted_modifiers.txt
+++ b/common/scripted_modifiers/00_religion_scripted_modifiers.txt
@@ -1,0 +1,537 @@
+﻿#Scripted Modifiers based on a character's Religion or Faith.
+religion_scaled_virtuous_traits_modifier = {
+	modifier = {
+		add = {
+			add = $BASE_VALUE$
+			multiply = $CHARACTER$.num_virtuous_traits
+		}
+		$CHARACTER$ = {
+			num_virtuous_traits > 0
+		}
+	}
+}
+
+religion_scaled_sinful_traits_modifier = {
+	modifier = {
+		add = {
+			add = $BASE_VALUE$
+			multiply = $CHARACTER$.num_sinful_traits
+		}
+		$CHARACTER$ = {
+			num_sinful_traits > 0
+		}
+	}
+}
+
+religion_demand_conversion_default_modifier = {
+	opinion_modifier = {
+		opinion_target = scope:actor
+		who = scope:recipient
+		multiplier = {
+			value = 1
+			if = {
+				limit = {
+					scope:actor = {
+						is_landless_adventurer = yes
+					}
+				}
+				add = -0.5
+			}
+		}
+	}
+
+	modifier = {
+		desc = ASK_FOR_CONVERSION_RECIPIENT_LEARNING
+		add = {
+			value = scope:actor.learning
+			subtract = scope:recipient.learning
+			if = {
+				limit = {
+					scope:actor.learning > scope:recipient.learning
+					scope:actor = {
+						is_landless_adventurer = yes
+						has_perk = defender_of_the_faith_perk
+					}
+				}
+				multiply = 2
+			}
+		}
+	}
+
+	#modifier = {
+	#	desc = ASK_FOR_CONVERSION_ACTOR_LEARNING
+	#	add = {
+	#		value = scope:actor.learning
+	#		multiply = 5
+	#	}
+	#}
+	modifier = {
+		desc = SCHEME_WEAK_HOOK_USED
+		add = 50
+		scope:hook = yes
+		scope:actor = { NOT = { is_landless_adventurer = yes } }
+	}
+	modifier = {
+		desc = RELIGIOUS_HEAD_INTERACTION_SAVIOR
+		add = 30
+		scope:actor = {
+			has_trait = savior
+		}
+	}
+	modifier = {
+		desc = RELIGIOUS_HEAD_INTERACTION_DIVINE_BLOOD
+		add = 15
+		scope:actor = {
+			has_trait = divine_blood
+		}
+	}
+	modifier = {
+		desc = ASK_FOR_CONVERSION_RECIPIENT_IS_STUBBORN
+		add = -15
+		scope:recipient = {
+			has_trait = stubborn
+		}
+	}
+	modifier = {
+		desc = ASK_FOR_CONVERSION_RECIPIENT_IS_FICKLE
+		add = 10
+		scope:recipient = {
+			has_trait = fickle
+		}
+	}
+	modifier = {
+		desc = ASK_FOR_CONVERSION_RECIPIENT_IS_ZEALOUS
+		add = -100
+		scope:recipient = {
+			has_trait = zealous
+		}
+	}
+	modifier = {
+		desc = ASK_FOR_CONVERSION_RECIPIENT_IS_NOT_CYNICAL
+		add = -50
+		scope:actor = {
+			NAND = {
+				is_landless_adventurer = yes
+				has_perk = defender_of_the_faith_perk
+			}
+		}
+		scope:recipient = {
+			NOR = { 
+				has_trait = zealous
+				has_trait = cynical 
+			}
+		}
+	}
+	modifier = {
+		desc = ASK_FOR_CONVERSION_RECIPIENT_IS_HERESIARCH
+		add = -100
+		scope:recipient = {
+			has_trait = heresiarch
+		}
+	}
+
+	modifier = {
+		desc = ASK_FOR_CONVERSION_RECIPIENT_FERVOR
+		scope:actor.faith.fervor != scope:recipient.faith.fervor
+		add = {
+			value = scope:actor.faith.fervor
+			subtract = scope:recipient.faith.fervor
+			if = {
+				limit = {
+					scope:actor = {
+						is_landless_adventurer = yes
+					}
+				}
+				multiply = 0.5
+			}
+		}
+	}
+
+	# modifier = {
+	# 	desc = ASK_FOR_CONVERSION_TAQIYA
+	# 	trigger = {
+	# 		scope:recipient = {
+	# 			target_is_liege_or_above = scope:actor
+	# 		}
+	# 		scope:recipient.faith = {
+	# 			religion = religion:islam_religion
+	# 			has_doctrine_parameter = sanctioned_false_conversion
+	# 		}
+	# 	}
+	# 	add = -20
+	# }
+
+	# modifier = {
+	# 	desc = ASK_FOR_CONVERSION_SANCTIONED_FALSE_CONVERSION
+	# 	trigger = {
+	# 		scope:recipient = {
+	# 			target_is_liege_or_above = scope:actor
+	# 		}
+	# 		scope:recipient.faith = {
+	# 			NOT = { religion = religion:islam_religion }
+	# 			has_doctrine_parameter = sanctioned_false_conversion
+	# 		}
+	# 	}
+	# 	add = -20
+	# }
+
+	modifier = {
+		desc = ASK_FOR_CONVERSION_ADAPTIVENESS
+		trigger = {
+			scope:recipient = {
+				target_is_liege_or_above = scope:actor
+			}
+			scope:recipient.faith = {
+				has_doctrine_parameter = tenet_adaptive_conversion_resistance
+			}
+		}
+		add = -20
+	}
+
+	modifier = {
+		desc = ASK_FOR_CONVERSION_DECLINING_IS_A_CRIME
+		trigger = {
+			scope:recipient = {
+				target_is_liege_or_above = scope:actor
+			}
+			scope:actor = {
+				refusing_conversion_is_crime_trigger = {
+					CHARACTER = scope:recipient
+				}
+			}
+		}
+		add = 50
+	}
+		
+	modifier = {
+		add = intimidated_halved_reason_value
+		scope:actor = {
+			is_landless_adventurer = no
+		}
+		scope:recipient = {
+			has_dread_level_towards = {
+				target = scope:actor
+				level = 1
+			}
+		}
+		desc = INTIMIDATED_REASON
+	}
+	modifier = {
+		add = cowed_halved_reason_value
+		scope:actor = {
+			is_landless_adventurer = no
+		}
+		scope:recipient = {
+			has_dread_level_towards = {
+				target = scope:actor
+				level = 2
+			}
+		}
+		desc = COWED_REASON
+	}
+
+	modifier = {
+		add = 50
+		scope:recipient = {
+			exists = dynasty
+			dynasty = { has_dynasty_perk = fp1_adventure_legacy_3 }
+		}
+		desc = FP1_ADVENTURE_LEGACY_3_REASON
+	}
+
+	modifier = {
+		add = 20
+		scope:actor = {
+			exists = dynasty
+			dynasty = { has_dynasty_modifier = fp3_rekindler_of_iran_modifier }
+		}
+		desc = fp3_rekindler_of_iran_modifier_reason
+	}
+
+	modifier = { # Cultural Tradition, harder to convert
+		add = -50
+		scope:recipient = {
+			culture = {
+				has_cultural_parameter = harder_to_convert_character_faith
+			}
+		}
+		desc = CULTURE_HARD_TO_CONVERT_REASON
+	}
+	modifier = {
+		add = {
+			value = scope:recipient.piety_level
+			multiply = -10
+		}
+		scope:recipient = {
+			piety_level > 1
+		}
+		desc = ASK_FOR_CONVERSION_RECIPIENT_IS_PIOUS
+	}
+
+	modifier = {
+		add = -150
+		scope:recipient= {
+			government_allows = administrative
+			top_liege = {
+				government_allows = administrative
+				government_allows = state_faith
+				exists = primary_title.state_faith
+			}
+			faith = top_liege.primary_title.state_faith
+		}
+		desc = EP3_STATE_FAITH_CONVERSION
+	}
+	modifier = {
+		add = 100
+		scope:recipient= {
+			government_allows = administrative
+			top_liege = {
+				government_allows = administrative
+				government_allows = state_faith
+				exists = primary_title.state_faith
+			}
+			faith != top_liege.primary_title.state_faith
+		}
+		desc = EP3_STATE_FAITH_CONVERSION_NEG
+	}
+	modifier = {
+		add = 25
+		exists = scope:influence_send_option
+		scope:influence_send_option = yes
+		desc = INFLUENCE_INTERACTION_ACCEPTANCE_SEND_OPTION
+	}
+	modifier = {
+		desc = ASK_FOR_CONVERSION_RECIPIENT_WILL_NOT_ACCEPT
+		add = -1500
+		scope:recipient = {
+			has_character_flag = ai_will_not_convert
+		}
+	}
+}
+
+# If a character is asked to convert, will they practice their old faith in secret?
+religion_adopt_secret_faith_modifier = {
+	# Honest characters are OK with keeping a secret faith if that faith condones false conversions
+	modifier = {
+		$TARGET$ = { has_trait = honest }
+		$FAITH$ = {
+			NOT = { has_doctrine_parameter = sanctioned_false_conversion }
+		}
+		add = -50
+		desc = "SCHEME_TRAIT_HONEST"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = craven }
+		add = -30
+		desc = "SCHEME_TRAIT_CRAVEN"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = brave }
+		$FORCED$ = yes
+		add = 15
+		desc = "SCHEME_TRAIT_BRAVE"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = zealous }
+		$FORCED$ = yes
+		desc = "SCHEME_TRAIT_ZEALOUS"
+		add = 30
+	}
+	modifier = {
+		$TARGET$ = { has_trait = zealous }
+		$FORCED$ = no
+		add = -50
+		desc = "SCHEME_TRAIT_ZEALOUS"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = cynical }
+		$FORCED$ = yes
+		add = -30
+		desc = "SCHEME_TRAIT_CYNICAL"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = cynical }
+		$FORCED$ = no
+		add = -10
+		desc = "SCHEME_TRAIT_CYNICAL"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = stubborn }
+		$FORCED$ = yes
+		add = 10
+		desc = "SCHEME_TRAIT_STUBBORN"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = stubborn }
+		$FORCED$ = no
+		add = -15
+		desc = "SCHEME_TRAIT_STUBBORN"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = fickle }
+		$FORCED$ = no
+		add = 10
+		desc = "SCHEME_TRAIT_FICKLE"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = fickle }
+		$FORCED$ = yes
+		add = -15
+		desc = "SCHEME_TRAIT_FICKLE"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = paranoid }
+		add = -30
+		desc = "SCHEME_TRAIT_PARANOID"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = devoted }
+		$FORCED$ = yes
+		add = 15
+		desc = "SCHEME_TRAIT_DEVOTED"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = devoted }
+		$FORCED$ = no
+		add = -30
+		desc = "SCHEME_TRAIT_DEVOTED"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = order_member }
+		$FORCED$ = yes
+		add = 30
+		desc = "SCHEME_TRAIT_ORDER_MEMBER"
+	}
+	modifier = {
+		$TARGET$ = { has_trait = order_member }
+		$FORCED$ = no
+		add = -30
+		desc = "SCHEME_TRAIT_ORDER_MEMBER"
+	}
+	modifier = {
+		$TARGET$ = { has_intrigue_lifestyle_trait_trigger = yes }
+		desc = "SCHEME_IS_A_SCHEMER"
+		add = 10
+	}
+	modifier = {
+		$FAITH$ = { has_doctrine_parameter = sanctioned_false_conversion }
+		$TARGET$ = {
+			NOT = { has_trait = cynical }
+		}
+		$FORCED$ = yes
+		desc = ASK_FOR_CONVERSION_SANCTIONED_FALSE_CONVERSION
+		add = 50
+	}
+	modifier = {
+		$FAITH$ = { has_doctrine_parameter = sanctioned_false_conversion }
+		$TARGET$ = {
+			NOT = { has_trait = cynical }
+		}
+		$FORCED$ = no
+		desc = ASK_FOR_CONVERSION_SANCTIONED_FALSE_CONVERSION
+		add = 30
+	}
+	modifier = {
+		$TARGET$ = { has_trait = trusting }
+		$FORCED$ = no
+		desc = "SCHEME_TRAIT_TRUSTING"
+		add = 10
+	}
+}
+
+sun_trial_death_modifier = {
+	modifier = {
+		add = {
+			if = {
+				limit = { health <= fine_health }
+				value = health
+				subtract = fine_health
+				multiply = -10 # Since number will be negative, we have to flip it to increase the death chance.
+			}
+		}
+	}
+	modifier = {
+		add = {
+			if = {
+				limit = {
+					imprisoner = {
+						capital_province = {
+							OR = {
+								terrain = desert
+								terrain = desert_mountains
+							}
+						}
+					}
+				}
+				value = 100 # 85% base chance of death in the desert.
+			}
+			else_if = {
+				limit = {
+					imprisoner = {
+						capital_province = {
+							OR = {
+								terrain = mountains
+								terrain = drylands
+								terrain = steppe
+								terrain = jungle
+							}
+						}
+					}
+				}
+				value = 50 # 80% base chance of death in the barren or dangerous terrain.
+			}
+		}
+	}
+}
+
+sun_trial_survival_modifier = {
+	modifier = {
+		add = {
+			if = {
+				limit = { health > fine_health }
+				value = health
+				subtract = fine_health
+				multiply = 10
+			}
+		}
+	}
+	modifier = {
+		add = {
+			if = {
+				limit = {
+					imprisoner = {
+						capital_province = {
+							OR = {
+								terrain = farmlands
+								terrain = hills
+								terrain = plains
+								terrain = floodplains
+								terrain = wetlands
+								terrain = oasis
+							}
+						}
+					}
+				}
+				value = 100 # Likely to survive in these areas
+			}
+			else_if = {
+				limit = {
+					imprisoner = {
+						capital_province = {
+							OR = {
+								terrain = forest
+								terrain = jungle
+								terrain = taiga
+							}
+						}
+					}
+				}
+				value = 80 # Slightly lower chance of surviving in these areas
+			}
+		}
+	}
+	modifier = {
+		has_trait = stubborn
+		add = 10
+	}
+}

--- a/common/scripted_modifiers/00_religion_scripted_modifiers.txt
+++ b/common/scripted_modifiers/00_religion_scripted_modifiers.txt
@@ -69,7 +69,7 @@ religion_demand_conversion_default_modifier = {
 		desc = SCHEME_WEAK_HOOK_USED
 		add = 50
 		scope:hook = yes
-		#Unop Spending a hook as a LAAMP increases the acceptance, unless you are attempting to convert a ruler using the
+		#Unop Spending a hook as a LAAMP increases the acceptance, unless you are attempting to convert a ruler
 		# who is not your house member (e.g. via the "Attempt to Convert" interaction)
 		#scope:actor = { NOT = { is_landless_adventurer = yes } }
 		trigger_if = {

--- a/common/scripted_modifiers/00_religion_scripted_modifiers.txt
+++ b/common/scripted_modifiers/00_religion_scripted_modifiers.txt
@@ -69,7 +69,23 @@ religion_demand_conversion_default_modifier = {
 		desc = SCHEME_WEAK_HOOK_USED
 		add = 50
 		scope:hook = yes
-		scope:actor = { NOT = { is_landless_adventurer = yes } }
+		#Unop Spending a hook as a LAAMP increases the acceptance, unless you are attempting to convert a ruler using the
+		# who is not your house member (e.g. via the "Attempt to Convert" interaction)
+		#scope:actor = { NOT = { is_landless_adventurer = yes } }
+		trigger_if = {
+			limit = {
+				scope:actor = {
+					is_landless_adventurer = yes
+				}
+				scope:recipient = {
+					is_ruler = yes
+				}
+			}
+			scope:actor = {
+				is_house_head = yes
+				house = scope:recipient.house
+			}
+		}
 	}
 	modifier = {
 		desc = RELIGIOUS_HEAD_INTERACTION_SAVIOR


### PR DESCRIPTION
I noticed that if you use the "Demand Conversion" interaction on courtiers as a landless adventurer, you can spend a hook if you have one, but this doesn't increase the acceptance at all. I found out that this is explicitly disallowed in `religion_demand_conversion_default_modifier`.

From my perspective, this doesn't make sense. LAs should be able to spend a hook and get the benefits if they are demanding conversion from their own followers, or demanding conversion from house members as the house head. The only case where this check makes sense is in the context of the "Attempt to Convert" interaction (attempting to convert any ruler if you have a certain perk), because they are already getting a (smaller) benefit in the interaction itself.

I modified the above modifier accordingly.