### PR TITLE
Fix tribal raiding capture intent not having modifiers applied

### DIFF
--- a/events/war_events/raid_events.txt
+++ b/events/war_events/raid_events.txt
@@ -892,7 +892,12 @@ raiding.0013 = {
 				}
 
 				modifier = {
-					root = { raid_intent = capture_intent_nomadic }
+					root = {
+						OR = {
+							raid_intent = capture_intent_nomadic
+							raid_intent = capture_intent_norse #Unop: Added the missing norse entry (called norsed but it is for tribal)
+						}
+					}
 					has_raid_intent_immunity = no
 					add = {
 						value = 15


### PR DESCRIPTION
Fix https://forum.paradoxplaza.com/forum/threads/capture-raid-intent-does-not-actually-increase-capture-chance-for-tribal-rulers-code-error-found.1895244/