### PR TITLE
Fix bp3_decisions.0100 not checking legitimists prerequisites

### DIFF
--- a/events/decisions_events/bp3_decisions_events.txt
+++ b/events/decisions_events/bp3_decisions_events.txt
@@ -36,7 +36,12 @@ bp3_decisions.0100 = {
     # Become legitimists
     option = {
         name = bp3_decisions.0100.b
-        trigger = { NOT = { has_realm_law = camp_purpose_legitimists } }
+        #Unop Check if root can have legitimists camp purpose here since otherwise it will change automatically 
+        trigger = {
+            NOT = { has_realm_law = camp_purpose_legitimists }
+            ep3_can_have_legitimists_camp_purpose_trigger = yes
+        }
+        show_as_unavailable = { always = yes }
         add_realm_law_skip_effects = camp_purpose_legitimists
     }
 }


### PR DESCRIPTION
Fixes #178

I opted for checking the prerequisites for becoming legitimists in the trigger, rather than giving a claim to a random kingdom, or disabling the option entirely. If you fulfill the requirements, you can become Legitimists also without the decision, but at the cost of 1000 additional prestige.