### PR TITLE
Fix gold not being taken/given since the effect is now in a show_as_tooltip in purchase_land_interaction_effect

### DIFF
--- a/common/scripted_effects/07_dlc_ep3_scripted_effects.txt
+++ b/common/scripted_effects/07_dlc_ep3_scripted_effects.txt
@@ -1431,12 +1431,12 @@ purchase_land_interaction_effect = {
 	}
 	# Purchase land specific
 	scope:actor = {
-		show_as_tooltip = {
+		#show_as_tooltip = { #Unop: We based all script review on the effect taking gold, so comment this
 			pay_short_term_gold = {
 				gold = scope:purchase_land_cost
 				target = scope:recipient
 			}
-		}
+		#}
 	}
 	# Resolve title, liege, government changes
 	ep3_become_landed_transfer_effect = {

--- a/events/dlc/ep3/ep3_laamp_events.txt
+++ b/events/dlc/ep3/ep3_laamp_events.txt
@@ -8773,9 +8773,8 @@ ep3_laamps.7004 = {
 		show_as_tooltip = {
 			pay_short_term_gold = {
 				target = scope:recipient
-				gold = 100
+				gold = scope:purchase_land_cost #Unop: Use the scope name of the value used in purchase_land_interaction_effect
 			}
-
 		}
 
 		# Unop: Will handled by the effect


### PR DESCRIPTION
Since purchase_land_interaction_effect is no longer taking the gold, we need to actually take the gold from those who called it