### PR TITLE
Region change for the "Far From Home" achievement

### DIFF
--- a/map_data/geographical_regions/unop_indian_islands_region.txt
+++ b/map_data/geographical_regions/unop_indian_islands_region.txt
@@ -1,0 +1,26 @@
+﻿# Achievment requires to have a capital on the "Islands in Indian Ocean", but original region includes only pre-1.18 islands.
+
+dlc_fp1_achievement_far_from_home = {
+	kingdoms = {
+		#Unop: Sumatra and adaman islands
+		k_malayadvipa
+		#Unop: Java
+		k_yavakadvipa
+	}
+	duchies = {
+		# k_lanka
+		d_dakhina_desa d_ruhunu d_sinhala
+		# k_yemen
+		d_socotra
+		#Unop: k_maluku
+		d_IDO_lesser_sunda d_IDO_timor
+	}
+	counties = {
+		# k_tamilakam
+		c_maldives
+		# k_gujarat
+		c_kutch
+		#Unop: d_zanzibar
+		c_pemba c_zanzibar
+	}
+}


### PR DESCRIPTION
A bit of a personal change. Achievement requires to have a capital on the "Islands in the Indian Ocean" Region. But actual region is very limited and includes only pre-1.18 islands. 

I used this wikipedia map: https://upload.wikimedia.org/wikipedia/commons/d/d3/Indian_Ocean-CIA_WFB_Map.png , to include a lot of the new islands to the region. Because region instance could be overwritten by a separate file, I decided to just cut the change out of the original.


