### PR TITLE
Fix missing NOT_HOF_INTERACTION_HAS_HOUSE_MODIFIER localization

### DIFF
--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -286,3 +286,6 @@
  ep3_laamp_decision_event.1000.desc_outro_regional_world_asia_southeast_returned_04: "\n\nAlthough I am eager to return home, I am equally looking forward to returning to the region to further explore it's #S opportunities#!."
 
  monastic_schools_allowed_in_every_holding_type_active_name: "the ability to construct the #V $building_type_monastic_schools_01$#! line of [buildings|E] in all [holding_types|E]"
+
+ #Unop ep3_hof_ask_for_influence_interaction failure tooltip uses the NOT_ form because the trigger contains an inner NOT
+ NOT_HOF_INTERACTION_HAS_HOUSE_MODIFIER:0 "$HOF_INTERACTION_HAS_HOUSE_MODIFIER$"


### PR DESCRIPTION
Fixes #421

`ep3_hof_ask_for_influence_interaction` ("Ask for Clerical Influence") in `common/character_interactions/06_ep3_interactions.txt` has a `custom_description` whose inner trigger contains `NOT = { has_house_modifier = ep3_requested_faith_support_modifier }`. When the actor's house already has the modifier, the engine renders the failure tooltip with the `NOT_` prefix — but vanilla only defines `HOF_INTERACTION_HAS_HOUSE_MODIFIER`, so the raw key name is shown.

Adds `NOT_HOF_INTERACTION_HAS_HOUSE_MODIFIER` aliased to the existing positive-form text via `$HOF_INTERACTION_HAS_HOUSE_MODIFIER$`, so the two stay in sync.