### PR TITLE
Block Pay Tribute decision while previous mission cleanup is pending

### DIFF
--- a/common/scripted_triggers/tgp_tribute_mission_triggers.txt
+++ b/common/scripted_triggers/tgp_tribute_mission_triggers.txt
@@ -107,9 +107,12 @@ is_tributary_or_independent_neighbor_of_hegemon_trigger = {
 is_already_tribute_missioning_trigger = {
 	# set once we start travelling, if it becomes invalid we should no longer be treated as being on the mission
 	exists = var:tribute_mission_target_scope
-	# assure we are currently going to our overlord's capital, or else we're no longer on the mission 
-	current_travel_plan ?= {
-		final_destination_province = prev.var:tribute_mission_target_scope.capital_province
+	#Unop Only check the destination if a travel plan exists; without this, a planner-cancelled mission whose cleanup is still pending is treated as "not on a mission", letting the player start a new one and racing the delayed cleanup
+	trigger_if = {
+		limit = { exists = current_travel_plan }
+		current_travel_plan = {
+			final_destination_province = prev.var:tribute_mission_target_scope.capital_province
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #420

`is_already_tribute_missioning_trigger` in `common/scripted_triggers/tgp_tribute_mission_triggers.txt` requires both `exists = var:tribute_mission_target_scope` *and* `current_travel_plan ?= { final_destination_province = ... }`. After the player exits the travel planner there is no `current_travel_plan`, so the second clause evaluates as vacuously false (CK3's `?=` semantic), the trigger reports "not on a mission", and the "Pay Tribute" decision allows a fresh start while the cancel on_action's cleanup is still pending — racing it and producing wiped variables / lost gold / undefined mission state.

Restructures the destination check as a `trigger_if` that only runs when `current_travel_plan` exists. This way:
- Var set, no travel plan (planner-cancelled, cleanup pending) → trigger true → decision blocked.
- Var set, travel plan to overlord → trigger true (existing behavior).
- Var set, travel plan elsewhere → trigger false (existing "user re-routed" behavior preserved).
- Var unset → trigger false (mission cleaned up).

The existing tooltip `tribute_mission_decision.already_on_mission` ("You are already on a tribute mission") is shown to the player and is accurate for this case.