### PR TITLE
Dev/fix scan nick counter

### DIFF
--- a/common/casus_belli_types/00_event_war.txt
+++ b/common/casus_belli_types/00_event_war.txt
@@ -3271,7 +3271,7 @@ fp1_scandi_adventurer_conquest = {
 			else_if = {
 				limit = {
 					has_variable = fp1_has_beaten_sa_progress
-					var:fp1_has_beaten_sa_progress <= 9
+					var:fp1_has_beaten_sa_progress <= 8 #Unop: Was 9, but the nick should be unlock at the 10th not 11th
 				}
 				change_variable = {
 					name = fp1_has_beaten_sa_progress


### PR DESCRIPTION
Minor logic issue where it would be on the 11th successfull defendent war that you would gain the nickname instead of the 10th