### PR TITLE
Concubine child for all genders

### DIFF
--- a/common/on_action/child_birth_on_actions.txt
+++ b/common/on_action/child_birth_on_actions.txt
@@ -707,20 +707,21 @@ on_birth_child = {
 			}
 		}
 
+		#Unop: simplifing and fixing child of concubine distribution
 		if = {
 			limit = {
 				exists = scope:father
 				exists = scope:mother
-				scope:mother = { is_concubine_of = scope:father }
+				any_parent = {
+					is_concubine = yes
+					OR = {
+						is_concubine_of = scope:father
+						is_concubine_of = scope:mother
+					}
+				}
 			}
+			#Unop: only 1 (correct) trait will apply, as long as the trait itself has "valid_sex" attribute
 			add_trait = child_of_concubine_female
-		}
-		if = {
-			limit = {
-				exists = scope:father
-				exists = scope:mother
-				scope:father = { is_concubine_of = scope:mother }
-			}
 			add_trait = child_of_concubine_male
 		}
 		#create wet_nurse and nursed_child relation between the newborn and wet nurse court position character


### PR DESCRIPTION
https://forum.paradoxplaza.com/forum/threads/edited-only-children-who-are-the-same-sex-as-their-concubine-parent-can-get-the-child-of-concubine-trait.1875392/

More or less all in the bug report. Sons don't get child_of_concubine trait from concubine mothers and vice versa, for some reason. Pre 1.18 (I'm pretty sure) it was just a single trait for both genders.

I noticed that we can just give both traits to every child and they get only 1 gender-correct trait, as long as the trait itself still has "valid_sex" tag.