### PR TITLE
Fix hold_court.8160 leaving scope:accused unset when accused_list is empty

### DIFF
--- a/events/activities/hold_court_activity/hold_court_events_general.txt
+++ b/events/activities/hold_court_activity/hold_court_events_general.txt
@@ -21325,6 +21325,11 @@ hold_court.8160 = {
 				}
 				save_scope_as = accused
 			}
+			#Unop Fall back to the actual plotter when no other suspect was found, otherwise scope:accused stays unset and the event renders with a blank accused
+			if = {
+				limit = { NOT = { exists = scope:accused } }
+				scope:debug_scheme_owner ?= { save_scope_as = accused }
+			}
 		}
 		# Save an advocate if necessary/relevant
 		scope:victim = { 


### PR DESCRIPTION
Fixes #419 (first bug — second bug is tracked as #420)

`hold_court.8160` (Public Accusation, in `events/activities/hold_court_activity/hold_court_events_general.txt`) builds `accused_list` from root's vassals_or_below and courtiers passing `hold_court_8160_accused_trigger`, then picks one with `random_in_list = { ... save_scope_as = accused }`.

`hold_court_8160_accused_trigger` requires `can_start_scheme = { type = murder, target = scope:victim }`. The actual plotter (`scope:debug_scheme_owner`) is *already running* that scheme, so `can_start_scheme` returns false for them — they're filtered out of `accused_list`. If they're the only character in root's court who could plausibly plot against the victim, the list ends up empty, `random_in_list` saves nothing, and `scope:accused` stays unset. The event then renders with a blank/missing accused name (per the screenshot in the issue).

Adds a fallback: when `accused_list` produced no result, save `scope:debug_scheme_owner` (the actual plotter, which is always available at this point) as `accused`. The description blocks (nemesis/rival/claim/intrigue/etc.) resolve correctly against any character, and the existing `desc.fallback` ("No good reason") handles the no-obvious-motive case.