### PR TITLE
Fix missing description in chariot_race.4030 seduce option toast

### DIFF
--- a/events/activities/chariot_race_activity/chariot_race_ongoing_events.txt
+++ b/events/activities/chariot_race_activity/chariot_race_ongoing_events.txt
@@ -3257,7 +3257,8 @@ chariot_race.4030 = {
 				}
 				desc = chariot_race.4030.b.success
 				send_interface_toast = {
-					type = event_generic_good_text
+					#Unop event_generic_good_text requires a desc which is not provided here, leading to a "DESCRIPTION" placeholder
+					#type = event_generic_good_text
 					title = chariot_race.4030.b.success
 					left_icon = root
 					right_icon = scope:john
@@ -3331,7 +3332,8 @@ chariot_race.4030 = {
 				}
 				desc = chariot_race.4030.b.failure
 				send_interface_toast = {
-					type = event_generic_bad_text
+					#Unop event_generic_bad_text requires a desc which is not provided here, leading to a "DESCRIPTION" placeholder
+					#type = event_generic_bad_text
 					title = chariot_race.4030.b.failure
 					left_icon = root
 					right_icon = scope:john


### PR DESCRIPTION
Fixes #424

The `send_interface_toast` for `chariot_race.4030` option B (seduce) success and failure used `type = event_generic_good_text` / `event_generic_bad_text`, which require a `desc =` (rendered as `$event_message_text$`). Since neither toast supplied a `desc`, the engine printed the literal `DESCRIPTION` placeholder in the side notification.

The fix comments out the `type =` lines so the toasts default to a non-`_text` style (matching option A in the same event, which is unaffected by the bug).