### PR TITLE
Avoid changing prepare_travels_modifier incompatibly

### DIFF
--- a/common/modifiers/00_court_position_modifiers.txt
+++ b/common/modifiers/00_court_position_modifiers.txt
@@ -120,7 +120,19 @@ experimental_brew_small_health_positive_modifier = {
 
 prepare_travels_modifier = {
 	icon = travel
-	#Unop Add prepare_travels_modifier to the travel owner make it scale properly
+	travel_safety = 1
+	travel_speed = 1
+
+	scale = {
+		value = prepare_travels_modifier_value
+		desc = prepare_travels_modifier_scale_desc
+		display_mode = scaled
+	}
+}
+
+#Unop Modifier to be added to the travel owner so that it scales properly
+unop_prepare_travels_character_modifier = {
+	icon = travel
 	character_travel_safety = 1
 	character_travel_speed = 1
 

--- a/common/on_action/travel_on_actions.txt
+++ b/common/on_action/travel_on_actions.txt
@@ -1232,7 +1232,7 @@ on_travel_plan_start = {
 				has_variable = prepare_travels_value
 				var:prepare_travels_value >= 1
 			}
-			#Unop Add prepare_travels_modifier to the travel owner to make it scale properly
+			#Unop Add unop_prepare_travels_character_modifier to the travel owner so that it scales properly
 			#current_travel_plan = {
 			#	set_variable = {
 			#		name = prepare_travels_modifier_value
@@ -1244,7 +1244,7 @@ on_travel_plan_start = {
 				name = prepare_travels_modifier_value
 				value = root.var:prepare_travels_value
 			}
-			add_character_modifier = prepare_travels_modifier
+			add_character_modifier = unop_prepare_travels_character_modifier
 			remove_variable = prepare_travels_value
 		}
 	}
@@ -1563,12 +1563,12 @@ on_travel_plan_complete = {
 			trigger_event = laamp_base_learning_contract_events.4017
 		}
 
-		#Unop Remove prepare_travels_modifier from the travel owner
+		#Unop Remove unop_prepare_travels_character_modifier from the travel owner
 		if = {
 			limit = {
-				has_character_modifier = prepare_travels_modifier
+				has_character_modifier = unop_prepare_travels_character_modifier
 			}
-			remove_character_modifier = prepare_travels_modifier
+			remove_character_modifier = unop_prepare_travels_character_modifier
 			remove_variable = prepare_travels_modifier_value
 		}
 	}
@@ -1657,12 +1657,12 @@ on_travel_plan_abort = {
 		# Invalidating travels to a Nomadic Settlement Contract
 		mpo_invalidating_settlement_contract_effect = yes
 
-		#Unop Remove prepare_travels_modifier from the travel owner
+		#Unop Remove unop_prepare_travels_character_modifier from the travel owner
 		if = {
 			limit = {
-				has_character_modifier = prepare_travels_modifier
+				has_character_modifier = unop_prepare_travels_character_modifier
 			}
-			remove_character_modifier = prepare_travels_modifier
+			remove_character_modifier = unop_prepare_travels_character_modifier
 			remove_variable = prepare_travels_modifier_value
 		}
 	}

--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -230,3 +230,8 @@
  obedience_value_loyal_soldiers:0 "From [traditions|E]"
  # Mostly a copy of special_contract_march_border_trigger
  unop_special_contract_march_border_trigger:0 "[unop_vassal.GetName] border a foreign [realm|E]"
+
+ # New modifier similar to prepare_travels_modifier, but added to the travel owner so that it scales properly
+ unop_prepare_travels_character_modifier: "$prepare_travels_modifier$"
+ unop_prepare_travels_character_modifier_desc: "$prepare_travels_modifier_desc$"
+ unop_prepare_travels_character_modifier_scale_desc: "$prepare_travels_modifier_scale_desc$"


### PR DESCRIPTION
Correct my previous fix introduced with #225 so that the vanilla modifier `prepare_travels_modifier` is not changed incompatibly. Instead, use the new modifier `unop_prepare_travels_character_modifier`, so if other mods use the original modifier on travel plans, for example because they also copy vanilla files, they don't cause errors.