### PR TITLE
Japanese domain limit bonus from lifestyle

### DIFF
--- a/common/lifestyle_perks/00_wanderer_1_surveyor_tree_perks.txt
+++ b/common/lifestyle_perks/00_wanderer_1_surveyor_tree_perks.txt
@@ -361,7 +361,7 @@ personal_touch_perk = {
 		domain_limit_max = 1
 	}
 	government_character_modifier = {
-		flag = government_is_japan_administrative
+		flag = government_is_japan_feudal	#Unop: Adding bonus for Soryo government, rather than doubling Ritsuryo
 		domain_limit_max = 1
 	}
 


### PR DESCRIPTION
I was checking every way I can increase my domain limit as a shogun of Japan. There is 2 perks in game that increases domain limit: one in stewardship and other is in the wanderer lifestyle.

They both give domain_limit bonuses to every government that uses it, but looks like the one from the wanderer have a misspelling. It doesn't add any bonus to the _japan_feudal_, but instead it has double bonus for the administrative out of nowhere.

Pretty sure that this is a mistake on PDX side, as instead of giving `domain_limit_max = 2` to the _japan_admin_ (which would clearly indicate the intention to do so), perk gives it `domain_limit_max = 1` but 2 times in separate triggers. Looks like they just forgot to change it to _japan_feudal_ after copypasting.