### PR TITLE
Add the obedience bonus present in the YMLs but not in game

### DIFF
--- a/common/script_values/09_mpo_values.txt
+++ b/common/script_values/09_mpo_values.txt
@@ -1968,6 +1968,16 @@ obedience_value = {
 				}
 				add = { value = 25 desc = obedience_value_loyal_soldiers }
 			}
+
+			#INNOVATION
+			if = { # Unop: Saw nomad_innovation_gavelkind_bonus so I guess it's probably missing ?
+				limit = {
+					culture = {
+						has_innovation = innovation_gavelkind
+					}
+				}
+				add = { value = 10 desc = unop_nomad_innovation_gavelkind_bonus_label }
+			}
 		}
 	}
 }

--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -237,3 +237,6 @@
  unop_prepare_travels_character_modifier: "$prepare_travels_modifier$"
  unop_prepare_travels_character_modifier_desc: "$prepare_travels_modifier_desc$"
  unop_prepare_travels_character_modifier_scale_desc: "$prepare_travels_modifier_scale_desc$"
+ 
+ # To show that the obedience bonus comes from the gavelking innovation
+ unop_nomad_innovation_gavelkind_bonus_label: "$innovation_gavelkind$ [innovation|El]"


### PR DESCRIPTION
By looking at the issue with the empty entry in motte innovation when you are not playing tribal I found out 2 Yml that are saying gavelking & another should have bonus attached, right now they are not implemented and the text is not show in game

```
 nomad_innovation_development_01_bonus: "[SelectLocalization( GetPlayer.GetGovernment.HasGovernmentFlag( 'government_is_nomadic' ), 'nomad_innovation_development_01_bonus_desc', 'blank_line' )]"
 nomad_innovation_development_01_bonus_desc: "[nomad|E] [domicile_building|E] [gold|E] Construction Cost: #P -20%#!"
 nomad_innovation_gavelkind_bonus: "[SelectLocalization( GetPlayer.GetGovernment.HasGovernmentFlag( 'government_is_nomadic' ), 'nomad_innovation_gavelkind_bonus_desc', 'blank_line' )]"
 nomad_innovation_gavelkind_bonus_desc: "[courtiers|E], [vassals|E], and [tributaries|E] [obedience|E] score: #P +10#!" 
```

I probably won't merge this PR in the end, but keeping this for reference/archive