### PR TITLE
Fix wet_nurse_instill_virtue working on ruler that are < 6 YO

### DIFF
--- a/common/court_positions/tasks/00_wet_nurse_tasks.txt
+++ b/common/court_positions/tasks/00_wet_nurse_tasks.txt
@@ -61,13 +61,14 @@ wet_nurse_instill_virtue = {
 				limit = {
 					is_adult = no
 					number_of_personality_traits < 3
+					age >= 6 # Unop: Added this to be in line with the code just above
 				}
 				random = {
 					chance = {
 						value = 1
 						add = {
 							value = "scope:wetnurse_trait_giver.aptitude(court_tutor_court_position)"
-							multiply = 1.5
+							multiply = 0.5 # Unop: Was 1.5 wich seems high, you'll still get your virtues, just not as quickly
 						}
 					}
 					instill_virtue_trait_effect = yes


### PR DESCRIPTION
For reference: https://forum.paradoxplaza.com/forum/threads/instill-virtue-works-on-0-year-old-rulers.1851066/

<img width="804" height="179" alt="image" src="https://github.com/user-attachments/assets/11bea43c-15be-4db5-872c-928698b5f7c9" />

@pharaox I agree, they probably meant for it to be 0.5 instead. As we'll still get the virtues, this could go down