### PR TITLE
Regency removal for Resotred Japan emperors

### DIFF
--- a/common/character_interactions/00_diarch_interactions.txt
+++ b/common/character_interactions/00_diarch_interactions.txt
@@ -7548,7 +7548,14 @@ liege_dismiss_entrenched_regency_interaction = {
 			}
 		}
 		# Japanese Emperor cannot take this action
-		scope:actor = { tgp_is_japanese_emperor_trigger = no }
+		#Unop: Enables regency removal for restored emperors.
+		custom_tooltip = {
+			text = unop_government_is_japanese_emperor_prereformed_tt
+			OR = {
+				scope:actor = { tgp_is_japanese_emperor_trigger = no }
+				has_global_variable = tenno_restored
+			}
+		}
 		custom_tooltip = {
 			text = government_is_celestial_tt
 			scope:actor = {

--- a/localization/replace/english/unop_new_keys_action_l_english.yml
+++ b/localization/replace/english/unop_new_keys_action_l_english.yml
@@ -49,3 +49,5 @@
  action_upgrade_herder_holding_type_to_feudal_desc: "$action_upgrade_herder_holding_type_to_feudal_combined_group_description$"
  action_upgrade_herder_holding_type_to_feudal_click: "#I Click to select the $game_concept_holding$#!"
  action_upgrade_herder_holding_type_to_feudal_HELP: "\n\n#help #!" #TODO MPO $action_upgrade_tribal_holding_type_HELP$
+
+ unop_government_is_japanese_emperor_prereformed_tt: "You are powerless [ceremonial_liege|E]"


### PR DESCRIPTION
https://forum.paradoxplaza.com/forum/threads/chrysanthemum-throne-unbreakable-entrenched-regency.1865839/

Another seems-to-be-bugged interaction. For some reason even restoring "Direct Imperial Rule" doesn't allow for removing regency for holders of Chrysanthemum throne.

Gladly, restoring imperial rule creates a global var we can use. It does need a custom tooltip though, as the game can't handle it on its own.