### PR TITLE
Replace duel with random_list in travel_events.1003

### DIFF
--- a/events/travel_events/travel_events.txt
+++ b/events/travel_events/travel_events.txt
@@ -792,9 +792,9 @@ travel_events.1003 = {
     #Fight
     option = { 
         name = travel_events.1003.b
-        duel = {
-        	skill = prowess
-        	value = decent_skill_rating
+        random_list = { #Unop Avoid showing "Prowess Challenge" to the player
+        	#skill = prowess
+        	#value = decent_skill_rating
         	#They die!
 			1 = { 
 				scope:travel_leader = {


### PR DESCRIPTION
Replace `duel` with `random_list` in `travel_events.1003`. They actually work in the same way, but `duel` shows a misleading "Prowess Challenge", while there is no challenge in this case - the probabilities for the different outcomes are fixed and root's prowess doesn't matter.

I thought about reworking this into an actual duel but gave it up, the event seems to be intentionally written so that root's prowess doesn't matter in this case (and it's actually their travel leader, not root, who gets hurt or dies).