### PR TITLE
Dev/fix event ancestor

### DIFF
--- a/events/decisions_events/tgp_decision_events.txt
+++ b/events/decisions_events/tgp_decision_events.txt
@@ -1042,7 +1042,7 @@ tgp_decision_events.0200 = {
                         add = 2
                     }
                     modifier = {
-                        is_ruler = yes
+                        highest_held_title_tier >= tier_county #Unop: Was is_ruler = yes but since they are dead, it don't work
                         add = 4
                     }
                 }


### PR DESCRIPTION
Fix #357

@pharaox I've some doubt on the modifier:

```
modifier = {
    is_ruler = yes
    add = 4
}
```

Can dead char still return true for this ? if not this might need some tweaks to see if the GP/GGP was a ruler