### PR TITLE
Fix issue with doctrine_consanguinity_dynastic, properly this time

### DIFF
--- a/common/scripted_triggers/00_religious_triggers.txt
+++ b/common/scripted_triggers/00_religious_triggers.txt
@@ -235,8 +235,10 @@ relation_with_character_is_incestuous_in_faith_trigger = {
 			$FAITH$ = { has_doctrine = doctrine_consanguinity_dynastic }
 			OR = {
 				is_close_or_extended_family_of = $CHARACTER$
-				is_lowborn = no #Unop Lowborn characters having the same dynasty is ok
-				dynasty = $CHARACTER$.dynasty
+				AND = { #Unop Lowborn characters having the same dynasty is ok
+					is_lowborn = no
+					dynasty = $CHARACTER$.dynasty
+				}
 			}
 		}	
 		#doctrine_consanguinity_restricted; absolutely no family business


### PR DESCRIPTION
Fix issue with doctrine_consanguinity_dynastic, properly this time. The `is_lowborn = no` check must be AND-ed with the next one (as they are all in an OR).

@ProZeratul You may want to release this one quickly as I am my previous change broke it even worse than before.