### PR TITLE
Jizya court bug

### DIFF
--- a/common/subject_contracts/contracts/special_contracts.txt
+++ b/common/subject_contracts/contracts/special_contracts.txt
@@ -333,12 +333,21 @@ religious_rights = {
 			is_valid = {
 				scope:subject.faith != scope:liege.faith
 				#Unop: Fixing obscure bug that can spawn hold_court.8040 event for muslim/tax_nonbelievers court owners
-				scope:liege.faith = {
-					NOR = {
-						has_doctrine = tenet_tax_nonbelievers
-						has_doctrine = special_doctrine_jizya
+				OR = {
+					scope:liege.faith = {
+						NOR = {
+							has_doctrine = tenet_tax_nonbelievers
+							has_doctrine = special_doctrine_jizya
+						}
+					}
+					scope:subject = {
+						NOT = {
+							vassal_contract_has_flag = vassal_contract_cannot_revoke_titles
+						}
+						vassal_contract_has_flag = religiously_protected
 					}
 				}
+				#Unop: Thats simplified version of the is_shown trigger
 			}
 			parent = religious_rights_none
 			position = { 1 0 }


### PR DESCRIPTION
When playing, I've encountered weird bug: during court meeting one of my vassals requested religious protection for his titles. I checked his contract - he had Jizya enabled and, of course, there wasn't any mentions about religion protection as jizya does basically the same thing. 

I checked both contracts and event files: `religious_rights` contract is **visible** (and thus can be interacted) only for non-jizya lieges or if vassal already has it, but increasing its level only requires different religion and nothing else.

Court event `hold_court.8040` checks only if current protection level can be increased and doesn't take into account anything else. Realistically, for muslim/tax_nonbelievers lieges it should check and petition about Jizya status instead, but, as it is now, rp text doesn't make any sense for them **AND** it creates potentially buggy situation when vassal has both Jizya and Religious protection.

It could be fixed from `hold_court_events_general.txt` instead, but I would rather not touch that boilerplate code. Adding additional triggers to the protection status itself should do the trick, and it's a much smaller file.