### PR TITLE
Prevents AUH faiths from creating holy orders through coronation 

### DIFF
--- a/events/activities/coronation_activity/coronation_events_1.txt
+++ b/events/activities/coronation_activity/coronation_events_1.txt
@@ -8694,7 +8694,10 @@ coronation_events.1032 = {
 
         trigger = {
         	exists = scope:barony
-        	NOT = {
+        	NOR = {
+				faith = {	#Unop: Prevent immaterial harmony faiths from access to holy orders.
+					has_doctrine = special_doctrine_immaterial_harmony
+				}
 				faith = {
 					any_faith_holy_order = {
 						holy_order_patron = root


### PR DESCRIPTION
I like holy orders. But the game is clearly designed to prevent far-eastern faith from creating such. They don't have names and use ugly generic ones instead.

Usually it is impossible to create one, but when playing I surprisingly found one in my land (after noticing a decision to boot them out). I was curious and decided to check all the ways you can create a holy order. There is very few ways to do so: 1 is from generic decision, which is obviously blocked, 2 are specific for the Jomsvikings and Hashishins.

The only other way comes from a coronation event that creates a new holy order, and of course Paradox completely forgot to add AUH support to it, which allows you (or ai) to spawn holy orders for eastern faiths. I've added check, mimicking one from the decision to prevent player/ai from doing it.