### PR TITLE
Fix children executed and teenagers teething

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+tmp/

--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -448,6 +448,10 @@ filter = {
 				file = common/factions/10_tgp_factions.txt
 			}
 		}
+		NAND = { # These dlc features are not unknown
+			key = missing-item
+			text = "unknown dlc feature holy_buildings"
+		}
 
 		########################################################################
 		# Ignored

--- a/events/court_events/court_events_general.txt
+++ b/events/court_events/court_events_general.txt
@@ -11912,6 +11912,7 @@ scripted_trigger is_illegal_criminal_trigger = {
 scripted_trigger court_8170_criminal_trigger = {
 	is_imprisoned = no
 	is_landed = no
+	is_adult = yes
 	is_illegal_criminal_trigger = yes
 	NOR = {
 		has_relation_lover = root

--- a/events/dlc/bp2/bp2_yearly_7.txt
+++ b/events/dlc/bp2/bp2_yearly_7.txt
@@ -1614,7 +1614,8 @@ bp2_yearly.7005 = { #Wet Nurse informs you about first fallen teeth of your chil
 		}
 		random_courtier = {
 			limit = {
-				child_not_teen_trigger = yes
+				child_not_infant_trigger = yes #Unop Ensure this limit matches the trigger
+				age <= 8
 				this = root.player_heir
 				is_available_ai = yes
 				location = root.location
@@ -1625,7 +1626,8 @@ bp2_yearly.7005 = { #Wet Nurse informs you about first fallen teeth of your chil
 				}
 			}
 			alternative_limit = {
-				child_not_teen_trigger = yes
+				child_not_infant_trigger = yes #Unop Ensure this limit matches the trigger
+				age <= 8
 				NOT = {
 					any_sibling = {
 						age > prev.age
@@ -1636,13 +1638,15 @@ bp2_yearly.7005 = { #Wet Nurse informs you about first fallen teeth of your chil
 				is_child_of = root
 			}
 			alternative_limit = {
-				child_not_teen_trigger = yes
+				child_not_infant_trigger = yes #Unop Ensure this limit matches the trigger
+				age <= 8
 				is_available_ai = yes
 				location = root.location
 				is_child_of = root
 			}
 			alternative_limit = {
-				child_not_teen_trigger = yes
+				child_not_infant_trigger = yes #Unop Ensure this limit matches the trigger
+				age <= 8
 				is_available_ai = yes
 				location = root.location
 				OR = {


### PR DESCRIPTION
* Fix children being condemned as criminals (e.g. due to their faith) and executed in `court.8170`.
* Fix teenagers teething in `bp2_yearly.7005`
* Update `ck3-tiger.conf` with a new dlc constant.
* Add `tmp/` (used by `Makefile`) to .gitignore