### PR TITLE
Court tutor & guru are not handled in many child education events

### DIFF
--- a/common/scripted_triggers/00_unop_triggers.txt
+++ b/common/scripted_triggers/00_unop_triggers.txt
@@ -959,3 +959,39 @@ unop_can_location_be_reset = {
 	NOT = { exists = involved_activity }
 	num_taken_task_contracts <= 0
 }
+
+unop_guardian_or_court_tutor_3_trait = {
+	trigger_if = {
+		limit = {
+			any_relation = {
+				type = guardian
+			}
+		}
+		any_relation = {
+			type = guardian
+			OR = {
+				has_trait = $TRAIT$
+				has_trait = $TRAIT_2$
+				has_trait = $TRAIT_3$
+			}
+		}
+	}
+	trigger_else = {
+		OR = {
+			court_owner.court_position:court_tutor_court_position ?= {
+				OR = {
+					has_trait = $TRAIT$
+					has_trait = $TRAIT_2$
+					has_trait = $TRAIT_3$
+				}
+			}
+			court_owner.court_position:court_guru_court_position ?= {
+				OR = {
+					has_trait = $TRAIT$
+					has_trait = $TRAIT_2$
+					has_trait = $TRAIT_3$
+				}
+			}
+		}
+	}
+}

--- a/events/dlc/tgp/tgp_child_personality_events.txt
+++ b/events/dlc/tgp/tgp_child_personality_events.txt
@@ -49,29 +49,11 @@ tgp_child_personality.0002 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = arrogant
-					has_trait = compassionate
-					has_trait = callous
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = arrogant
-					has_trait = compassionate
-					has_trait = callous
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = arrogant
+				TRAIT_2 = compassionate
+				TRAIT_3 = callous
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -100,8 +82,16 @@ tgp_child_personality.0002 = {
 				save_scope_as = guardian
 			}
 		}
-		else = {
+		else_if = {
+			limit = {
+				exists = court_owner.court_position:court_tutor_court_position
+			}
 			court_owner.court_position:court_tutor_court_position ?= {
+				save_scope_as = guardian
+			}
+		}
+		else = {
+			court_owner.court_position:court_guru_court_position ?= {
 				save_scope_as = guardian
 			}
 		}
@@ -272,29 +262,11 @@ tgp_child_personality.0003 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = deceitful
-					has_trait = honest
-					has_trait = humble
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = deceitful
-					has_trait = honest
-					has_trait = humble
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = deceitful
+				TRAIT_2 = honest
+				TRAIT_3 = humble
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -475,29 +447,11 @@ tgp_child_personality.0004 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = generous
-					has_trait = diligent
-					has_trait = patient
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = generous
-					has_trait = diligent
-					has_trait = patient
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = generous
+				TRAIT_2 = diligent
+				TRAIT_3 = patient
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -681,29 +635,11 @@ tgp_child_personality.0007 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = just
-					has_trait = cynical
-					has_trait = temperate
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = just
-					has_trait = cynical
-					has_trait = temperate
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = just
+				TRAIT_2 = cynical
+				TRAIT_3 = temperate
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -879,29 +815,11 @@ tgp_child_personality.0009 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = brave
-					has_trait = calm
-					has_trait = zealous
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = brave
-					has_trait = calm
-					has_trait = zealous
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = brave
+				TRAIT_2 = calm
+				TRAIT_3 = zealous
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -1089,29 +1007,11 @@ tgp_child_personality.0010 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = ambitious
-					has_trait = sadistic
-					has_trait = paranoid
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = ambitious
-					has_trait = sadistic
-					has_trait = paranoid
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = ambitious
+				TRAIT_2 = sadistic
+				TRAIT_3 = paranoid
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -1281,14 +1181,11 @@ tgp_child_personality.7000 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = diligent
-					has_trait = gregarious
-					has_trait = temperate
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = diligent
+				TRAIT_2 = gregarious
+				TRAIT_3 = temperate
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -1331,19 +1228,13 @@ tgp_child_personality.7000 = {
 				is_ai = yes
 			}
 			add_character_flag = diligent
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7001
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7001 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = diligent
-				}
+				guardian_or_court_tutor_trait = { TRAIT = diligent }
 			}
 			modifier = {
 				add = 100
@@ -1351,12 +1242,9 @@ tgp_child_personality.7000 = {
 					has_cultural_parameter = diligent_trait_more_common
 				}
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = lazy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lazy }
 			}
 		}
 	}
@@ -1375,26 +1263,17 @@ tgp_child_personality.7000 = {
 				is_ai = yes
 			}
 			add_character_flag = gregarious
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7001
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7001 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = gregarious
-				}
+				guardian_or_court_tutor_trait = { TRAIT = gregarious }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = shy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = shy }
 			}
 		}
 	}
@@ -1413,26 +1292,17 @@ tgp_child_personality.7000 = {
 				is_ai = yes
 			}
 			add_character_flag = temperate
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7001
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7001 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = temperate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = temperate }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = gluttonous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = gluttonous }
 			}
 			modifier = {
 				add = 100
@@ -1477,13 +1347,21 @@ tgp_child_personality.7300 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = eccentric
-					has_trait = gregarious
-					has_trait = compassionate
-				}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = eccentric
+				TRAIT_2 = gregarious
+				TRAIT_3 = compassionate
+ 			}
+		}
+		modifier = { #Unop: Add missing culure modifier
+			add = 5
+			culture = {
+				has_cultural_parameter = compassionate_trait_more_common
+			}
+			NOR = {
+				has_trait = compassionate
+				has_trait = callous
+				has_trait = sadistic
 			}
 		}
 	}
@@ -1508,28 +1386,19 @@ tgp_child_personality.7300 = {
 				is_ai = yes
 			}
 			add_character_flag = eccentric
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7301
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7301 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = eccentric
-				}
+				guardian_or_court_tutor_trait = { TRAIT = eccentric }
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = fickle
-						has_trait = stubborn
-					}
+				guardian_or_court_tutor_2_trait = { #Unop: Mini-optimization
+					TRAIT = fickle
+					TRAIT_2 = stubborn
 				}
 			}
 		}
@@ -1551,28 +1420,25 @@ tgp_child_personality.7300 = {
 				is_ai = yes
 			}
 			add_character_flag = compassionate
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7301
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7301 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = compassionate
+				guardian_or_court_tutor_trait = { TRAIT = compassionate }
+			}
+			modifier = { #Unop: To also check tutor&guru
+				add = -0.5
+				guardian_or_court_tutor_2_trait = { 
+					TRAIT = sadistic
+					TRAIT_2 = callous
 				}
 			}
-			modifier = {
-				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = sadistic
-						has_trait = callous
-					}
+			modifier = { #Unop: Add missing culure modifier
+				add = 100
+				culture = {
+					has_cultural_parameter = compassionate_trait_more_common
 				}
 			}
 		}
@@ -1594,26 +1460,17 @@ tgp_child_personality.7300 = {
 				is_ai = yes
 			}
 			add_character_flag = callous
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7301
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7301 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = callous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = callous }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = compassionate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = compassionate }
 			}
 		}
 	}
@@ -1654,14 +1511,11 @@ tgp_child_personality.7010 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = zealous
-					has_trait = ambitious
-					has_trait = sadistic
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = zealous
+				TRAIT_2 = ambitious
+				TRAIT_3 = sadistic
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -1703,26 +1557,17 @@ tgp_child_personality.7010 = {
 				is_ai = yes
 			}
 			add_character_flag = zealous
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7011
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7011 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = zealous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = zealous }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = cynical
-				}
+				guardian_or_court_tutor_trait = { TRAIT = cynical }
 			}
 			modifier = {
 				add = 100
@@ -1747,26 +1592,17 @@ tgp_child_personality.7010 = {
 				is_ai = yes
 			}
 			add_character_flag = ambitious
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7011
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7011 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = ambitious
-				}
+				guardian_or_court_tutor_trait = { TRAIT = ambitious }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = content
-				}
+				guardian_or_court_tutor_trait = { TRAIT = content }
 			}
 			modifier = {
 				add = 100
@@ -1792,26 +1628,17 @@ tgp_child_personality.7010 = {
 				is_ai = yes
 			}
 			add_character_flag = sadistic
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7011
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7011 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = sadistic
-				}
+				guardian_or_court_tutor_trait = { TRAIT = sadistic }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = compassionate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = compassionate }
 			}
 		}
 	}
@@ -1853,14 +1680,11 @@ tgp_child_personality.7020 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = shy
-					has_trait = paranoid
-					has_trait = craven
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = shy
+				TRAIT_2 = paranoid
+				TRAIT_3 = craven
+ 			}
 		}
 	}
 
@@ -1888,26 +1712,17 @@ tgp_child_personality.7020 = {
 				is_ai = yes
 			}
 			add_character_flag = shy
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7021
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7021 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = shy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = shy }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = gregarious
-				}
+				guardian_or_court_tutor_trait = { TRAIT = gregarious }
 			}
 		}
 	}
@@ -1926,26 +1741,17 @@ tgp_child_personality.7020 = {
 				is_ai = yes
 			}
 			add_character_flag = paranoid
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7021
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7021 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = paranoid
-				}
+				guardian_or_court_tutor_trait = { TRAIT = paranoid }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = trusting
-				}
+				guardian_or_court_tutor_trait = { TRAIT = trusting }
 			}
 		}
 	}
@@ -1964,26 +1770,17 @@ tgp_child_personality.7020 = {
 				is_ai = yes
 			}
 			add_character_flag = craven
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7021
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7021 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = craven
-				}
+				guardian_or_court_tutor_trait = { TRAIT = craven }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = brave
-				}
+				guardian_or_court_tutor_trait = { TRAIT = brave }
 			}
 		}
 	}
@@ -2030,14 +1827,11 @@ tgp_child_personality.7050 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = just
-					has_trait = greedy
-					has_trait = callous
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = just
+				TRAIT_2 = greedy
+				TRAIT_3 = callous
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -2070,26 +1864,17 @@ tgp_child_personality.7050 = {
 				is_ai = yes
 			}
 			add_character_flag = just
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7051
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7051 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = just
-				}
+				guardian_or_court_tutor_trait = { TRAIT = just }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = arbitrary
-				}
+				guardian_or_court_tutor_trait = { TRAIT = arbitrary }
 			}
 			modifier = {
 				add = 100
@@ -2115,26 +1900,17 @@ tgp_child_personality.7050 = {
 				is_ai = yes
 			}
 			add_character_flag = greedy
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7051
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7051 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = greedy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = greedy }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = generous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = generous }
 			}
 		}
 	}
@@ -2155,28 +1931,19 @@ tgp_child_personality.7050 = {
 				is_ai = yes
 			}
 			add_character_flag = callous
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7051
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7051 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = callous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = callous }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = callous
-						has_trait = sadistic
-					}
+				guardian_or_court_tutor_2_trait = { 
+					TRAIT = callous
+					TRAIT_2 = sadistic
 				}
 			}
 		}
@@ -2211,6 +1978,7 @@ tgp_child_personality.7200 = {
 			OR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 			OR = {
 				has_trait = wrathful
@@ -2224,14 +1992,11 @@ tgp_child_personality.7200 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = brave
-					has_trait = stubborn
-					has_trait = wrathful
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = brave
+				TRAIT_2 = stubborn
+				TRAIT_3 = wrathful
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -2241,6 +2006,7 @@ tgp_child_personality.7200 = {
 			NOR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 	}
@@ -2270,26 +2036,17 @@ tgp_child_personality.7200 = {
 				is_ai = yes
 			}
 			add_character_flag = brave
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7201
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7201 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = brave
-				}
+				guardian_or_court_tutor_trait = { TRAIT = brave }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = craven
-				}
+				guardian_or_court_tutor_trait = { TRAIT = craven }
 			}
 		}
 	}
@@ -2300,6 +2057,7 @@ tgp_child_personality.7200 = {
 			NOR = {
 				has_trait = fickle
 				has_trait = stubborn
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 		add_trait = stubborn
@@ -2309,25 +2067,19 @@ tgp_child_personality.7200 = {
 				is_ai = yes
 			}
 			add_character_flag = stubborn
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7201
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7201 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = stubborn
-				}
+				guardian_or_court_tutor_trait = { TRAIT = stubborn }
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = fickle
+				guardian_or_court_tutor_2_trait = { #Unop: Mini-optimization
+					TRAIT = fickle
+					TRAIT_2 = eccentric
 				}
 			}
 			modifier = {
@@ -2354,26 +2106,17 @@ tgp_child_personality.7200 = {
 				is_ai = yes
 			}
 			add_character_flag = wrathful
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7201
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7201 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = wrathful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = wrathful }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = calm
-				}
+				guardian_or_court_tutor_trait = { TRAIT = calm }
 			}
 		}
 	}
@@ -2444,14 +2187,11 @@ tgp_child_personality.7070 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = vengeful
-					has_trait = deceitful
-					has_trait = calm
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = vengeful
+				TRAIT_2 = deceitful
+				TRAIT_3 = calm
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -2501,26 +2241,17 @@ tgp_child_personality.7070 = {
 				is_ai = yes
 			}
 			add_character_flag = vengeful
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7071
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7071 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = vengeful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = vengeful }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = forgiving
-				}
+				guardian_or_court_tutor_trait = { TRAIT = forgiving }
 			}
 			modifier = {
 				add = 100
@@ -2546,26 +2277,17 @@ tgp_child_personality.7070 = {
 				is_ai = yes
 			}
 			add_character_flag = deceitful
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7071
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7071 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = deceitful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = deceitful }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = honest
-				}
+				guardian_or_court_tutor_trait = { TRAIT = honest }
 			}
 		}
 	}
@@ -2585,26 +2307,17 @@ tgp_child_personality.7070 = {
 				is_ai = yes
 			}
 			add_character_flag = calm
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7071
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7071 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = calm
-				}
+				guardian_or_court_tutor_trait = { TRAIT = calm }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = wrathful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = wrathful }
 			}
 			modifier = {
 				add = 100
@@ -2645,14 +2358,11 @@ tgp_child_personality.7040 = {
 
 	weight_multiplier = {
 		base = 1
-		modifier = {
+		modifier = { #Unop: To also check tutor&guru
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = lustful
-					has_trait = chaste
-				}
+			guardian_or_court_tutor_2_trait = { 
+				TRAIT = lustful
+				TRAIT_2 = chaste
 			}
 		}
 		modifier = {
@@ -2681,26 +2391,17 @@ tgp_child_personality.7040 = {
 				is_ai = yes
 			}
 			add_character_flag = lustful
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7041
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7041 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = lustful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lustful }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = chaste
-				}
+				guardian_or_court_tutor_trait = { TRAIT = chaste }
 			}
 		}
 	}
@@ -2713,26 +2414,17 @@ tgp_child_personality.7040 = {
 				is_ai = yes
 			}
 			add_character_flag = chaste
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7041
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7041 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = chaste
-				}
+				guardian_or_court_tutor_trait = { TRAIT = chaste }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = lustful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lustful }
 			}
 		}
 	}
@@ -2781,14 +2473,11 @@ tgp_child_personality.7080 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = generous
-					has_trait = fickle
-					has_trait = arrogant
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = generous
+				TRAIT_2 = fickle
+				TRAIT_3 = arrogant
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -2827,26 +2516,17 @@ tgp_child_personality.7080 = {
 				is_ai = yes
 			}
 			add_character_flag = generous
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7081
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7081 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = generous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = generous }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = greedy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = greedy }
 			}
 			modifier = {
 				add = 100
@@ -2863,6 +2543,7 @@ tgp_child_personality.7080 = {
 			NOR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 		add_trait = fickle
@@ -2872,25 +2553,19 @@ tgp_child_personality.7080 = {
 				is_ai = yes
 			}
 			add_character_flag = fickle
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7081
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7081 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = fickle
-				}
+				guardian_or_court_tutor_trait = { TRAIT = fickle }
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = stubborn
+				guardian_or_court_tutor_2_trait = { #Unop: Mini-optimization
+					TRAIT = eccentric
+					TRAIT_2 = stubborn
 				}
 			}
 		}
@@ -2911,26 +2586,17 @@ tgp_child_personality.7080 = {
 				is_ai = yes
 			}
 			add_character_flag = arrogant
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7081
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7081 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = arrogant
-				}
+				guardian_or_court_tutor_trait = { TRAIT = arrogant }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = humble
-				}
+				guardian_or_court_tutor_trait = { TRAIT = humble }
 			}
 		}
 	}
@@ -2983,14 +2649,11 @@ tgp_child_personality.7030 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = lazy
-					has_trait = gluttonous
-					has_trait = compassionate
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = lazy
+				TRAIT_2 = gluttonous
+				TRAIT_3 = compassionate
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -3043,26 +2706,17 @@ tgp_child_personality.7030 = {
 				is_ai = yes
 			}
 			add_character_flag = lazy
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7031
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7031 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = lazy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lazy }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = diligent
-				}
+				guardian_or_court_tutor_trait = { TRAIT = diligent }
 			}
 		}
 	}
@@ -3083,26 +2737,17 @@ tgp_child_personality.7030 = {
 				is_ai = yes
 			}
 			add_character_flag = gluttonous
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7031
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7031 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = gluttonous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = gluttonous }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = temperate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = temperate }
 			}
 		}
 	}
@@ -3123,28 +2768,19 @@ tgp_child_personality.7030 = {
 				is_ai = yes
 			}
 			add_character_flag = compassionate
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7031
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7031 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = compassionate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = compassionate }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = callous
-						has_trait = sadistic
-					}
+				guardian_or_court_tutor_2_trait = { 
+					TRAIT = callous
+					TRAIT_2 = sadistic
 				}
 			}
 			modifier = {
@@ -3197,17 +2833,14 @@ tgp_child_personality.7090 = {
 	}
 
 	weight_multiplier = {
-		base = 1
+		base = 1		
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = forgiving
-					has_trait = trusting
-					has_trait = patient
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = forgiving
+				TRAIT_2 = trusting
+				TRAIT_3 = patient
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -3259,26 +2892,17 @@ tgp_child_personality.7090 = {
 				is_ai = yes
 			}
 			add_character_flag = forgiving
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7091
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7091 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = forgiving
-				}
+				guardian_or_court_tutor_trait = { TRAIT = forgiving }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = vengeful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = vengeful }
 			}
 		}
 	}
@@ -3298,26 +2922,17 @@ tgp_child_personality.7090 = {
 				is_ai = yes
 			}
 			add_character_flag = trusting
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7091
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7091 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = trusting
-				}
+				guardian_or_court_tutor_trait = { TRAIT = trusting }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = paranoid
-				}
+				guardian_or_court_tutor_trait = { TRAIT = paranoid }
 			}
 		}
 	}
@@ -3337,26 +2952,17 @@ tgp_child_personality.7090 = {
 				is_ai = yes
 			}
 			add_character_flag = patient
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7091
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7091 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = patient
-				}
+				guardian_or_court_tutor_trait = { TRAIT = patient }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = impatient
-				}
+				guardian_or_court_tutor_trait = { TRAIT = impatient }
 			}
 			modifier = {
 				add = 100
@@ -3412,14 +3018,11 @@ tgp_child_personality.7060 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = humble
-					has_trait = cynical
-					has_trait = content
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = humble
+				TRAIT_2 = cynical
+				TRAIT_3 = content
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -3468,26 +3071,17 @@ tgp_child_personality.7060 = {
 				is_ai = yes
 			}
 			add_character_flag = humble
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7061
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7061 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = humble
-				}
+				guardian_or_court_tutor_trait = { TRAIT = humble }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = arrogant
-				}
+				guardian_or_court_tutor_trait = { TRAIT = arrogant }
 			}
 			modifier = {
 				add = 100
@@ -3513,26 +3107,17 @@ tgp_child_personality.7060 = {
 				is_ai = yes
 			}
 			add_character_flag = cynical
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7061
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7061 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = cynical
-				}
+				guardian_or_court_tutor_trait = { TRAIT = cynical }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = zealous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = zealous }
 			}
 		}
 	}
@@ -3552,26 +3137,17 @@ tgp_child_personality.7060 = {
 				is_ai = yes
 			}
 			add_character_flag = content
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7061
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7061 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = content
-				}
+				guardian_or_court_tutor_trait = { TRAIT = content }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = ambitious
-				}
+				guardian_or_court_tutor_trait = { TRAIT = ambitious }
 			}
 			modifier = {
 				add = 100
@@ -3646,14 +3222,11 @@ tgp_child_personality.7100 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = honest
-					has_trait = arbitrary
-					has_trait = impatient
-				}
-			}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = honest
+				TRAIT_2 = arbitrary
+				TRAIT_3 = impatient
+ 			}
 		}
 		modifier = {
 			add = 5
@@ -3687,26 +3260,17 @@ tgp_child_personality.7100 = {
 				is_ai = yes
 			}
 			add_character_flag = honest
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7101
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7101 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = honest
-				}
+				guardian_or_court_tutor_trait = { TRAIT = honest }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = deceitful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = deceitful }
 			}
 			modifier = {
 				add = 100
@@ -3732,26 +3296,17 @@ tgp_child_personality.7100 = {
 				is_ai = yes
 			}
 			add_character_flag = arbitrary
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7101
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7101 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = arbitrary
-				}
+				guardian_or_court_tutor_trait = { TRAIT = arbitrary }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = just
-				}
+				guardian_or_court_tutor_trait = { TRAIT = just }
 			}
 		}
 	}
@@ -3771,26 +3326,17 @@ tgp_child_personality.7100 = {
 				is_ai = yes
 			}
 			add_character_flag = impatient
-			random_relation = {
-				type = guardian
-				trigger_event = tgp_child_personality.7101
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = tgp_child_personality.7101 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = impatient
-				}
+				guardian_or_court_tutor_trait = { TRAIT = impatient }
 			}
-			modifier = {
+			modifier = { #Unop: To also check tutor&guru
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = patient
-				}
+				guardian_or_court_tutor_trait = { TRAIT = patient }
 			}
 		}
 	}
@@ -7097,6 +6643,7 @@ tgp_child_personality.7081 = {
 				NOR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -7727,6 +7274,7 @@ tgp_child_personality.7201 = {
 				NOR = {
 					has_trait = stubborn
 					has_trait = fickle
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}

--- a/events/education_and_childhood/child_personality_events.txt
+++ b/events/education_and_childhood/child_personality_events.txt
@@ -114,29 +114,11 @@ child_personality.0001 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = craven
-					has_trait = lazy
-					has_trait = arbitrary
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = craven
-					has_trait = lazy
-					has_trait = arbitrary
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = craven
+				TRAIT_2 = lazy
+				TRAIT_3 = arbitrary
 			}
 		}
 	}
@@ -476,29 +458,11 @@ child_personality.0002 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = arrogant
-					has_trait = compassionate
-					has_trait = callous
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = arrogant
-					has_trait = compassionate
-					has_trait = callous
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = arrogant
+				TRAIT_2 = compassionate
+				TRAIT_3 = callous
 			}
 		}
 		modifier = {
@@ -528,8 +492,16 @@ child_personality.0002 = {
 				save_scope_as = guardian
 			}
 		}
-		else = {
+		else_if = {
+			limit = {
+				exists = court_owner.court_position:court_tutor_court_position
+			}
 			court_owner.court_position:court_tutor_court_position ?= {
+				save_scope_as = guardian
+			}
+		}
+		else = {
+			court_owner.court_position:court_guru_court_position ?= {
 				save_scope_as = guardian
 			}
 		}
@@ -697,29 +669,11 @@ child_personality.0003 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = deceitful
-					has_trait = honest
-					has_trait = humble
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = deceitful
-					has_trait = honest
-					has_trait = humble
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = deceitful
+				TRAIT_2 = honest
+				TRAIT_3 = humble
 			}
 		}
 		modifier = {
@@ -758,8 +712,16 @@ child_personality.0003 = {
 				save_scope_as = guardian
 			}
 		}
-		else = {
+		else_if = {
+			limit = {
+				exists = court_owner.court_position:court_tutor_court_position
+			}
 			court_owner.court_position:court_tutor_court_position ?= {
+				save_scope_as = guardian
+			}
+		}
+		else = {
+			court_owner.court_position:court_guru_court_position ?= {
 				save_scope_as = guardian
 			}
 		}
@@ -931,29 +893,11 @@ child_personality.0004 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = generous
-					has_trait = diligent
-					has_trait = patient
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = generous
-					has_trait = diligent
-					has_trait = patient
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = generous
+				TRAIT_2 = diligent
+				TRAIT_3 = patient
 			}
 		}
 		modifier = {
@@ -1239,6 +1183,7 @@ child_personality.0005 = {
 			OR = {
 				has_trait = fickle
 				has_trait = stubborn
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 	}
@@ -1246,29 +1191,11 @@ child_personality.0005 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = wrathful
-					has_trait = forgiving
-					has_trait = fickle
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = wrathful
-					has_trait = forgiving
-					has_trait = fickle
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = wrathful
+				TRAIT_2 = forgiving
+				TRAIT_3 = fickle
 			}
 		}
 	}
@@ -1586,6 +1513,7 @@ child_personality.0005 = {
 			NOR = {
 				has_trait = fickle
 				has_trait = stubborn
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 		ai_chance = {
@@ -1596,7 +1524,10 @@ child_personality.0005 = {
 			}
 			modifier = {
 				add = -0.5
-				guardian_or_court_tutor_trait = { TRAIT = stubborn }
+				guardian_or_court_tutor_2_trait = { #Unop: To also check eccentric
+					TRAIT = stubborn
+					TRAIT_2 = eccentric 
+				}
 			}
 		}
 		add_trait = fickle
@@ -1662,6 +1593,7 @@ child_personality.0006 = {
 			OR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 	}
@@ -1670,29 +1602,11 @@ child_personality.0006 = {
 		base = 1
 
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = vengeful
-					has_trait = chaste
-					has_trait = stubborn
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = vengeful
-					has_trait = chaste
-					has_trait = stubborn
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = vengeful
+				TRAIT_2 = chaste
+				TRAIT_3 = stubborn
 			}
 		}
 		modifier = {
@@ -1713,6 +1627,7 @@ child_personality.0006 = {
 			NOR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 	}
@@ -2014,6 +1929,7 @@ child_personality.0006 = {
 			NOR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 		ai_chance = {
@@ -2024,7 +1940,10 @@ child_personality.0006 = {
 			}
 			modifier = {
 				add = -0.5
-				guardian_or_court_tutor_trait = { TRAIT = fickle }
+				guardian_or_court_tutor_2_trait = { #Unop: To also check eccentric
+					TRAIT = fickle
+					TRAIT_2 = eccentric
+				}
 			}
 			modifier = {
 				add = 100
@@ -2080,6 +1999,7 @@ child_personality.0007 = {
 				is_available = yes
 			}
 			exists = court_owner.court_position:court_tutor_court_position
+			exists = court_owner.court_position:court_guru_court_position #Unop: Guru is also the tutor
 			any_courtier_or_guest = {
 				is_adult = yes
 				is_available = yes
@@ -2113,29 +2033,11 @@ child_personality.0007 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = just
-					has_trait = cynical
-					has_trait = temperate
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = just
-					has_trait = cynical
-					has_trait = temperate
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = just
+				TRAIT_2 = cynical
+				TRAIT_3 = temperate
 			}
 		}
 		modifier = {
@@ -2340,29 +2242,11 @@ child_personality.0008 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = greedy
-					has_trait = gregarious
-					has_trait = lustful
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = greedy
-					has_trait = gregarious
-					has_trait = lustful
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = greedy
+				TRAIT_2 = gregarious
+				TRAIT_3 = lustful
 			}
 		}
 		modifier = {
@@ -2703,29 +2587,11 @@ child_personality.0009 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = brave
-					has_trait = calm
-					has_trait = zealous
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = brave
-					has_trait = calm
-					has_trait = zealous
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = brave
+				TRAIT_2 = calm
+				TRAIT_3 = zealous
 			}
 		}
 		modifier = {
@@ -3095,6 +2961,7 @@ child_personality.0010 = {
 				is_available = yes
 			}
 			exists = court_owner.court_position:court_tutor_court_position
+			exists = court_owner.court_position:court_guru_court_position #Unop: Guru is also the tutor
 			any_courtier_or_guest = {
 				is_adult = yes
 				is_available = yes
@@ -3129,29 +2996,11 @@ child_personality.0010 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = ambitious
-					has_trait = sadistic
-					has_trait = paranoid
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = ambitious
-					has_trait = sadistic
-					has_trait = paranoid
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = ambitious
+				TRAIT_2 = sadistic
+				TRAIT_3 = paranoid
 			}
 		}
 		modifier = {
@@ -3288,6 +3137,7 @@ child_personality.0011 = {
 				is_available = yes
 			}
 			exists = court_owner.court_position:court_tutor_court_position
+			exists = court_owner.court_position:court_guru_court_position #Unop: Guru is also the tutor
 			any_courtier_or_guest = {
 				is_adult = yes
 				is_available = yes
@@ -3309,6 +3159,7 @@ child_personality.0011 = {
 			OR = {
 				has_trait = fickle
 				has_trait = stubborn
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 			OR = {
 				has_trait = trusting
@@ -3320,29 +3171,11 @@ child_personality.0011 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = content
-					has_trait = fickle
-					has_trait = trusting
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = content
-					has_trait = fickle
-					has_trait = trusting
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = content
+				TRAIT_2 = fickle
+				TRAIT_3 = trusting
 			}
 		}
 		modifier = {
@@ -3403,6 +3236,7 @@ child_personality.0011 = {
 			NOR = {
 				has_trait = fickle
 				has_trait = stubborn
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 		ai_chance = {
@@ -3413,7 +3247,10 @@ child_personality.0011 = {
 			}
 			modifier = {
 				add = -0.5
-				guardian_or_court_tutor_trait = { TRAIT = stubborn }
+				guardian_or_court_tutor_2_trait = { #Unop: To also check eccentric
+					TRAIT = stubborn
+					TRAIT_2 = eccentric
+				}
 			}
 		}
 		add_trait = fickle
@@ -3482,6 +3319,7 @@ child_personality.0012 = {
 				is_available = yes
 			}
 			exists = court_owner.court_position:court_tutor_court_position
+			exists = court_owner.court_position:court_guru_court_position #Unop: Guru is also the tutor
 			any_courtier_or_guest = {
 				is_adult = yes
 				is_available = yes
@@ -3514,29 +3352,11 @@ child_personality.0012 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = impatient
-					has_trait = shy
-					has_trait = gluttonous
-				}
-			}
-		}
-		modifier = {
-			add = 2
-			NOT = {
-				any_relation = {
-					type = guardian
-				}
-			}
-			court_owner.court_position:court_tutor_court_position ?= {
-				OR = {
-					has_trait = impatient
-					has_trait = shy
-					has_trait = gluttonous
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = impatient
+				TRAIT_2 = shy
+				TRAIT_3 = gluttonous
 			}
 		}
 	}
@@ -4908,6 +4728,7 @@ child_personality.0052 = {
 		NOR = {
 			has_trait = stubborn
 			has_trait = fickle
+			has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 		}
 		NOT = { has_trait = incapable }
 	}
@@ -4942,6 +4763,7 @@ child_personality.0053 = {
 		NOR = {
 			has_trait = stubborn
 			has_trait = fickle
+			has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 		}
 		NOT = { has_trait = incapable }
 	}
@@ -6320,6 +6142,7 @@ child_personality.1051 = {
 				OR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -6359,6 +6182,7 @@ child_personality.1051 = {
 				NOR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -6406,6 +6230,7 @@ child_personality.1052 = {
 				OR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -6445,6 +6270,7 @@ child_personality.1052 = {
 				NOR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -6583,6 +6409,7 @@ child_personality.1061 = {
 				OR = {
 					has_trait = stubborn
 					has_trait = fickle
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -6622,6 +6449,7 @@ child_personality.1061 = {
 				NOR = {
 					has_trait = stubborn
 					has_trait = fickle
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -6667,6 +6495,7 @@ child_personality.1062 = {
 				OR = {
 					has_trait = stubborn
 					has_trait = fickle
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -6706,6 +6535,7 @@ child_personality.1062 = {
 				NOR = {
 					has_trait = stubborn
 					has_trait = fickle
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -7922,6 +7752,7 @@ child_personality.1111 = {
 				OR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 				OR = {
 					has_trait = trusting
@@ -7943,6 +7774,7 @@ child_personality.1111 = {
 				NOR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -8094,6 +7926,7 @@ child_personality.1113 = {
 				OR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -8133,6 +7966,7 @@ child_personality.1113 = {
 				NOR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}

--- a/events/education_and_childhood/child_personality_events_2.txt
+++ b/events/education_and_childhood/child_personality_events_2.txt
@@ -47,13 +47,10 @@ child_personality.7000 = {
 		base = 1
 		modifier = {
 			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = diligent
-					has_trait = gregarious
-					has_trait = temperate
-				}
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = diligent
+				TRAIT_2 = gregarious
+				TRAIT_3 = temperate
 			}
 		}
 		modifier = {
@@ -144,19 +141,13 @@ child_personality.7000 = {
 				is_ai = yes
 			}
 			add_character_flag = diligent
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7001
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7001 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = diligent
-				}
+				guardian_or_court_tutor_trait = { TRAIT = diligent } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -166,10 +157,7 @@ child_personality.7000 = {
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = lazy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lazy } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -197,26 +185,17 @@ child_personality.7000 = {
 				is_ai = yes
 			}
 			add_character_flag = gregarious
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7001
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7001 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = gregarious
-				}
+				guardian_or_court_tutor_trait = { TRAIT = gregarious } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = shy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = shy } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -235,26 +214,17 @@ child_personality.7000 = {
 				is_ai = yes
 			}
 			add_character_flag = temperate
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7001
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7001 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = temperate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = temperate } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = gluttonous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = gluttonous } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -664,14 +634,11 @@ child_personality.7010 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = zealous
-					has_trait = ambitious
-					has_trait = sadistic
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = zealous
+				TRAIT_2 = ambitious
+				TRAIT_3 = sadistic
 			}
 		}
 		modifier = {
@@ -779,26 +746,17 @@ child_personality.7010 = {
 				is_ai = yes
 			}
 			add_character_flag = zealous
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7011
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7011 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = zealous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = zealous } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = cynical
-				}
+				guardian_or_court_tutor_trait = { TRAIT = cynical } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -861,26 +819,17 @@ child_personality.7010 = {
 				is_ai = yes
 			}
 			add_character_flag = ambitious
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7011
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7011 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = ambitious
-				}
+				guardian_or_court_tutor_trait = { TRAIT = ambitious } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = content
-				}
+				guardian_or_court_tutor_trait = { TRAIT = content } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -940,26 +889,17 @@ child_personality.7010 = {
 				is_ai = yes
 			}
 			add_character_flag = sadistic
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7011
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7011 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = sadistic
-				}
+				guardian_or_court_tutor_trait = { TRAIT = sadistic } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = compassionate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = compassionate } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -1280,14 +1220,11 @@ child_personality.7020 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = shy
-					has_trait = paranoid
-					has_trait = craven
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = shy
+				TRAIT_2 = paranoid
+				TRAIT_3 = craven
 			}
 		}
 	}
@@ -1375,26 +1312,17 @@ child_personality.7020 = {
 				is_ai = yes
 			}
 			add_character_flag = shy
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7021
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7021 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = shy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = shy } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = gregarious
-				}
+				guardian_or_court_tutor_trait = { TRAIT = gregarious } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -1417,26 +1345,17 @@ child_personality.7020 = {
 				is_ai = yes
 			}
 			add_character_flag = paranoid
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7021
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7021 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = paranoid
-				}
+				guardian_or_court_tutor_trait = { TRAIT = paranoid } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = trusting
-				}
+				guardian_or_court_tutor_trait = { TRAIT = trusting } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -1469,26 +1388,17 @@ child_personality.7020 = {
 				is_ai = yes
 			}
 			add_character_flag = craven
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7021
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7021 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = craven
-				}
+				guardian_or_court_tutor_trait = { TRAIT = craven } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = brave
-				}
+				guardian_or_court_tutor_trait = { TRAIT = brave } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -1788,14 +1698,11 @@ child_personality.7030 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = lazy
-					has_trait = gluttonous
-					has_trait = compassionate
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = lazy
+				TRAIT_2 = gluttonous
+				TRAIT_3 = compassionate
 			}
 		}
 		modifier = {
@@ -1903,26 +1810,17 @@ child_personality.7030 = {
 				is_ai = yes
 			}
 			add_character_flag = lazy
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7031
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7031 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = lazy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lazy } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = diligent
-				}
+				guardian_or_court_tutor_trait = { TRAIT = diligent } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -1955,26 +1853,17 @@ child_personality.7030 = {
 				is_ai = yes
 			}
 			add_character_flag = gluttonous
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7031
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7031 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = gluttonous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = gluttonous } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = temperate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = temperate } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -2011,28 +1900,19 @@ child_personality.7030 = {
 				is_ai = yes
 			}
 			add_character_flag = compassionate
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7031
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7031 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = compassionate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = compassionate } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = callous
-						has_trait = sadistic
-					}
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = callous 
+					TRAIT_2 = sadistic
 				}
 			}
 			modifier = {
@@ -2450,13 +2330,10 @@ child_personality.7040 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = lustful
-					has_trait = chaste
-				}
+			add = 2	
+			guardian_or_court_tutor_2_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = lustful
+				TRAIT_2 = chaste
 			}
 		}
 		modifier = {
@@ -2666,26 +2543,17 @@ child_personality.7040 = {
 				is_ai = yes
 			}
 			add_character_flag = lustful
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7041
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7041 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = lustful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lustful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = chaste
-				}
+				guardian_or_court_tutor_trait = { TRAIT = chaste } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -2704,26 +2572,17 @@ child_personality.7040 = {
 				is_ai = yes
 			}
 			add_character_flag = lustful
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7041
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7041 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = lustful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lustful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = chaste
-				}
+				guardian_or_court_tutor_trait = { TRAIT = chaste } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -2736,26 +2595,17 @@ child_personality.7040 = {
 				is_ai = yes
 			}
 			add_character_flag = chaste
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7041
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7041 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = chaste
-				}
+				guardian_or_court_tutor_trait = { TRAIT = chaste } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = lustful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = lustful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -2944,6 +2794,7 @@ child_personality.7050 = {
 			OR = {
 				exists = cp:councillor_steward
 				employs_court_position = court_tutor_court_position
+				employs_court_position = court_guru_court_position
 			}
 		}
 		NAND = {
@@ -2967,14 +2818,11 @@ child_personality.7050 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = just
-					has_trait = greedy
-					has_trait = callous
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = just
+				TRAIT_2 = greedy
+				TRAIT_3 = callous
 			}
 		}
 		modifier = {
@@ -2998,6 +2846,15 @@ child_personality.7050 = {
 				}
 				random_court_position_holder = {
 					type = court_tutor_court_position
+					save_scope_as = teacher
+				}
+			}
+			else_if = {
+				limit = {
+					employs_court_position = court_guru_court_position
+				}
+				random_court_position_holder = {
+					type = court_guru_court_position
 					save_scope_as = teacher
 				}
 			}
@@ -3052,26 +2909,17 @@ child_personality.7050 = {
 				is_ai = yes
 			}
 			add_character_flag = just
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7051
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7051 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = just
-				}
+				guardian_or_court_tutor_trait = { TRAIT = just } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = arbitrary
-				}
+				guardian_or_court_tutor_trait = { TRAIT = arbitrary } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -3121,26 +2969,17 @@ child_personality.7050 = {
 				is_ai = yes
 			}
 			add_character_flag = greedy
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7051
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7051 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = greedy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = greedy } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = generous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = generous } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -3186,29 +3025,20 @@ child_personality.7050 = {
 				is_ai = yes
 			}
 			add_character_flag = callous
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7051
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7051 }
 		}
 		ai_chance = {
 			base = 1
-			modifier = {
+			modifier = { 
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = callous
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = callous #Unop: Originally was giving both +4 & -0.5 if callous, now only +4 if callous
+					TRAIT_2 = sadistic #Unop: Originally was giving -0.5 if sadistic, IMHO it should increase the chances here from the option context
 				}
 			}
-			modifier = {
+			modifier = { #Unop: Originally compassionate was not taken into account, so added it as the only option that decrease the odds
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = callous
-						has_trait = sadistic
-					}
-				}
+				guardian_or_court_tutor_trait = { TRAIT = compassionate } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -3510,14 +3340,11 @@ child_personality.7060 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = humble
-					has_trait = cynical
-					has_trait = content
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = humble
+				TRAIT_2 = cynical
+				TRAIT_3 = content
 			}
 		}
 		modifier = {
@@ -3613,26 +3440,17 @@ child_personality.7060 = {
 				is_ai = yes
 			}
 			add_character_flag = humble
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7061
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7061 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = humble
-				}
+				guardian_or_court_tutor_trait = { TRAIT = humble } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = arrogant
-				}
+				guardian_or_court_tutor_trait = { TRAIT = arrogant } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -3664,26 +3482,17 @@ child_personality.7060 = {
 				is_ai = yes
 			}
 			add_character_flag = cynical
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7061
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7061 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = cynical
-				}
+				guardian_or_court_tutor_trait = { TRAIT = cynical } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = zealous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = zealous } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -3704,26 +3513,17 @@ child_personality.7060 = {
 				is_ai = yes
 			}
 			add_character_flag = content
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7061
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7061 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = content
-				}
+				guardian_or_court_tutor_trait = { TRAIT = content } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = ambitious
-				}
+				guardian_or_court_tutor_trait = { TRAIT = ambitious } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -4018,14 +3818,11 @@ child_personality.7070 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = vengeful
-					has_trait = deceitful
-					has_trait = calm
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = vengeful
+				TRAIT_2 = deceitful
+				TRAIT_3 = calm
 			}
 		}
 		modifier = {
@@ -4163,26 +3960,17 @@ child_personality.7070 = {
 				is_ai = yes
 			}
 			add_character_flag = vengeful
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7071
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7071 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = vengeful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = vengeful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = forgiving
-				}
+				guardian_or_court_tutor_trait = { TRAIT = forgiving } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -4212,26 +4000,17 @@ child_personality.7070 = {
 				is_ai = yes
 			}
 			add_character_flag = deceitful
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7071
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7071 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = deceitful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = deceitful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = honest
-				}
+				guardian_or_court_tutor_trait = { TRAIT = honest } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -4257,26 +4036,17 @@ child_personality.7070 = {
 				is_ai = yes
 			}
 			add_character_flag = calm
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7071
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7071 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = calm
-				}
+				guardian_or_court_tutor_trait = { TRAIT = calm } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = wrathful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = wrathful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -4613,14 +4383,11 @@ child_personality.7080 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = generous
-					has_trait = fickle
-					has_trait = arrogant
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = generous
+				TRAIT_2 = fickle
+				TRAIT_3 = arrogant
 			}
 		}
 		modifier = {
@@ -4695,26 +4462,17 @@ child_personality.7080 = {
 				is_ai = yes
 			}
 			add_character_flag = generous
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7081
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7081 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = generous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = generous } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = greedy
-				}
+				guardian_or_court_tutor_trait = { TRAIT = greedy } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -4731,6 +4489,7 @@ child_personality.7080 = {
 			NOR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle
 			}
 		}
 		add_trait = fickle
@@ -4740,26 +4499,20 @@ child_personality.7080 = {
 				is_ai = yes
 			}
 			add_character_flag = fickle
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7081
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7081 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = fickle
-				}
+				guardian_or_court_tutor_trait = { TRAIT = fickle } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = stubborn
-				}
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = stubborn
+					TRAIT_2 = eccentric
+				} 
 			}
 		}
 	}
@@ -4791,26 +4544,17 @@ child_personality.7080 = {
 				is_ai = yes
 			}
 			add_character_flag = arrogant
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7081
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7081 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = arrogant
-				}
+				guardian_or_court_tutor_trait = { TRAIT = arrogant } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = humble
-				}
+				guardian_or_court_tutor_trait = { TRAIT = humble } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -4992,6 +4736,7 @@ child_personality.7081 = {
 				NOR = {
 					has_trait = fickle
 					has_trait = stubborn
+					has_trait = eccentric #Unop: eccentric is opposed to fickle
 				}
 			}
 		}
@@ -5082,6 +4827,7 @@ child_personality.7090 = {
 			OR = {
 				exists = cp:councillor_chancellor
 				employs_court_position = court_tutor_court_position
+				employs_court_position = court_guru_court_position
 			}
 		}
 		NAND = {
@@ -5104,14 +4850,11 @@ child_personality.7090 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = forgiving
-					has_trait = trusting
-					has_trait = patient
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = forgiving
+				TRAIT_2 = trusting
+				TRAIT_3 = patient
 			}
 		}
 		modifier = {
@@ -5135,6 +4878,15 @@ child_personality.7090 = {
 				}
 				random_court_position_holder = {
 					type = court_tutor_court_position
+					save_scope_as = teacher
+				}
+			}
+			else_if = {
+				limit = {
+					employs_court_position = court_guru_court_position
+				}
+				random_court_position_holder = {
+					type = court_guru_court_position
 					save_scope_as = teacher
 				}
 			}
@@ -5184,26 +4936,17 @@ child_personality.7090 = {
 				is_ai = yes
 			}
 			add_character_flag = forgiving
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7091
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7091 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = forgiving
-				}
+				guardian_or_court_tutor_trait = { TRAIT = forgiving } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = vengeful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = vengeful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -5246,26 +4989,17 @@ child_personality.7090 = {
 				is_ai = yes
 			}
 			add_character_flag = trusting
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7091
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7091 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = trusting
-				}
+				guardian_or_court_tutor_trait = { TRAIT = trusting } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = paranoid
-				}
+				guardian_or_court_tutor_trait = { TRAIT = paranoid } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -5308,26 +5042,17 @@ child_personality.7090 = {
 				is_ai = yes
 			}
 			add_character_flag = patient
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7091
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7091 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = patient
-				}
+				guardian_or_court_tutor_trait = { TRAIT = patient } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = impatient
-				}
+				guardian_or_court_tutor_trait = { TRAIT = impatient } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -5592,14 +5317,11 @@ child_personality.7100 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = honest
-					has_trait = arbitrary
-					has_trait = impatient
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = honest
+				TRAIT_2 = arbitrary
+				TRAIT_3 = impatient
 			}
 		}
 		modifier = {
@@ -5675,26 +5397,17 @@ child_personality.7100 = {
 				is_ai = yes
 			}
 			add_character_flag = honest
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7101
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7101 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = honest
-				}
+				guardian_or_court_tutor_trait = { TRAIT = honest } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = deceitful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = deceitful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = 100
@@ -5735,26 +5448,17 @@ child_personality.7100 = {
 				is_ai = yes
 			}
 			add_character_flag = arbitrary
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7101
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7101 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = arbitrary
-				}
+				guardian_or_court_tutor_trait = { TRAIT = arbitrary } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = just
-				}
+				guardian_or_court_tutor_trait = { TRAIT = just } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -5780,26 +5484,17 @@ child_personality.7100 = {
 				is_ai = yes
 			}
 			add_character_flag = impatient
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7101
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7101 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = impatient
-				}
+				guardian_or_court_tutor_trait = { TRAIT = impatient } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = patient
-				}
+				guardian_or_court_tutor_trait = { TRAIT = patient } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -6061,6 +5756,7 @@ child_personality.7200 = {
 			OR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 			OR = {
 				has_trait = wrathful
@@ -6073,14 +5769,11 @@ child_personality.7200 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = brave
-					has_trait = stubborn
-					has_trait = wrathful
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = brave
+				TRAIT_2 = stubborn
+				TRAIT_3 = wrathful
 			}
 		}
 		modifier = {
@@ -6091,6 +5784,7 @@ child_personality.7200 = {
 			NOR = {
 				has_trait = stubborn
 				has_trait = fickle
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 	}
@@ -6175,26 +5869,17 @@ child_personality.7200 = {
 				is_ai = yes
 			}
 			add_character_flag = brave
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7201
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7201 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = brave
-				}
+				guardian_or_court_tutor_trait = { TRAIT = brave } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = craven
-				}
+				guardian_or_court_tutor_trait = { TRAIT = craven } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -6205,6 +5890,7 @@ child_personality.7200 = {
 			NOR = {
 				has_trait = fickle
 				has_trait = stubborn
+				has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 			}
 		}
 		add_trait = stubborn
@@ -6223,26 +5909,20 @@ child_personality.7200 = {
 				is_ai = yes
 			}
 			add_character_flag = stubborn
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7201
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7201 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = stubborn
-				}
+				guardian_or_court_tutor_trait = { TRAIT = stubborn } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = fickle
-				}
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = fickle
+					TRAIT_2 = eccentric
+				} 
 			}
 			modifier = {
 				add = 100
@@ -6280,26 +5960,17 @@ child_personality.7200 = {
 				is_ai = yes
 			}
 			add_character_flag = wrathful
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7201
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7201 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = wrathful
-				}
+				guardian_or_court_tutor_trait = { TRAIT = wrathful } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = calm
-				}
+				guardian_or_court_tutor_trait = { TRAIT = calm } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -6481,6 +6152,7 @@ child_personality.7201 = {
 				NOR = {
 					has_trait = stubborn
 					has_trait = fickle
+					has_trait = eccentric #Unop: eccentric is opposed to fickle & stubborn
 				}
 			}
 		}
@@ -6592,14 +6264,22 @@ child_personality.7300 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = eccentric
-					has_trait = gregarious
-					has_trait = compassionate
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = eccentric
+				TRAIT_2 = gregarious
+				TRAIT_3 = compassionate
+			}
+		}
+		modifier = { #Unop: Add missing culure modifier
+			add = 5
+			culture = {
+				has_cultural_parameter = compassionate_trait_more_common
+			}
+			NOR = {
+				has_trait = compassionate
+				has_trait = callous
+				has_trait = sadistic
 			}
 		}
 	}
@@ -6627,28 +6307,19 @@ child_personality.7300 = {
 				is_ai = yes
 			}
 			add_character_flag = eccentric
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7301
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7301 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = eccentric
-				}
+				guardian_or_court_tutor_trait = { TRAIT = eccentric } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = fickle
-						has_trait = stubborn
-					}
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = fickle
+					TRAIT_2 = stubborn
 				}
 			}
 		}
@@ -6670,28 +6341,25 @@ child_personality.7300 = {
 				is_ai = yes
 			}
 			add_character_flag = compassionate
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7301
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7301 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = compassionate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = compassionate } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = sadistic
-						has_trait = callous
-					}
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = sadistic
+					TRAIT_2 = callous
+				}
+			}
+			modifier = { #Unop: Add missing culure modifier
+				add = 100
+				culture = {
+					has_cultural_parameter = compassionate_trait_more_common
 				}
 			}
 		}
@@ -6713,26 +6381,17 @@ child_personality.7300 = {
 				is_ai = yes
 			}
 			add_character_flag = callous
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7301
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7301 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = callous
-				}
+				guardian_or_court_tutor_trait = { TRAIT = callous } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					has_trait = compassionate
-				}
+				guardian_or_court_tutor_trait = { TRAIT = compassionate } #Unop: To match what is done in the child_personality_events.txt file
 			}
 		}
 	}
@@ -7037,14 +6696,22 @@ child_personality.7400 = {
 	weight_multiplier = {
 		base = 1
 		modifier = {
-			add = 2
-			any_relation = {
-				type = guardian
-				OR = {
-					has_trait = eccentric
-					has_trait = stubborn
-					has_trait = fickle
-				}
+			add = 2	
+			unop_guardian_or_court_tutor_3_trait = { #Unop: Custom trigger to check the 3 traits with the guardian > tutor or guru
+				TRAIT = eccentric
+				TRAIT_2 = stubborn
+				TRAIT_3 = fickle
+			}
+		}
+		modifier = { #Unop: Add missing culure modifier
+			add = 5
+			culture = {
+				has_cultural_parameter = stubborn_trait_more_common
+			}
+			NOR = {
+				has_trait = stubborn
+				has_trait = fickle
+				has_trait = eccentric
 			}
 		}
 	}
@@ -7093,10 +6760,7 @@ child_personality.7400 = {
 				is_ai = yes
 			}
 			add_character_flag = eccentric
-			random_relation = {
-				type = guardian
-				trigger_event = { id = child_personality.7401 days = 1 }
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7401 }
 		}
 		progress_towards_friend_effect = {
 			REASON = friend_boardgames_on_horseback
@@ -7113,20 +6777,14 @@ child_personality.7400 = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = eccentric
-				}
+				guardian_or_court_tutor_trait = { TRAIT = eccentric } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = fickle
-						has_trait = stubborn
-					}
-				}
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = fickle 
+					TRAIT_2 = stubborn
+				} 
 			}
 		}
 	}
@@ -7140,28 +6798,25 @@ child_personality.7400 = {
 				is_ai = yes
 			}
 			add_character_flag = stubborn
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7401
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7401 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = stubborn
-				}
+				guardian_or_court_tutor_trait = { TRAIT = stubborn } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = fickle
-						has_trait = eccentric
-					}
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = fickle 
+					TRAIT_2 = eccentric
+				} 
+			}
+			modifier = { #Unop: Add missing culure modifier
+				add = 100
+				culture = {
+					has_cultural_parameter = stubborn_trait_more_common
 				}
 			}
 		}
@@ -7176,29 +6831,20 @@ child_personality.7400 = {
 				is_ai = yes
 			}
 			add_character_flag = fickle
-			random_relation = {
-				type = guardian
-				trigger_event = child_personality.7401
-			}
+			guardian_or_court_tutor_trigger_event = { EVENT = child_personality.7401 }
 		}
 		ai_chance = {
 			base = 1
 			modifier = {
 				add = 4
-				any_relation = {
-					type = guardian
-					has_trait = fickle
-				}
+				guardian_or_court_tutor_trait = { TRAIT = fickle } #Unop: To match what is done in the child_personality_events.txt file
 			}
 			modifier = {
 				add = -0.5
-				any_relation = {
-					type = guardian
-					OR = {
-						has_trait = eccentric
-						has_trait = stubborn
-					}
-				}
+				guardian_or_court_tutor_2_trait = { #Unop: To match what is done in the child_personality_events.txt file
+					TRAIT = eccentric 
+					TRAIT_2 = stubborn
+				} 
 			}
 		}
 	}


### PR DESCRIPTION
- [x] Create a variant to unop_guardian_or_court_tutor_3_trait to handle 3 traits checks for guardian then tutor or guru
- [x] Replace the events that are fired on the guardian to call guardian_or_court_tutor_trigger_event instead
- [x] Make sure court guru is also checked in some events where it only checked for guardian & court tutor
- [x] Make sure to add eccentric to the fickle & stubborn checks
- [x] Fix child_personality.7050.c **_ai_chance_** not checking compassionate
- [x] Make sure to replace all ai_chance modifiers that rely on checking the trait directly are calling either:
  - guardian_or_court_tutor_trait 
  - guardian_or_court_tutor_2_trait
- [x] Add missing culural influence modifiers to
  - tgp_child_personality.7300 & tgp_child_personality.7300.b
  - child_personality.7300 & child_personality.7300.b
  - child_personality.7400 & child_personality.7400.b