### PR TITLE
Allow transport contract targets across water

### DIFF
--- a/common/task_contracts/laamp_transport_contracts.txt
+++ b/common/task_contracts/laamp_transport_contracts.txt
@@ -1,0 +1,2029 @@
+﻿##################################################
+# INFO
+# Transport contracts for laamps. Any contract that require usage of the travel system to complete, i.e. fetch quests, escort quests, etc.
+#
+##################################################
+
+
+
+##################################################
+# GROUPS (for populate_task_contracts_for_area)
+#
+# laamp_contracts_transport_group
+#
+#
+#
+
+
+##################################################
+#
+# laamp_transport_vip - Escort Emissary - Escort a character's Courtier to another character
+# laamp_transport_artifact - Artifact Delivery - Transfer an artifact from one character to another
+# laamp_transport_gold - A Golden Gift - Transfer gold from one character to another
+# laamp_transport_ward - Ward Transfer - Escorting a Ward to a Guardian
+# laamp_transport_explorer - Eager Explorer - Baron wants to visit a Point of Interest
+# laamp_transport_animal - A Living Gift - Escorting a pet story cycle from one character to another character 
+#
+##################################################
+
+# VIP escort
+# scope:employer = ruler wanting to send a courtier to a foreign court
+# var:task_contract_object = the courtier to be escorted
+# task_contract_target = random neighbor of scope:employer
+# task_contract_destination = capital of task_contract_target
+laamp_transport_vip = {
+	group = laamp_contracts_transport_group
+	icon = "gfx/interface/icons/character_interactions/icon_contract_escort.dds"
+	travel = no
+	use_diplomatic_range = no
+
+	# Validity Triggers
+	valid_to_create = {
+		# Standard triggers.
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+		employer_has_treasury_to_offer_job_trigger = yes
+		valid_laamp_sensible_start_trigger = yes
+		# Specific flavour triggers.
+		laamp_task_contract_employer_not_antisocial_trigger = yes
+		scope:employer = {
+			any_courtier = {
+				is_ai = yes
+				is_available = yes
+				is_adult = yes
+				is_lowborn = no
+			}
+			any_neighboring_top_liege_realm_owner = {
+				is_ai = yes
+				is_adult = yes
+				capital_province != root.domicile.domicile_location
+			}
+		}
+	}
+	valid_to_keep = {
+		exists = root.var:task_contract_object
+		var:task_contract_object = {
+			is_courtier_of = root.task_contract_employer
+			is_available = yes
+		}
+	}
+	valid_to_accept = {
+		# Standard triggers.
+		valid_laamp_basic_accept_only_trigger = yes
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+	}
+	valid_to_continue = {
+		var:task_contract_object ?= {
+			is_alive = yes
+		}
+		var:task_contract_target ?= {
+			is_alive = yes
+		}
+	}
+
+	weight = {
+		# Standard weights.
+		value = task_contract_weight_interesting_quite_rare_value
+		add = laamp_contracts_weight_up_transport_value
+		add = task_contract_weight_employer_contact_list_value
+		scope:employer = { multiply = task_contract_weight_by_tier_value }
+	}
+	# On_Actions
+	on_create = {
+		scope:contract = {
+			save_scope_as = task_contract
+			task_contract_employer = {
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.var:task_contract_object }
+					}
+					random_courtier = {
+						limit = {
+							is_ai = yes
+							is_available = yes
+							is_adult = yes
+							is_lowborn = no
+						}
+						save_scope_as = task_contract_object
+					}
+				}
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_target }
+					}
+					random_neighboring_top_liege_realm_owner = {
+						limit = {
+							is_ai = yes
+							is_adult = yes
+							capital_province != scope:task_contract.task_contract_taker.domicile.domicile_location
+						}
+						save_scope_as = task_contract_target
+						if = {
+							limit = {
+								NOT = { exists = scope:task_contract.task_contract_destination }
+							}
+							capital_province = {
+								save_scope_as = task_contract_destination
+							}
+						}
+					}
+				}
+				else_if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_destination }
+					}
+					scope:task_contract.task_contract_target = {
+						capital_province = {
+							save_scope_as = task_contract_destination
+						}
+					}
+				}
+			}
+			set_variable = {
+				name = task_contract_employer
+				value = scope:task_contract.task_contract_employer
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_target
+				}
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract.task_contract_target
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract_target
+				}
+				set_task_contract_target = scope:task_contract_target
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_destination
+				}
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract.task_contract_destination
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract_destination
+				}
+			}
+			set_variable = {
+				name = task_contract_object
+				value = scope:task_contract_object
+			}
+			# Make our gold rewards static.
+			grab_gold_fuzz_number_effect = yes
+			set_variable = {
+				name = gold_success_critical
+				value = task_contract_success_gold_gain_travel_value
+			}
+			set_variable = {
+				name = gold_success_standard
+				value = task_contract_success_gold_gain_half_travel_value
+			}
+		}
+	}
+
+	on_accepted = {
+		task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_accept_contract" }
+		save_scope_as = task_contract
+		task_contract_taker = {
+			trigger_event = ep3_contract_event.0001
+		}
+	}
+
+	on_invalidated = {
+		if = {
+			limit = {
+				root.task_contract_taker = {
+					any_character_active_contract = {
+						this = root
+					}
+				}
+			}
+			task_contract_employer = {
+				save_scope_as = task_contract_employer
+			}
+			save_scope_value_as = {
+				name = task_contract_tier
+				value = root.task_contract_tier
+			}
+			var:task_contract_destination = {
+				save_scope_as = task_contract_destination
+			}
+			var:task_contract_object = {
+				save_scope_as = task_contract_object
+			}
+
+			if = {
+				limit = {
+					var:task_contract_object ?= {
+						is_alive = yes
+					}
+				}
+				var:task_contract_object = {
+					return_to_court = yes
+				}
+			}
+			task_contract_taker = {
+				set_variable = {
+					name = invalidated_task_contract_type
+					value = flag:laamp_transport_vip
+				}
+			}
+			if = {
+				limit = {
+					var:task_contract_object ?= {
+						is_alive = no
+					}
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:escortee_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+			else_if = {
+				limit = {
+					task_contract_employer = {
+						is_alive = no
+					}
+				}
+				task_contract_employer.primary_title.holder ?= {
+					save_scope_as = employer_heir
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:employer_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				
+				}
+			}
+			else_if = {
+				limit = {
+					var:task_contract_target = {
+						is_alive = no
+					}
+				}
+				var:task_contract_target ?= {
+					save_scope_as = dead_target
+				}
+				task_contract_employer = {
+					save_scope_as = task_contract_employer
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:target_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+		}
+	}
+
+	# Rewards
+	task_contract_reward = {
+		#reward name
+		success_critical = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_critical
+					PRESTIGE = task_contract_success_prestige_gain_full_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_excelled_reward_value
+					OPINION_TYPE = critically_succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		success_standard = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_standard
+					PRESTIGE = task_contract_success_prestige_gain_half_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_standard_reward_value
+					OPINION_TYPE = succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		failure_standard = {
+			positive = no
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_failure_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = 0
+					PRESTIGE = task_contract_failure_prestige_loss_full_value
+					PIETY = 0
+					PROVISIONS = task_contract_failure_provisions_gain_minor_value
+					OPINION = task_contract_opinion_standard_failure_value
+					OPINION_TYPE = failed_task_contract_opinion
+					CONTACT = no
+					CONTACT_HOOK = no
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+	}
+}
+
+# Artifact delivery
+# scope:employer = ruler wanting to send an artifact to a foreign court
+# var:escorted_artifact = the artifact to be escorted
+# task_contract_target = random neighbor of scope:employer
+# task_contract_destination = capital of task_contract_target
+laamp_transport_artifact = {
+	group = laamp_contracts_transport_group
+	icon = "gfx/interface/icons/character_interactions/icon_contract_escort.dds"
+	travel = no
+	use_diplomatic_range = no
+
+	# Validity Triggers
+	valid_to_create = {
+		# Standard triggers.
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+		employer_has_treasury_to_offer_job_trigger = yes
+		valid_laamp_sensible_start_trigger = yes
+		# Specific flavour triggers.
+		scope:employer = {
+			any_character_artifact = {
+				NOR = {
+					has_variable = artifact_succession_title
+					has_variable = historical_unique_artifact
+					has_variable = banner_house
+					has_variable = banner_dynasty
+				}
+			}
+			any_neighboring_top_liege_realm_owner = {
+				is_ai = yes
+				is_adult = yes
+				capital_province != root.domicile.domicile_location
+			}
+		}
+	}
+	valid_to_keep = {
+		exists = root.var:escorted_artifact
+	}
+	valid_to_accept = {
+		# Standard triggers.
+		valid_laamp_basic_accept_only_trigger = yes
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+		scope:employer = {
+			any_character_artifact = {
+				NOR = {
+					has_variable = artifact_succession_title
+					has_variable = historical_unique_artifact
+					has_variable = banner_house
+					has_variable = banner_dynasty
+				}
+			}
+		}
+	}
+	valid_to_continue = {
+		var:escorted_artifact ?= {
+			artifact_owner = {
+				OR = {
+					root.task_contract_taker = this
+					root.task_contract_target = this
+				}
+			}
+		}
+		var:task_contract_target ?= {
+			is_alive = yes
+		}
+	}
+
+	weight = {
+		# Standard weights.
+		value = task_contract_weight_interesting_quite_rare_value
+		add = laamp_contracts_weight_up_transport_value
+		add = task_contract_weight_employer_contact_list_value
+		scope:employer = { multiply = task_contract_weight_by_tier_value }
+	}
+	# On_Actions
+	on_create = {
+		scope:contract = {
+			save_scope_as = task_contract
+			task_contract_employer = {
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.var:escorted_artifact }
+					}
+					random_character_artifact = {
+						limit = {
+							NOR = {
+								has_variable = historical_unique_artifact
+							}
+							artifact_can_be_gift_advance_trigger = yes
+						}
+						save_scope_as = escorted_artifact
+					}
+				}
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_target }
+					}
+					random_neighboring_top_liege_realm_owner = {
+						limit = {
+							is_ai = yes
+							is_adult = yes
+							capital_province != scope:task_contract.task_contract_taker.domicile.domicile_location
+						}
+						save_scope_as = task_contract_target
+						if = {
+							limit = {
+								NOT = { exists = scope:task_contract.task_contract_destination }
+							}
+							capital_province = {
+								save_scope_as = task_contract_destination
+							}
+						}
+					}
+				}
+				else_if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_destination }
+					}
+					scope:task_contract.task_contract_target = {
+						capital_province = {
+							save_scope_as = task_contract_destination
+						}
+					}
+				}
+			}
+			set_variable = {
+				name = task_contract_employer
+				value = scope:task_contract.task_contract_employer
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_target
+				}
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract.task_contract_target
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract_target
+				}
+				set_task_contract_target = scope:task_contract_target
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_destination
+				}
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract.task_contract_destination
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract_destination
+				}
+			}
+			set_variable = {
+				name = escorted_artifact
+				value = scope:escorted_artifact
+			}
+			# Make our gold rewards static.
+			grab_gold_fuzz_number_effect = yes
+			set_variable = {
+				name = gold_success_critical
+				value = task_contract_success_gold_gain_travel_value
+			}
+			set_variable = {
+				name = gold_success_standard
+				value = task_contract_success_gold_gain_travel_value
+			}
+		}
+	}
+
+	on_accepted = {
+		task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_accept_contract" }
+		save_scope_as = task_contract
+		task_contract_taker = {
+			trigger_event = ep3_contract_event.0001
+		}
+	}
+
+	on_invalidated = {
+		if = {
+			limit = {
+				root.task_contract_taker = {
+					any_character_active_contract = {
+						this = root
+					}
+				}
+			}
+			task_contract_employer = {
+				save_scope_as = task_contract_employer
+			}
+			save_scope_value_as = {
+				name = task_contract_tier
+				value = root.task_contract_tier
+			}
+			var:task_contract_destination = {
+				save_scope_as = task_contract_destination
+			}
+
+			if = {
+				limit = {
+					var:task_contract_object ?= {
+						is_alive = yes
+					}
+				}
+				var:task_contract_object = {
+					return_to_court = yes
+				}
+			}
+			task_contract_taker = {
+				set_variable = {
+					name = invalidated_task_contract_type
+					value = flag:laamp_transport_artifact
+				}
+			}
+			if = {
+				limit = {
+					var:task_contract_object ?= {
+						is_alive = no
+					}
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:escortee_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+			else_if = {
+				limit = {
+					task_contract_employer = {
+						is_alive = no
+					}
+				}
+				task_contract_employer.primary_title.holder ?= {
+					save_scope_as = employer_heir
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:employer_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				
+				}
+			}
+			else_if = {
+				limit = {
+					var:task_contract_target = {
+						is_alive = no
+					}
+				}
+				var:task_contract_target ?= {
+					save_scope_as = dead_target
+				}
+				task_contract_employer = {
+					save_scope_as = task_contract_employer
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:target_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+			if = {
+				limit = {
+					var:escorted_artifact ?= {
+						owner = root.task_contract_taker
+					}
+				}
+				var:escorted_artifact = {
+					set_owner = root.task_contract_employer
+				}
+			}
+		}
+	}
+
+	# Rewards
+	task_contract_reward = {
+		success_critical = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_critical
+					PRESTIGE = task_contract_success_prestige_gain_full_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_excelled_reward_value
+					OPINION_TYPE = critically_succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		success_standard = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_standard
+					PRESTIGE = task_contract_success_prestige_gain_full_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_standard_reward_value
+					OPINION_TYPE = succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		transport_destroyed = {
+			positive = no
+			visible = no
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_failure_on_contract" }
+				save_scope_as = task_contract
+				task_contract_taker = {
+					send_interface_toast = {
+						type = event_toast_effect_bad
+						title = laamp_transport_contract.transport_failed
+						left_icon = root.task_contract_taker
+						right_icon = root.task_contract_employer
+						add_prestige = task_contract_failure_prestige_loss_full_value
+						reverse_add_opinion = {
+							modifier = failed_task_contract_opinion
+							target = root.task_contract_employer
+							opinion = -50
+						}
+					}
+				}
+			}
+		}
+		transport_stolen = {
+			positive = no
+			visible = no
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_failure_on_contract" }
+				save_scope_as = task_contract
+				task_contract_taker = {
+					send_interface_toast = {
+						type = event_toast_effect_bad
+						title = laamp_transport_contract.transport_failed
+						left_icon = root.task_contract_taker
+						right_icon = root.task_contract_employer
+						add_prestige = task_contract_failure_prestige_loss_full_value
+						reverse_add_opinion = {
+							modifier = failed_task_contract_opinion
+							target = root.task_contract_employer
+							opinion = -50
+						}
+					}
+				}
+			}
+		}
+		failure_standard = {
+			positive = no
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_failure_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = 0
+					PRESTIGE = task_contract_failure_prestige_loss_full_value
+					PIETY = 0
+					PROVISIONS = task_contract_failure_provisions_gain_minor_value
+					OPINION = task_contract_opinion_standard_failure_value
+					OPINION_TYPE = failed_task_contract_opinion
+					CONTACT = no
+					CONTACT_HOOK = no
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+	}
+}
+
+# Large sum of gold
+# scope:employer = ruler wanting to send a gift to a foreign court
+# var:escorted_artifact = the artifact to be escorted
+# task_contract_target = random neighbor of scope:employer
+# task_contract_destination = capital of task_contract_target
+laamp_transport_gold = {
+	group = laamp_contracts_transport_group
+	icon = "gfx/interface/icons/character_interactions/icon_contract_escort.dds"
+	travel = no
+	use_diplomatic_range = no
+
+	# Validity Triggers
+	valid_to_create = {
+		# Standard triggers.
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+		employer_has_treasury_to_offer_job_trigger = yes
+		valid_laamp_sensible_start_trigger = yes
+		scope:employer = {
+			gold >= {
+				value = task_contract_escort_gold_value
+				multiply = 1.5
+			}
+			any_neighboring_top_liege_realm_owner = {
+				is_ai = yes
+				is_adult = yes
+				gold <= 0
+				likes_character_trigger = { CHARACTER = scope:employer }
+				capital_province != root.domicile.domicile_location
+			}
+		}
+	}
+	valid_to_accept = {
+		# Standard triggers.
+		valid_laamp_basic_accept_only_trigger = yes
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+	}
+	valid_to_continue = {
+		var:task_contract_target ?= {
+			is_alive = yes
+		}
+	}
+
+	weight = {
+		# Standard weights.
+		value = task_contract_weight_interesting_somewhat_rare_value
+		add = laamp_contracts_weight_up_transport_value
+		add = task_contract_weight_employer_contact_list_value
+		scope:employer = { multiply = task_contract_weight_by_tier_value }
+	}
+
+	# On_Actions
+	on_create = {
+		scope:contract = {
+			save_scope_as = task_contract
+			task_contract_employer = {
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_target }
+					}
+					random_neighboring_top_liege_realm_owner = {
+						limit = {
+							is_ai = yes
+							is_adult = yes
+							gold <= 0
+							likes_character_trigger = { CHARACTER = scope:task_contract.task_contract_employer }
+							capital_province != scope:task_contract.task_contract_taker.domicile.domicile_location
+						}
+						save_scope_as = task_contract_target
+						capital_province = {
+							save_scope_as = task_contract_destination
+						}
+					}
+				}
+				else_if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_destination }
+					}
+					scope:task_contract.task_contract_target = {
+						capital_province = {
+							save_scope_as = task_contract_destination
+						}
+					}
+				}
+			}
+			set_variable = {
+				name = task_contract_employer
+				value = scope:task_contract.task_contract_employer
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_target
+				}
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract.task_contract_target
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract_target
+				}
+				set_task_contract_target = scope:task_contract_target
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_destination
+				}
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract.task_contract_destination
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract_destination
+				}
+			}
+			set_variable = {
+				name = escorted_gold
+				value = scope:task_contract.task_contract_employer.task_contract_escort_gold_value
+			}
+			# Make our gold rewards static.
+			grab_gold_fuzz_number_effect = yes
+			set_variable = {
+				name = gold_success_standard
+				value = task_contract_success_gold_gain_travel_value
+			}
+		}
+	}
+
+	on_accepted = {
+		task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_accept_contract" }
+		save_scope_as = task_contract
+		task_contract_taker = {
+			trigger_event = ep3_contract_event.0001
+		}
+	}
+
+	on_invalidated = {
+		if = {
+			limit = {
+				root.task_contract_taker = {
+					any_character_active_contract = {
+						this = root
+					}
+				}
+			}
+			task_contract_employer = {
+				save_scope_as = task_contract_employer
+			}
+			save_scope_value_as = {
+				name = task_contract_tier
+				value = root.task_contract_tier
+			}
+			var:task_contract_destination = {
+				save_scope_as = task_contract_destination
+			}
+
+			task_contract_taker = {
+				set_variable = {
+					name = invalidated_task_contract_type
+					value = flag:laamp_transport_gold
+				}
+			}
+			if = {
+				limit = {
+					task_contract_employer = {
+						is_alive = no
+					}
+				}
+				task_contract_employer.primary_title.holder ?= {
+					save_scope_as = employer_heir
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:employer_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				
+				}
+			}
+			else_if = {
+				limit = {
+					var:task_contract_target = {
+						is_alive = no
+					}
+				}
+				var:task_contract_target ?= {
+					save_scope_as = dead_target
+				}
+				task_contract_employer = {
+					save_scope_as = task_contract_employer
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:target_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+		}
+	}
+
+	# Rewards	
+	task_contract_reward = {
+		success_standard = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_standard
+					PRESTIGE = task_contract_success_prestige_gain_full_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_standard_reward_value
+					OPINION_TYPE = succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		failure_standard = {
+			positive = no
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_failure_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = 0
+					PRESTIGE = task_contract_failure_prestige_loss_full_value
+					PIETY = 0
+					PROVISIONS = task_contract_failure_provisions_gain_minor_value
+					OPINION = task_contract_opinion_standard_failure_value
+					OPINION_TYPE = failed_task_contract_opinion
+					CONTACT = no
+					CONTACT_HOOK = no
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+	}
+}
+
+# Child education
+# scope:employer = ruler wanting to send a child to educate at a foreign court
+# var:task_contract_object = the ward to be escorted
+# task_contract_target = worthy educator neighboring scope:employer
+# task_contract_destination = capital of task_contract_target
+laamp_transport_ward = {
+	group = laamp_contracts_transport_group
+	icon = "gfx/interface/icons/character_interactions/icon_contract_escort.dds"
+	travel = no
+	use_diplomatic_range = no
+
+	# Validity Triggers
+	valid_to_create = {
+		# Standard triggers.
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+		employer_has_treasury_to_offer_job_trigger = yes
+		valid_laamp_sensible_start_trigger = yes
+		# Specific flavour triggers.
+		scope:employer = {
+			any_child = {
+				is_ai = yes
+				is_available_child = yes
+				OR = {
+					num_of_relation_guardian = 0
+					any_relation = {
+						type = guardian
+						is_landed = no
+					}
+				}
+				age = { 4 12 }
+			}
+			OR = {
+				any_neighboring_top_liege_realm_owner = {
+					is_ai = yes
+					num_of_relation_ward < 2
+					is_adult = yes
+					OR = {
+						has_education_rank_4_trigger = yes
+						has_education_rank_5_trigger = yes
+						num_virtuous_traits > 0
+					}
+					has_any_good_relationship_with_character_trigger = { CHARACTER = scope:employer }
+					capital_province != root.domicile.domicile_location
+				}
+				any_vassal = {
+					is_ai = yes
+					num_of_relation_ward < 2
+					is_adult = yes
+					OR = {
+						has_education_rank_4_trigger = yes
+						has_education_rank_5_trigger = yes
+						num_virtuous_traits > 0
+					}
+					has_any_good_relationship_with_character_trigger = { CHARACTER = scope:employer }
+					capital_province != root.domicile.domicile_location
+				}
+			}
+		}
+	}
+	valid_to_keep = {
+		root.var:task_contract_object ?= {
+			is_available_child = yes
+		}
+	}
+	valid_to_accept = {
+		# Standard triggers.
+		valid_laamp_basic_accept_only_trigger = yes
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+	}
+	valid_to_continue = {
+		var:task_contract_object ?= {
+			is_alive = yes
+		}
+		var:task_contract_target ?= {
+			is_alive = yes
+		}
+	}
+
+	weight = {
+		# Standard weights.
+		value = task_contract_weight_interesting_somewhat_rare_value
+		add = laamp_contracts_weight_up_transport_value
+		add = task_contract_weight_employer_contact_list_value
+		scope:employer = { multiply = task_contract_weight_by_tier_value }
+	}
+
+	# On_Actions
+	on_create = {
+		scope:contract = {
+			save_scope_as = task_contract
+			task_contract_employer = {
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.var:task_contract_object }
+					}
+					random_child = {
+						limit = {
+							is_available_child = yes
+							OR = {
+								num_of_relation_guardian = 0
+								any_relation = {
+									type = guardian
+									is_landed = no
+								}
+							}
+							age = { 4 12 }
+						}
+						save_scope_as = task_contract_object
+					}
+				}
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_target }
+					}
+					random_neighboring_top_liege_realm_owner = {
+						limit = {
+							is_ai = yes
+							is_adult = yes
+							num_of_relation_ward < 2
+							OR = {
+								has_education_rank_4_trigger = yes
+								has_education_rank_5_trigger = yes
+								num_virtuous_traits > num_sinful_traits
+							}
+							has_any_good_relationship_with_character_trigger = { CHARACTER = scope:task_contract.task_contract_employer }
+							capital_province != scope:task_contract.task_contract_taker.domicile.domicile_location
+						}
+						save_scope_as = task_contract_target
+					}
+				}
+				else = {
+					random_vassal = {
+						limit = {
+							is_ai = yes
+							num_of_relation_ward < 2
+							is_adult = yes
+							OR = {
+								has_education_rank_4_trigger = yes
+								has_education_rank_5_trigger = yes
+								num_virtuous_traits > num_sinful_traits
+							}
+							has_any_good_relationship_with_character_trigger = { CHARACTER = scope:task_contract.task_contract_employer }
+							capital_province != scope:task_contract.task_contract_taker.domicile.domicile_location
+						}
+						save_scope_as = task_contract_target
+					}
+				}
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_destination }
+					}
+					scope:task_contract_target = {
+						capital_province = {
+							save_scope_as = task_contract_destination
+						}
+					}
+				}
+			}
+			set_variable = {
+				name = task_contract_employer
+				value = scope:task_contract.task_contract_employer
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_target
+				}
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract.task_contract_target
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract_target
+				}
+				set_task_contract_target = scope:task_contract_target
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_destination
+				}
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract.task_contract_destination
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract_destination
+				}
+			}
+			set_variable = {
+				name = task_contract_object
+				value = scope:task_contract_object
+			}
+			#set the ward/guardian variables same as in education interactions
+			var:task_contract_object = {
+				set_variable = {
+					name = character_requested_as_educator
+					value = scope:task_contract.task_contract_target
+					years = 10
+				}
+				set_variable = {
+					name = character_making_education_request
+					value = scope:task_contract.task_contract_employer
+					years = 10
+				}
+				set_variable = {
+					name = ward_travelling_to_guardian
+					value = scope:task_contract.task_contract_target
+				}
+			}
+			var:task_contract_target = {
+				set_variable = {
+					name = guardian_waiting_for_ward
+					value = scope:task_contract.task_contract_target
+				}
+			}
+			# Make our gold rewards static.
+			grab_gold_fuzz_number_effect = yes
+			set_variable = {
+				name = gold_success_standard
+				value = task_contract_success_gold_gain_travel_value
+			}
+		}
+	}
+
+	on_accepted = {
+		task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_accept_contract" }
+		save_scope_as = task_contract
+		task_contract_taker = {
+			trigger_event = ep3_contract_event.0001
+		}
+	}
+
+	on_invalidated = {
+		if = {
+			limit = {
+				root.task_contract_taker = {
+					any_character_active_contract = {
+						this = root
+					}
+				}
+			}
+			task_contract_employer = {
+				save_scope_as = task_contract_employer
+			}
+			save_scope_value_as = {
+				name = task_contract_tier
+				value = root.task_contract_tier
+			}
+			var:task_contract_destination = {
+				save_scope_as = task_contract_destination
+			}
+			var:task_contract_object = {
+				save_scope_as = task_contract_object
+			}
+
+			task_contract_taker = {
+				set_variable = {
+					name = invalidated_task_contract_type
+					value = flag:laamp_transport_ward
+				}
+			}
+			if = {
+				limit = {
+					var:task_contract_object ?= {
+						is_alive = no
+					}
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:escortee_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+			else_if = {
+				limit = {
+					task_contract_employer = {
+						is_alive = no
+					}
+				}
+				task_contract_employer.primary_title.holder ?= {
+					save_scope_as = employer_heir
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:employer_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				
+				}
+			}
+			else_if = {
+				limit = {
+					var:task_contract_target = {
+						is_alive = no
+					}
+				}
+				var:task_contract_target ?= {
+					save_scope_as = dead_target
+				}
+				task_contract_employer = {
+					save_scope_as = task_contract_employer
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:target_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+			#remove the ward/guardian variables
+			if = {
+				limit = {
+					var:task_contract_object ?= {
+						is_alive = yes
+					}
+				}
+				var:task_contract_object = {
+					remove_variable = character_requested_as_educator
+					remove_variable = character_making_education_request
+					remove_variable = ward_travelling_to_guardian
+					return_to_court = yes
+				}
+			}
+			if = {
+				limit = {
+					task_contract_target ?= {
+						is_alive = yes
+					}
+				}
+				task_contract_target = {
+					remove_variable = guardian_waiting_for_ward
+				}
+			}
+		}
+	}
+
+	# Rewards
+	task_contract_reward = {
+		success_standard = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_standard
+					PRESTIGE = task_contract_success_prestige_gain_full_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_standard_reward_value
+					OPINION_TYPE = succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		failure_standard = {
+			positive = no
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_failure_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = 0
+					PRESTIGE = task_contract_failure_prestige_loss_full_value
+					PIETY = 0
+					PROVISIONS = task_contract_failure_provisions_gain_minor_value
+					OPINION = task_contract_opinion_standard_failure_value
+					OPINION_TYPE = failed_task_contract_opinion
+					CONTACT = no
+					CONTACT_HOOK = no
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+	}
+}
+
+# Explorer of Points of Interests
+# scope:employer = pool character wanting to visit a point of interest
+# var:travel_reason = the reason poi is worth a visit
+# task_contract_destination = capital of task_contract_target
+laamp_transport_explorer = {
+	group = laamp_contracts_transport_group
+	icon = "gfx/interface/icons/character_interactions/icon_contract_escort.dds"
+	travel = no
+	use_diplomatic_range = no
+
+	# Validity Triggers
+	valid_to_create = {
+		# Standard triggers.
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+		employer_has_treasury_to_offer_job_trigger = yes
+		valid_laamp_sensible_start_trigger = yes
+		# Specific flavour triggers.
+		scope:employer = {
+			is_ai = yes
+			is_available_allow_travelling = yes
+			is_adult = yes
+			highest_held_title_tier <= tier_barony
+			OR = {
+				ai_boldness >= 50
+				ai_energy >= 50
+				has_trait = lifestyle_traveler
+			}
+			any_neighboring_top_liege_realm_owner = {
+				is_within_diplo_range = { CHARACTER = root }
+				any_realm_province = {
+					this != root.domicile.domicile_location
+					has_any_travel_poi_trigger = yes
+				}
+			}
+		}
+	}
+	valid_to_accept = {
+		# Standard triggers.
+		valid_laamp_basic_accept_only_trigger = yes
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+	}
+	valid_to_continue = {
+		var:task_contract_object ?= {
+			is_alive = yes
+		}
+		var:task_contract_target ?= {
+			is_alive = yes
+		}
+	}
+
+	weight = {
+		# Standard weights.
+		value = task_contract_weight_interesting_almost_rare_value
+		add = laamp_contracts_weight_up_transport_value
+		add = task_contract_weight_employer_contact_list_value
+		scope:employer = { multiply = task_contract_weight_by_tier_value }
+	}
+
+	# On_Actions
+	on_create = {
+		scope:contract = {
+			save_scope_as = task_contract
+			task_contract_employer = {
+				random_neighboring_top_liege_realm_owner = {
+					limit = {
+						is_within_diplo_range = { CHARACTER = scope:task_contract.task_contract_taker }
+						any_realm_province = {
+							this != scope:task_contract.task_contract_taker.domicile.domicile_location
+							has_any_travel_poi_trigger = yes
+							save_temporary_scope_as = poi_province
+						}
+					}
+				}
+			}
+			scope:poi_province = {
+				save_scope_as = task_contract_destination
+				if = {
+					limit = { exists = province_owner }
+					province_owner = {
+						save_scope_as = task_contract_target
+					}
+				}
+				else = {
+					county.holder = {
+						save_scope_as = task_contract_target
+					}
+				}
+			}
+			set_variable = {
+				name = task_contract_employer
+				value = scope:task_contract.task_contract_employer
+			}
+			set_variable = {
+				name = task_contract_object
+				value = scope:task_contract.task_contract_employer
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_target
+				}
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract.task_contract_target
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract_target
+				}
+				set_task_contract_target = scope:task_contract_target
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_destination
+				}
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract.task_contract_destination
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract_destination	
+				}
+			}
+			var:task_contract_destination = {
+				switch = {
+					trigger = has_travel_point_of_interest
+					poi_capitals = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:capitals
+						}
+					}
+					poi_special_buildings_martial = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:special_buildings_martial
+						}
+					}
+					poi_special_buildings_learning = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:special_buildings_learning
+						}
+					}
+					poi_special_buildings_religious = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:special_buildings_religious
+						}
+					}
+					poi_special_buildings_diplomatic = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:special_buildings_diplomatic
+						}
+					}
+					poi_grand_city = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:grand_city
+						}
+					}
+					poi_special_buildings_wonder = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:special_buildings_wonder
+						}
+					}
+					poi_special_buildings_economic = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:special_buildings_economic
+						}
+					}
+					poi_mausoleum_at_halicarnassus = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:mausoleum_at_halicarnassus
+						}
+					}
+					poi_lighthouse_of_alexandria = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:lighthouse_of_alexandria
+						}
+					}
+					poi_natural_feature = {
+						save_scope_value_as = {
+							name = travel_reason
+							value = flag:natural_feature
+						}
+					}
+				}
+			}
+			set_variable = {
+				name = travel_reason
+				value = scope:travel_reason
+			}
+			# Make our gold rewards static.
+			grab_gold_fuzz_number_effect = yes
+			set_variable = {
+				name = gold_success_critical
+				value = task_contract_success_gold_gain_travel_value
+			}
+			set_variable = {
+				name = gold_success_standard
+				value = task_contract_success_gold_gain_half_travel_value
+			}
+		}
+	}
+
+	on_accepted = {
+		task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_accept_contract" }
+		save_scope_as = task_contract
+		task_contract_taker = {
+			trigger_event = ep3_contract_event.0001
+		}
+	}
+	on_invalidated = {
+		if = {
+			limit = {
+				root.task_contract_taker = {
+					any_character_active_contract = {
+						this = root
+					}
+				}
+			}
+			task_contract_employer = {
+				save_scope_as = task_contract_employer
+			}
+			save_scope_value_as = {
+				name = task_contract_tier
+				value = root.task_contract_tier
+			}
+			var:task_contract_destination = {
+				save_scope_as = task_contract_destination
+			}
+
+			task_contract_taker = {
+				set_variable = {
+					name = invalidated_task_contract_type
+					value = flag:laamp_transport_explorer
+				}
+			}
+			if = {
+				limit = {
+					task_contract_employer = {
+						is_alive = no
+					}
+				}
+				task_contract_employer.primary_title.holder ?= {
+					save_scope_as = employer_heir
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:employer_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				
+				}
+			}
+			task_contract_employer = {
+				if = {
+					limit = {
+						is_landed = no
+					}
+					move_to_pool = yes
+				}
+			}
+		}
+	}
+
+	# Rewards
+	task_contract_reward = {
+		success_critical = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_critical
+					PRESTIGE = task_contract_success_prestige_gain_full_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_excelled_reward_value
+					OPINION_TYPE = critically_succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		success_standard = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_standard
+					PRESTIGE = task_contract_success_prestige_gain_half_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_standard_reward_value
+					OPINION_TYPE = succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		failure_standard = {
+			positive = no
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_failure_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = 0
+					PRESTIGE = task_contract_failure_prestige_loss_full_value
+					PIETY = 0
+					PROVISIONS = task_contract_failure_provisions_gain_minor_value
+					OPINION = task_contract_opinion_standard_failure_value
+					OPINION_TYPE = failed_task_contract_opinion
+					CONTACT = no
+					CONTACT_HOOK = no
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+	}
+}
+
+# Pet Story Cycle: dog or cat
+# scope:employer = ruler with a pet wanting to give it away to a foreign court
+# var:escorted_story = the story cycle with the pet
+# task_contract_target = random ruler that doesn't have a pet story cycle
+# task_contract_destination = capital of task_contract_target
+laamp_transport_animal = {
+	group = laamp_contracts_transport_group
+	icon = "gfx/interface/icons/character_interactions/icon_contract_escort.dds"
+	travel = no
+	use_diplomatic_range = no
+
+	# Validity Triggers
+	valid_to_create = {
+		# Standard triggers.
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+		employer_has_treasury_to_offer_job_trigger = yes
+		valid_laamp_sensible_start_trigger = yes
+		# Specific flavour triggers.
+		scope:employer = {
+			has_named_cat_or_dog_trigger = yes
+			any_owned_story = {
+				NOT = { exists = var:gifted_pet_story }
+			}
+			any_neighboring_top_liege_realm_owner = {
+				is_ai = yes
+				is_adult = yes
+				has_cat_or_dog_trigger = no
+				capital_province != root.domicile.domicile_location
+			}
+		}
+	}
+	valid_to_keep = {
+		exists = root.var:escorted_story
+	}
+	valid_to_accept = {
+		# Standard triggers.
+		valid_laamp_basic_accept_only_trigger = yes
+		valid_laamp_basic_trigger = {
+			EMPLOYER = scope:employer
+			LAAMP = root
+		}
+		scope:employer = {
+			has_named_cat_or_dog_trigger = yes
+		}
+	}
+	valid_to_continue = {
+		exists = var:escorted_story
+		var:task_contract_target ?= {
+			is_alive = yes
+		}
+	}
+
+	weight = {
+		# Standard weights.
+		value = task_contract_weight_interesting_somewhat_rare_value
+		add = laamp_contracts_weight_up_transport_value
+		add = task_contract_weight_employer_contact_list_value
+		scope:employer = { multiply = task_contract_weight_by_tier_value }
+	}
+
+	# On_Actions
+	on_create = {
+		scope:contract = {
+			save_scope_as = task_contract
+			task_contract_employer = {
+				random_owned_story = {
+					limit = {
+						NOT = { exists = var:gifted_pet_story }
+						OR = {
+							story_type = story_cycle_pet_dog
+							story_type = story_cycle_pet_cat
+						}
+					}
+					save_scope_as = escorted_story
+				}
+				if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_target }
+					}
+					random_neighboring_top_liege_realm_owner = {
+						limit = {
+							is_ai = yes
+							is_adult = yes
+							has_cat_or_dog_trigger = no
+							capital_province != scope:task_contract.task_contract_taker.domicile.domicile_location
+						}
+						save_scope_as = task_contract_target
+						capital_province = {
+							save_scope_as = task_contract_destination
+						}
+					}
+				}
+				else_if = {
+					limit = {
+						NOT = { exists = scope:task_contract.task_contract_destination }
+					}
+					scope:task_contract.task_contract_target = {
+						capital_province = {
+							save_scope_as = task_contract_destination
+						}
+					}
+				}
+			}
+			set_variable = {
+				name = task_contract_employer
+				value = scope:task_contract.task_contract_employer
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_target
+				}
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract.task_contract_target
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_target
+					value = scope:task_contract_target
+				}
+				set_task_contract_target = scope:task_contract_target
+			}
+			if = {
+				limit = {
+					exists = scope:task_contract.task_contract_destination
+				}
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract.task_contract_destination
+				}
+			}
+			else = {
+				set_variable = {
+					name = task_contract_destination
+					value = scope:task_contract_destination	
+				}
+			}
+			set_variable = {
+				name = escorted_story
+				value = scope:escorted_story
+			}
+			if = {
+				limit = {
+					exists = scope:escorted_story.var:story_cycle_dog_name
+				}
+				set_variable = {
+					name = story_cycle_dog_name
+					value = scope:escorted_story.var:story_cycle_dog_name
+				}
+			}
+			else = {
+				set_variable = {
+					name = story_cycle_cat_name
+					value = scope:escorted_story.var:story_cycle_cat_name
+				}
+			}
+			# Make our gold rewards static.
+			grab_gold_fuzz_number_effect = yes
+			set_variable = {
+				name = gold_success_standard
+				value = task_contract_success_gold_gain_travel_value
+			}
+		}
+	}
+
+	on_accepted = {
+		task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_accept_contract" }
+		save_scope_as = task_contract
+		task_contract_taker = {
+			trigger_event = ep3_contract_event.0001
+		}
+	}
+
+	on_invalidated = {
+		if = {
+			limit = {
+				root.task_contract_taker = {
+					any_character_active_contract = {
+						this = root
+					}
+				}
+			}
+			task_contract_employer = {
+				save_scope_as = task_contract_employer
+			}
+			save_scope_value_as = {
+				name = task_contract_tier
+				value = root.task_contract_tier
+			}
+			var:task_contract_destination = {
+				save_scope_as = task_contract_destination
+			}
+
+			task_contract_taker = {
+				set_variable = {
+					name = invalidated_task_contract_type
+					value = flag:laamp_transport_animal
+				}
+			}
+			if = {
+				limit = {
+					NOT = { exists = var:escorted_story }
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:pet_dead
+					}
+					#for the localization to show the pet's name in the follow up event
+					if = {
+						limit = {
+							exists = root.var:story_cycle_dog_name
+						}
+						set_variable = {
+							name = story_cycle_dog_name
+							value = root.var:story_cycle_dog_name
+							days = 1
+						}
+					}
+					else = {
+						set_variable = {
+							name = story_cycle_cat_name
+							value = root.var:story_cycle_cat_name
+							days = 1
+						}
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+			else_if = {
+				limit = {
+					var:task_contract_target = {
+						is_alive = no
+					}
+				}
+				var:task_contract_target ?= {
+					save_scope_as = dead_target
+				}
+				task_contract_employer = {
+					save_scope_as = task_contract_employer
+				}
+				task_contract_taker = {
+					save_scope_value_as = {
+						name = task_contract_invalidation_reason
+						value = flag:target_dead
+					}
+					trigger_event = ep3_contract_event.0012
+				}
+			}
+		}
+	}
+
+	# Rewards
+	task_contract_reward = {
+		success_standard = {
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_success_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = scope:task_contract.var:gold_success_standard
+					PRESTIGE = task_contract_success_prestige_gain_full_value
+					PIETY = 0
+					PROVISIONS = 0
+					OPINION = task_contract_opinion_standard_reward_value
+					OPINION_TYPE = succeeded_task_contract_opinion
+					CONTACT = yes
+					CONTACT_HOOK = yes
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+		failure_standard = {
+			positive = no
+			effect = {
+				task_contract_taker = { play_sound_effect = "event:/DLC/EP3/SFX/UI/Contracts/ep3_ui_contracts_failure_on_contract" }
+				save_scope_value_as = { name = extra_reward value = flag:no }
+				laamp_rewards_disburse_ordinary_currency_effect = {
+					GOLD = 0
+					PRESTIGE = task_contract_failure_prestige_loss_full_value
+					PIETY = 0
+					PROVISIONS = task_contract_failure_provisions_gain_minor_value
+					OPINION = task_contract_opinion_standard_failure_value
+					OPINION_TYPE = failed_task_contract_opinion
+					CONTACT = no
+					CONTACT_HOOK = no
+					EXTRA_REWARD = scope:extra_reward
+				}
+			}
+		}
+	}
+}

--- a/common/task_contracts/laamp_transport_contracts.txt
+++ b/common/task_contracts/laamp_transport_contracts.txt
@@ -55,7 +55,7 @@ laamp_transport_vip = {
 				is_adult = yes
 				is_lowborn = no
 			}
-			any_neighboring_top_liege_realm_owner = {
+			any_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 				is_ai = yes
 				is_adult = yes
 				capital_province != root.domicile.domicile_location
@@ -116,7 +116,7 @@ laamp_transport_vip = {
 					limit = {
 						NOT = { exists = scope:task_contract.task_contract_target }
 					}
-					random_neighboring_top_liege_realm_owner = {
+					random_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 						limit = {
 							is_ai = yes
 							is_adult = yes
@@ -386,7 +386,7 @@ laamp_transport_artifact = {
 					has_variable = banner_dynasty
 				}
 			}
-			any_neighboring_top_liege_realm_owner = {
+			any_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 				is_ai = yes
 				is_adult = yes
 				capital_province != root.domicile.domicile_location
@@ -458,7 +458,7 @@ laamp_transport_artifact = {
 					limit = {
 						NOT = { exists = scope:task_contract.task_contract_target }
 					}
-					random_neighboring_top_liege_realm_owner = {
+					random_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 						limit = {
 							is_ai = yes
 							is_adult = yes
@@ -773,7 +773,7 @@ laamp_transport_gold = {
 				value = task_contract_escort_gold_value
 				multiply = 1.5
 			}
-			any_neighboring_top_liege_realm_owner = {
+			any_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 				is_ai = yes
 				is_adult = yes
 				gold <= 0
@@ -813,7 +813,7 @@ laamp_transport_gold = {
 					limit = {
 						NOT = { exists = scope:task_contract.task_contract_target }
 					}
-					random_neighboring_top_liege_realm_owner = {
+					random_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 						limit = {
 							is_ai = yes
 							is_adult = yes
@@ -1036,7 +1036,7 @@ laamp_transport_ward = {
 				age = { 4 12 }
 			}
 			OR = {
-				any_neighboring_top_liege_realm_owner = {
+				any_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 					is_ai = yes
 					num_of_relation_ward < 2
 					is_adult = yes
@@ -1121,7 +1121,7 @@ laamp_transport_ward = {
 					limit = {
 						NOT = { exists = scope:task_contract.task_contract_target }
 					}
-					random_neighboring_top_liege_realm_owner = {
+					random_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 						limit = {
 							is_ai = yes
 							is_adult = yes
@@ -1422,7 +1422,7 @@ laamp_transport_explorer = {
 				ai_energy >= 50
 				has_trait = lifestyle_traveler
 			}
-			any_neighboring_top_liege_realm_owner = {
+			any_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 				is_within_diplo_range = { CHARACTER = root }
 				any_realm_province = {
 					this != root.domicile.domicile_location
@@ -1461,7 +1461,7 @@ laamp_transport_explorer = {
 		scope:contract = {
 			save_scope_as = task_contract
 			task_contract_employer = {
-				random_neighboring_top_liege_realm_owner = {
+				random_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 					limit = {
 						is_within_diplo_range = { CHARACTER = scope:task_contract.task_contract_taker }
 						any_realm_province = {
@@ -1758,7 +1758,7 @@ laamp_transport_animal = {
 			any_owned_story = {
 				NOT = { exists = var:gifted_pet_story }
 			}
-			any_neighboring_top_liege_realm_owner = {
+			any_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 				is_ai = yes
 				is_adult = yes
 				has_cat_or_dog_trigger = no
@@ -1814,7 +1814,7 @@ laamp_transport_animal = {
 					limit = {
 						NOT = { exists = scope:task_contract.task_contract_target }
 					}
-					random_neighboring_top_liege_realm_owner = {
+					random_neighboring_and_across_water_top_liege_realm_owner = { #Unop Allow targets across water
 						limit = {
 							is_ai = yes
 							is_adult = yes


### PR DESCRIPTION
Fixes #418

All six `laamp_transport_*` contracts (`vip`, `artifact`, `gold`, `ward`, `explorer`, `animal`) picked targets via `random_neighboring_top_liege_realm_owner` (and gated creation with `any_neighboring_top_liege_realm_owner`), which only walks land neighbors. Rulers in landlocked or water-locked positions — notably 867 Japan — end up with no realistic target, or get sent on contracts that take 9+ months one way.

Switch both the `valid_to_create` gate and the `on_create` random pick to the `_and_across_water` variant in each of the six contracts so adventurers across narrow seas count as valid targets.

The reporter's named alternative (`random_neighboring_and_across_water_realm_owner`) doesn't exist in vanilla; the matching member of the file's existing iterator family is `random_neighboring_and_across_water_top_liege_realm_owner`. The same-rank variant the reporter also suggested would be a balance change rather than a fix and is out of scope here.

`make tiger` reports no new errors or warnings introduced by this change.