### PR TITLE
Fix banner tooltip in court_maintenance.0011

### DIFF
--- a/events/court_maintenance_events.txt
+++ b/events/court_maintenance_events.txt
@@ -425,7 +425,10 @@ court_maintenance.0011 = {
 			custom_tooltip = court_maintenance.0011.banner_house_tooltip
 		}
 		#Dynasty
-		else = { custom_tooltip = court_maintenance.0011.banner_dynasty_tooltip }
+		else_if = { #Unop Only show tooltip if a dynasty banner was actually created
+			limit = { exists = scope:dynasty_banner }
+			custom_tooltip = court_maintenance.0011.banner_dynasty_tooltip
+		}
 
 		# Add extra legitimacy, for the first time they gain the Kingdom title
 		add_legitimacy_effect = { LEGITIMACY = major_legitimacy_gain }


### PR DESCRIPTION
When you become the ceremonial regent, you don't get banners, since you are not a "real" monarch. However, the logic for showing the tooltip assumes you always get one, so an incorrect tooltip is displayed.