### PR TITLE
Fix major-decision culture rewards for divergent/hybrid cultures

### DIFF
--- a/common/scripted_effects/00_major_decisions_scripted_effects.txt
+++ b/common/scripted_effects/00_major_decisions_scripted_effects.txt
@@ -1410,7 +1410,9 @@ form_carolingian_empire_scripted_effect = {
 		}
 	}
 	# Innovations
-	culture:french = {
+	#culture:french = { #Unop Reward all Frankish-heritage cultures, not just French
+	every_culture_global = {
+		limit = { has_cultural_pillar = heritage_frankish }
 		if = {
 			limit = {
 				NOT = { has_innovation = innovation_knighthood }

--- a/common/scripted_effects/00_major_decisions_scripted_effects.txt
+++ b/common/scripted_effects/00_major_decisions_scripted_effects.txt
@@ -1,0 +1,4209 @@
+﻿create_roman_empire_scripted_effect = {
+	primary_title = { save_scope_as = old_primary_title }
+	add_trait = augustus
+	if = {
+		limit = { has_dlc_feature = legends }
+		create_legend_seed = {
+			type = legitimizing
+			quality = illustrious
+			chronicle = new_title
+			properties = {
+				title = title:h_roman_empire
+				founder = root
+			}
+		}
+	}
+	#Create Roman Empire, shift dejure/history/laws, destroy e_byzantium.
+
+	if = {
+		limit = { capital_county = { this = title:c_byzantion } }
+		title:h_roman_empire = {
+			set_capital_county = title:c_byzantion
+		}
+	}
+
+	hidden_effect = {
+		every_held_title = { #Should shift all dejure of all Empires owned at the time.
+			title_tier = empire
+
+			set_de_jure_liege_title = title:h_roman_empire
+		}
+		every_empire = {
+			limit = {
+				NOT = { exists = hegemony }
+				any_de_jure_county = {
+					percent >= 0.6
+					holder = {
+						OR = {
+							this = root
+							any_liege_or_above = { this = root }
+						}
+					}
+				}
+			}
+			set_de_jure_liege_title = title:h_roman_empire
+		}
+	}
+	split_byzantine_empire_effect = yes
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:h_roman_empire = {
+		change_title_holder = {
+			holder = root
+			change = scope:change
+		}
+		copy_title_history = title:e_byzantium
+	}
+	resolve_title_and_vassal_change = scope:change
+	if = { # Move your Title MaAs to your new title if you have any
+		limit = {
+			government_allows = administrative
+			primary_title = {
+				any_title_maa_regiment = { }
+			}
+		}
+		hidden_effect = {
+			primary_title = { transfer_title_maa_ownership = title:h_roman_empire }
+		}
+	}
+	if = { # If you have founded the Varangian Guard, you get to keep the benefits
+		limit = {
+			scope:old_primary_title = { has_variable = founded_varangian_guard }
+		}
+		hidden_effect = {
+			title:h_roman_empire = { set_variable = founded_varangian_guard }
+		}
+	}
+	hidden_effect = { set_primary_title_to = title:h_roman_empire }
+	every_held_title = { #Should destroy all other Empires owned at the time.
+		title_tier = empire
+
+		root = { destroy_title = prev }
+	}
+	
+	if = { #Automatically move capital to Constantinople, unless it's been set to Rome.
+		limit = {
+			NOT = { capital_county = { this = title:c_roma } }
+			NOT = { capital_county = { this = title:c_byzantion } }
+			culture = { has_cultural_pillar = heritage_byzantine }
+		}
+		hidden_effect = {
+			if = { #Usurp if not held personally.
+				limit = {
+					NOT = { this = title:c_byzantion.holder }
+				}
+				create_title_and_vassal_change = {
+					type = returned
+					save_scope_as = change
+					add_claim_on_loss = no
+				}
+				title:c_byzantion = {
+					change_title_holder = {
+						holder = root
+						change = scope:change
+					}
+				}
+				resolve_title_and_vassal_change = scope:change
+			}
+		}
+		root = { set_realm_capital = title:c_byzantion }
+	}
+	else_if = {
+		limit = {
+			NOT = { capital_county = { this = title:c_roma } }
+			NOT = { capital_county = { this = title:c_byzantion } }
+			NOT = { culture = { has_cultural_pillar = heritage_byzantine } }
+			exists = title:h_roman_empire.holder
+		}
+		hidden_effect = {
+			if = { #Usurp if not held personally.
+				limit = {
+					NOT = { this = title:c_roma.holder }
+				}
+				create_title_and_vassal_change = {
+					type = returned
+					save_scope_as = change
+					add_claim_on_loss = no
+				}
+				title:c_roma = {
+					change_title_holder = {
+						holder = root
+						change = scope:change
+					}
+				}
+				resolve_title_and_vassal_change = scope:change
+			}
+		}
+		root = { set_realm_capital = title:c_roma }
+	}
+	hidden_effect = {
+		add_character_flag = flag_restorer_of_rome #used for Eulogy.
+		title:h_roman_empire = {
+			set_variable = rome_was_restored_by_byzantium
+		}
+	}
+}
+
+create_roman_empire_holy_scripted_effect = {
+	add_trait = augustus
+	#Create Roman Empire, shift dejure/history/laws, destroy e_hre.
+	hidden_effect = {
+		every_held_title = { #Should shift all dejure of all Empires owned at the time.
+			title_tier = empire
+
+			set_de_jure_liege_title = title:h_roman_empire
+		}
+		primary_title = {
+			if = {
+				limit = {
+					any_in_de_jure_hierarchy = {
+						tier = tier_kingdom
+						OR = {
+							title:k_france ?= this
+							title:k_aquitaine ?= this
+							title:k_brittany ?= this
+						}
+					}
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						tier = tier_kingdom
+						OR = {
+							title:k_france ?= this
+							title:k_aquitaine ?= this
+							title:k_brittany ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_france
+					title:e_france = { set_de_jure_liege_title = title:h_roman_empire }
+				}
+			}
+			every_in_de_jure_hierarchy = {
+				limit = {
+					tier = tier_kingdom
+				}
+				set_de_jure_liege_title = title:e_germany
+				title:e_germany = { set_de_jure_liege_title = title:h_roman_empire }
+			}
+		}
+		every_empire = {
+			limit = {
+				NOT = { exists = hegemony }
+				any_de_jure_county = {
+					percent >= 0.6
+					holder = {
+						OR = {
+							this = root
+							any_liege_or_above = { this = root }
+						}
+					}
+				}
+			}
+			set_de_jure_liege_title = title:h_roman_empire
+		}
+	}
+	split_byzantine_empire_effect = yes
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:h_roman_empire = {
+		change_title_holder = {
+			holder = root
+			change = scope:change
+		}
+		set_variable = {
+			name = variable_restored_hre #Used for flavor later.
+			value = yes
+		}
+		copy_title_history = title:e_hre
+	}
+	resolve_title_and_vassal_change = scope:change
+	if = { # Move your Title MaAs to your new title if you have any
+		limit = {
+			government_allows = administrative
+			primary_title = {
+				any_title_maa_regiment = { }
+			}
+		}
+		hidden_effect = {
+			primary_title = { transfer_title_maa_ownership = title:h_roman_empire }
+		}
+	}
+	if = { # If you have founded the Varangian Guard, you get to keep the benefits (you are not likely to have done it here, but better safe than sorry)
+		limit = {
+			primary_title = { has_variable = founded_varangian_guard }
+		}
+		hidden_effect = {
+			title:h_roman_empire = { set_variable = founded_varangian_guard }
+		}
+	}
+	hidden_effect = { set_primary_title_to = title:h_roman_empire }
+	every_held_title = { #Should destroy all other Empires owned at the time.
+		title_tier = empire
+
+		root = { destroy_title = prev }
+	}
+	hidden_effect = {
+		title:h_roman_empire = {
+			set_coa = e_hre_roman
+			set_title_color = { 255 255 255 }
+		}
+	}
+
+	if = { #Automatically move capital to Rome.
+		limit = {
+			NOT = { capital_county = { this = title:c_roma } }
+			exists = title:h_roman_empire.holder
+		}
+		hidden_effect = {
+			if = { #Usurp if not held personally.
+				limit = {
+					NOT = { title:c_roma.holder = { this = root } }
+				}
+				create_title_and_vassal_change = {
+					type = returned
+					save_scope_as = change
+					add_claim_on_loss = no
+				}
+				title:c_roma = {
+					change_title_holder = {
+						holder = root
+						change = scope:change
+					}
+				}
+				resolve_title_and_vassal_change = scope:change
+			}
+		}
+		title:h_roman_empire.holder = { set_realm_capital = title:c_roma }
+	}
+	hidden_effect = {
+		create_story = restoring_roman_provinces_story
+		add_character_flag = flag_restorer_of_rome #used for Eulogy.
+	}
+}
+
+create_roman_empire_italy_scripted_effect = {
+	add_trait = augustus
+	#Create Roman Empire, shift dejure/history/laws, destroy e_italy.
+	hidden_effect = {
+		every_held_title = { #Should shift all dejure of all Empires owned at the time.
+			title_tier = empire
+
+			set_de_jure_liege_title = title:h_roman_empire
+		}
+		every_empire = {
+			limit = {
+				NOT = { exists = hegemony }
+				any_de_jure_county = {
+					percent >= 0.6
+					holder = {
+						OR = {
+							this = root
+							any_liege_or_above = { this = root }
+						}
+					}
+				}
+			}
+			set_de_jure_liege_title = title:h_roman_empire
+		}
+	}
+	split_byzantine_empire_effect = yes
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:h_roman_empire = {
+		change_title_holder = {
+			holder = root
+			change = scope:change
+		}
+		set_variable = {
+			name = variable_restored_italy #Used for flavor later.
+			value = yes
+		}
+		copy_title_history = title:e_italy
+	}
+	resolve_title_and_vassal_change = scope:change
+	if = { # Move your Title MaAs to your new title if you have any
+		limit = {
+			government_allows = administrative
+			primary_title = {
+				any_title_maa_regiment = { }
+			}
+		}
+		hidden_effect = {
+			primary_title = { transfer_title_maa_ownership = title:h_roman_empire }
+		}
+	}
+	if = { # If you have founded the Varangian Guard, you get to keep the benefits (you are not likely to have done it here, but better safe than sorry)
+		limit = {
+			primary_title = { has_variable = founded_varangian_guard }
+		}
+		hidden_effect = {
+			title:h_roman_empire = { set_variable = founded_varangian_guard }
+		}
+	}
+	hidden_effect = { set_primary_title_to = title:h_roman_empire }
+	every_held_title = { #Should destroy all other Empires owned at the time.
+		title_tier = empire
+
+		root = { destroy_title = prev }
+	}
+	if = { #Automatically move capital to Rome.
+		limit = {
+			NOT = { capital_county = { this = title:c_roma } }
+			exists = title:h_roman_empire.holder
+		}
+		hidden_effect = {
+			if = { #Usurp if not held personally.
+				limit = {
+					NOT = { title:c_roma.holder = { this = root } }
+				}
+				create_title_and_vassal_change = {
+					type = returned
+					save_scope_as = change
+					add_claim_on_loss = no
+				}
+				title:c_roma = {
+					change_title_holder = {
+						holder = root
+						change = scope:change
+					}
+				}
+				resolve_title_and_vassal_change = scope:change
+			}
+		}
+		title:h_roman_empire.holder = { set_realm_capital = title:c_roma }
+	}
+	hidden_effect = {
+		create_story = restoring_roman_provinces_story
+		add_character_flag = flag_restorer_of_rome #used for Eulogy.
+	}
+}
+
+split_byzantine_empire_effect = {
+	hidden_effect = {
+		every_sub_realm_title = { # First we check for held titles in the realm
+			limit = {
+				tier = tier_kingdom
+				NOR = {
+					de_jure_liege = title:e_illyria
+					de_jure_liege = title:e_macedonia
+					de_jure_liege = title:e_anatolia
+					de_jure_liege = title:e_oriens
+					de_jure_liege = title:e_aegyptus
+					de_jure_liege = title:e_africa
+				}
+			}
+			if = {
+				limit = {
+					title:e_italy ?= { is_titular = no }
+					OR = {
+						title:k_trinacria ?= this
+						title:k_sicily ?= this
+						title:k_naples ?= this
+						title:k_venice ?= this
+						title:k_romagna ?= this
+						title:k_sardinia ?= this
+						title:k_italy ?= this
+					}
+				}
+				set_de_jure_liege_title = title:e_italy
+				title:e_italy = { set_de_jure_liege_title = title:h_roman_empire }
+			}
+			if = {
+				limit = {
+					OR = {
+						title:k_trinacria ?= this
+						title:k_epirus ?= this
+						title:k_croatia ?= this
+						title:k_serbia ?= this
+						title:k_bosnia ?= this
+						title:k_sicily ?= this
+						title:k_venice ?= this
+						title:k_naples ?= this
+					}
+				}
+				set_de_jure_liege_title = title:e_illyria
+				title:e_illyria = { set_de_jure_liege_title = title:h_roman_empire }
+			}
+			if = {
+				limit = {
+					OR = {
+						title:k_thessalonika ?= this
+						title:k_hellas ?= this
+						title:k_krete ?= this
+						title:k_bulgaria ?= this
+					}
+				}
+				set_de_jure_liege_title = title:e_macedonia
+				title:e_macedonia = { set_de_jure_liege_title = title:h_roman_empire }
+			}
+			if = {
+				limit = {
+					OR = {
+						title:k_saruhan ?= this
+						title:k_tekke ?= this
+						title:k_trebizond ?= this
+						title:k_ottoman ?= this
+						title:k_rum ?= this
+						title:k_mentese ?= this
+						title:k_karaman ?= this
+						title:k_germiyan ?= this
+						title:k_eretnid ?= this
+						title:k_candar ?= this
+						title:k_nikaea ?= this
+						title:k_pontus ?= this
+						title:k_armenia ?= this
+						title:k_georgia ?= this
+						title:k_armenian_principality ?= this
+						title:k_old_armenia ?= this
+						title:k_anatolia ?= this
+						title:k_aydin ?= this
+					}
+				}
+				set_de_jure_liege_title = title:e_anatolia
+				title:e_anatolia = { set_de_jure_liege_title = title:h_roman_empire }
+			}
+			if = {
+				limit = {
+					exists = title:e_oriens
+					OR = {
+						title:k_syria ?= this
+						title:k_jerusalem ?= this
+						title:k_cyprus ?= this
+						title:k_jazira ?= this
+						title:k_mesopotamia ?= this
+						title:k_arabia ?= this
+						title:k_yemen ?= this
+						title:k_cyprus ?= this
+					}
+				}
+				set_de_jure_liege_title = title:e_oriens
+				title:e_oriens = { set_de_jure_liege_title = title:h_roman_empire }
+			}
+			if = {
+				limit = {
+					exists = title:e_aegyptus
+					OR = {
+						title:k_egypt ?= this
+						title:k_blemmyia ?= this
+						title:k_nubia ?= this
+						title:k_abyssinia ?= this
+					}
+				}
+				set_de_jure_liege_title = title:e_aegyptus
+				title:e_aegyptus = { set_de_jure_liege_title = title:h_roman_empire }
+			}
+			if = {
+				limit = {
+					exists = title:e_africa
+					OR = {
+						title:k_africa ?= this
+						title:k_tahert ?= this
+						title:k_maghreb ?= this
+					}
+				}
+				set_de_jure_liege_title = title:e_africa
+				title:e_africa = { set_de_jure_liege_title = title:h_roman_empire }
+			}
+		}
+		title:e_byzantium = { # Then we check for de jure titles of Byzantium
+			if = { 
+				limit = {
+					OR = {
+						NOT = { exists = holder }
+						holder ?= root
+					}
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						title:e_italy ?= { is_titular = no }
+						tier = tier_kingdom
+						OR = {
+							title:k_trinacria ?= this
+							title:k_sicily ?= this
+							title:k_naples ?= this
+							title:k_venice ?= this
+							title:k_romagna ?= this
+							title:k_sardinia ?= this
+							title:k_italy ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_italy
+					title:e_italy = { set_de_jure_liege_title = title:h_roman_empire }
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						tier = tier_kingdom	
+						OR = {
+							title:k_trinacria ?= this
+							title:k_epirus ?= this
+							title:k_croatia ?= this
+							title:k_serbia ?= this
+							title:k_bosnia ?= this
+							title:k_sicily ?= this
+							title:k_venice ?= this
+							title:k_naples ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_illyria
+					title:e_illyria = { set_de_jure_liege_title = title:h_roman_empire }
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						tier = tier_kingdom	
+						OR = {
+							title:k_thessalonika ?= this
+							title:k_hellas ?= this
+							title:k_krete ?= this
+							title:k_bulgaria ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_macedonia
+					title:e_macedonia = { set_de_jure_liege_title = title:h_roman_empire }
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						tier = tier_kingdom
+						OR = {
+							title:k_saruhan ?= this
+							title:k_tekke ?= this
+							title:k_trebizond ?= this
+							title:k_ottoman ?= this
+							title:k_rum ?= this
+							title:k_mentese ?= this
+							title:k_karaman ?= this
+							title:k_germiyan ?= this
+							title:k_eretnid ?= this
+							title:k_candar ?= this
+							title:k_nikaea ?= this
+							title:k_pontus ?= this
+							title:k_armenia ?= this
+							title:k_georgia ?= this
+							title:k_armenian_principality ?= this
+							title:k_old_armenia ?= this
+							title:k_anatolia ?= this
+							title:k_aydin ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_anatolia
+					title:e_anatolia = { set_de_jure_liege_title = title:h_roman_empire }
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						exists = title:e_oriens
+						tier = tier_kingdom
+						OR = {
+							title:k_syria ?= this
+							title:k_jerusalem ?= this
+							title:k_jazira ?= this
+							title:k_mesopotamia ?= this
+							title:k_arabia ?= this
+							title:k_yemen ?= this
+							title:k_cyprus ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_oriens
+					title:e_oriens = { set_de_jure_liege_title = title:h_roman_empire }
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						exists = title:e_aegyptus
+						tier = tier_kingdom
+						OR = {
+							title:k_egypt ?= this
+							title:k_blemmyia ?= this
+							title:k_nubia ?= this
+							title:k_abyssinia ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_aegyptus
+					title:e_aegyptus = { set_de_jure_liege_title = title:h_roman_empire }
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						exists = title:e_africa
+						tier = tier_kingdom
+						OR = {
+							title:k_africa ?= this
+							title:k_tahert ?= this
+							title:k_maghreb ?= this
+						}
+					}
+					set_de_jure_liege_title = title:e_africa
+					title:e_africa = { set_de_jure_liege_title = title:h_roman_empire }
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						tier = tier_kingdom
+					}
+					if = {
+						limit = {
+							any_title_to_title_neighboring_and_across_water_empire = {
+								count >= 1
+							}
+						}
+						random_title_to_title_neighboring_and_across_water_empire = {
+							save_scope_as = new_empire_de_jure
+						}
+						set_de_jure_liege_title = scope:new_empire_de_jure
+					}
+				}
+			}
+		}
+	}
+}
+
+create_eastern_roman_empire_scripted_effect = {
+	if = { # First we move the domicile of root, if necessary
+		limit = {
+			exists = domicile
+			domicile.domicile_location = {
+				geographical_region = custom_ep3_restore_rome_eastern_empire
+			}
+		}
+		domicile = {
+			move_domicile = root.capital_province
+		}
+	}
+	scope:new_holder = { # Secondly, we handle the new liege
+		add_trait = augustus
+		create_title_and_vassal_change = {
+			type = created
+			save_scope_as = change
+			add_claim_on_loss = no
+		}
+		if = { # We ensure they get Byzantion
+			limit = {
+				scope:new_holder != title:c_byzantion.holder
+			}
+			title:c_byzantion = {
+				change_title_holder = {
+					holder = scope:new_holder
+					change = scope:change
+				}
+			}
+		}
+		# We move over the De Jure for all the basic titles
+		title:e_byzantium ?= { set_de_jure_liege_title = title:h_eastern_roman_empire }
+		title:e_illyria ?= { set_de_jure_liege_title = title:h_eastern_roman_empire }
+		title:e_macedonia ?= { set_de_jure_liege_title = title:h_eastern_roman_empire }
+		title:e_anatolia ?= { set_de_jure_liege_title = title:h_eastern_roman_empire }
+		title:h_eastern_roman_empire = { # They get the new Roman Empire title
+			change_title_holder = {
+				holder = scope:new_holder
+				change = scope:change
+			}
+		}
+		root = { # They get every held title from current root in the greater region
+			every_held_title = {
+				limit = {
+					tier = tier_county
+					is_landless_type_title = no
+					title_province = { geographical_region = custom_ep3_restore_rome_eastern_empire }
+				}
+				change_title_holder = {
+					holder = scope:new_holder
+					change = scope:change
+				}
+			}
+		}
+		resolve_title_and_vassal_change = scope:change
+		set_primary_title_to = title:h_eastern_roman_empire 
+		set_realm_capital = title:c_byzantion
+	}
+		
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	# Then all the direct vassals who should move over
+	every_vassal = {
+		limit = {
+			highest_held_title_tier >= tier_county
+			capital_province = { geographical_region = custom_ep3_restore_rome_eastern_empire }
+		}
+		change_liege = {
+			liege = scope:new_holder
+			change = scope:change
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	# Then vassals who are not directly in line
+	every_vassal_or_below = {
+		limit = {
+			highest_held_title_tier >= tier_county
+			capital_province = { geographical_region = custom_ep3_restore_rome_eastern_empire }
+		}
+		change_liege = {
+			liege = scope:new_holder
+			change = scope:change
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+
+	# Then change the de_jure for empires that are de jure part of the Roman Empire, but who has mostly broken free
+	every_empire = {
+		limit = {
+			hegemony ?= title:h_roman_empire
+			any_de_jure_county = {
+				percent >= 0.51
+				title_province = {
+					geographical_region = custom_ep3_restore_rome_eastern_empire
+				}
+			}
+		}
+		set_de_jure_liege_title = title:h_eastern_roman_empire
+	}
+
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	# Then every title that aren't county title held by root, but they have a majority of the titles under their rule
+	every_held_title = {
+		limit = {
+			NOR = { 
+				tier = tier_county 
+				tier = tier_hegemony
+				this = root.primary_title
+			}
+			is_landless_type_title = no
+			any_de_jure_county = {
+				percent >= 0.51
+				title_province = {
+					geographical_region = custom_ep3_restore_rome_eastern_empire
+				}
+			}
+		}
+		change_title_holder = {
+			holder = scope:new_holder
+			change = scope:change
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+	
+	every_empire = {
+		limit = {
+			OR = {
+				any_de_jure_county = {
+					percent >= 0.75
+					holder = {
+						OR = {
+							this = scope:new_holder
+							any_liege_or_above = { this = scope:new_holder }
+						}
+					}
+				}
+				AND = {
+					de_jure_liege = title:h_eastern_roman_empire
+					any_de_jure_county = {
+						percent >= 0.51
+						holder = {
+							OR = {
+								this = scope:new_holder
+								any_liege_or_above = { this = scope:new_holder }
+							}
+						}
+					}
+				}
+			}
+		}
+		set_de_jure_liege_title = title:h_eastern_roman_empire
+	}
+}
+
+mend_great_schism_scripted_effect = {
+	root.faith = {
+		if = { #If from obscure branch of Christianity, make it official.
+			limit = {
+				root.faith = { NOT = { has_doctrine = special_doctrine_ecumenical_christian } }
+			}
+			add_doctrine = special_doctrine_ecumenical_christian
+		}
+		change_fervor = {
+			value = 25
+			desc = fervor_gain_mended_schism
+		}
+		hidden_effect = {
+			religion = {
+				every_faith = {
+					limit = {
+						this != religious_head.faith
+					}
+					remove_religious_head_title = yes
+				}
+			}
+		}
+	}
+	every_player = { #Notify all players of the same Faith.
+		limit = {
+			this != root
+			faith = root.faith
+		}
+		trigger_event = roman_restoration.0103
+	}
+	every_ruler = { #Notify rulers of other Christian branches that they are no longer valid and offer chance at conversion.
+		limit = {
+			faith.religion = root.faith.religion
+			faith != root.faith
+			NOT = { government_has_flag = government_is_theocracy }
+			this != this.faith.religious_head
+			faith = {
+				has_doctrine = special_doctrine_ecumenical_christian
+			}
+		}
+		trigger_event = roman_restoration.0101
+	}
+	every_player = { #Then notify all infidel players that might be around.
+		limit = {
+			OR = {
+				AND = { #Either filthy heretics...
+					faith.religion = root.faith.religion
+					faith = { NOT = { has_doctrine = special_doctrine_ecumenical_christian } }
+				}
+				faith.religion != root.faith.religion #...Or Heathens.
+			}
+		}
+		trigger_event = roman_restoration.0102
+	}
+	religion:christianity_religion = {
+		every_faith = { #All main branches of Christianity that were considered Ecumenical are now heresies.
+			custom = every_ecumenical_christian_faith.tt
+			limit = {
+				this.religion = root.faith.religion
+				has_doctrine = special_doctrine_ecumenical_christian
+				this != root.faith
+			}
+			remove_doctrine = special_doctrine_ecumenical_christian
+			change_fervor = {
+				value = -25
+				desc = fervor_loss_mended_schism
+			}
+		}
+	}
+
+	set_nickname_effect = { NICKNAME = nick_the_ecumenist }
+}
+
+restore_papacy_scripted_effect = {
+	save_scope_as = reformer
+	if = { #Pick your chaplain first.
+		limit = {
+			exists = cp:councillor_court_chaplain
+			cp:councillor_court_chaplain = { faith = faith:catholic }
+		}
+		cp:councillor_court_chaplain = { save_scope_as = new_pope }
+	}
+	else = {
+		hidden_effect = {
+			create_character = {
+				employer = root
+				template = religious_leader_character
+				random_traits = no
+				save_scope_as = new_pope
+			}
+		}
+		scope:new_pope = {
+			add_trait = education_learning_3
+			add_trait = zealous
+			add_trait = intellect_good_1
+			random_list = {
+				1 = { add_trait = lustful }
+				1 = { add_trait = chaste }
+				1 = { add_trait = wrathful }
+				1 = { add_trait = diligent }
+				1 = { add_trait = impatient }
+				1 = { add_trait = arrogant }
+				1 = { add_trait = humble }
+				1 = { add_trait = gregarious }
+			}
+			random_list = {
+				1 = { add_trait = honest }
+				1 = { add_trait = ambitious }
+				1 = { add_trait = just }
+				1 = { add_trait = cynical }
+				1 = { add_trait = zealous }
+				1 = { add_trait = compassionate }
+				1 = { add_trait = stubborn }
+			}
+		}
+	}
+	create_title_and_vassal_change = {
+		type = returned
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:k_papal_state = {
+		change_title_holder = {
+			holder = scope:new_pope
+			change = scope:change
+		}
+	}
+	title:c_roma = {
+		change_title_holder = {
+			holder = scope:new_pope
+			change = scope:change
+		}
+	}
+	title:d_latium = {
+		change_title_holder = {
+			holder = scope:new_pope
+			change = scope:change
+		}
+	}
+	title:d_spoleto = {
+		change_title_holder = {
+			holder = scope:new_pope
+			change = scope:change
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+	faith:catholic = {
+		change_fervor = {
+			value = 15
+			desc = fervor_gain_papacy_restored
+		}
+		if = {
+			limit = { NOT = { has_doctrine = special_doctrine_ecumenical_christian } }
+			add_doctrine = special_doctrine_ecumenical_christian
+		}
+		if = {
+			limit = { has_doctrine = doctrine_no_head }
+			hidden_effect = { remove_doctrine = doctrine_no_head }
+			add_doctrine = doctrine_spiritual_head
+		}
+		set_religious_head_title = title:k_papal_state
+	}
+}
+
+destroy_papacy_scripted_effect = {
+	save_scope_as = scoped_destroyer
+	if = {
+		limit = { exists = title:k_papal_state.holder }
+		title:k_papal_state.holder = { save_scope_as = scoped_pope }
+	}
+	add_piety = massive_piety_gain
+	root.faith = {
+		change_fervor = {
+			value = 50
+			desc = fervor_gain_papacy_destroyed
+		}
+	}
+
+	# Destroy the papacy title if it exists.
+	if = {
+		limit = {
+			exists = title:k_papal_state
+		}
+		destroy_title = title:k_papal_state
+	}
+
+	# If the Pope exists, they will suffer some kind of humiliating or tragic fate.
+	if = {
+		limit = {
+			exists = scope:scoped_pope
+		}
+		if = {
+			limit = {
+				faith = {
+					has_doctrine_parameter = human_sacrifice_active
+				}
+			}
+			scope:scoped_pope = {
+				death = {
+					death_reason = death_sacrificed_to_gods
+					killer = root
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				faith.religion = faith:hellenic_pagan.religion
+			}
+			scope:scoped_pope = {
+				death = {
+					death_reason = death_crucified
+					killer = root
+				}
+			}
+		}
+		else = {
+			scope:scoped_pope = { set_character_faith = root.faith }
+		}
+
+		if = {
+			limit = { scope:scoped_pope.gold > 0 }
+			scope:scoped_pope = {
+				hidden_effect = { remove_short_term_gold = scope:scoped_pope.gold }
+			}
+		}
+	}
+
+	# Catholicism is now sad.
+	faith:catholic = {
+		change_fervor = {
+			value = -100
+			desc = fervor_loss_papacy_destroyed
+		}
+		if = {
+			limit = { has_doctrine = special_doctrine_ecumenical_christian }
+			remove_doctrine = special_doctrine_ecumenical_christian
+		}
+		if = {
+			limit = { has_doctrine = doctrine_spiritual_head }
+			remove_doctrine = doctrine_spiritual_head
+			hidden_effect = { add_doctrine = doctrine_no_head }
+		}
+	}
+}
+
+form_switzerland_scripted_effect = {
+	save_scope_as = scoped_ruler
+	title:e_hre.holder = { save_scope_as = scoped_emperor }
+	title:d_savoie = { save_scope_as = savoy }
+	title:k_switzerland = { save_scope_as = switzerland }
+	#De jure shifts.
+	title:d_currezia = { set_de_jure_liege_title = title:k_switzerland }
+	title:d_transjurania = { set_de_jure_liege_title = title:k_switzerland }
+	if = {
+		limit = { completely_controls = title:d_savoie }
+		title:d_savoie = { set_de_jure_liege_title = title:k_switzerland }
+	}
+	else = { custom_tooltip = form_switzerland_kingdom_decision_effect_tooltip }
+	title:k_switzerland = { set_de_jure_liege_title = root.top_liege.primary_title }
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:k_switzerland = {
+		change_title_holder = {
+			holder = root
+			change = scope:change
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+	hidden_effect = { set_primary_title_to = title:k_switzerland }
+	add_prestige = major_prestige_gain
+	if = {
+		limit = {
+			OR = {
+				has_realm_law = crown_authority_0
+				has_realm_law = crown_authority_1
+				has_realm_law = crown_authority_2
+			}
+		}
+		add_realm_law_skip_effects = crown_authority_3
+	}
+}
+
+form_austria_scripted_effect = {
+	#Grab scopes for loc and such.
+	save_scope_as = scoped_ruler
+	title:e_hre.holder = { save_scope_as = scoped_emperor }
+	title:d_carinthia = { save_scope_as = carinthia }
+	title:d_krain = {save_scope_as = krain }
+	title:d_istria = { save_scope_as = istria }
+	title:k_austria = { save_scope_as = austria}
+	title:d_croatia.de_jure_liege = { save_scope_as = new_controller}
+	#Hand over k_austria.
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:k_austria = {
+		change_title_holder = {
+			holder = root
+			change = scope:change
+		}
+		copy_title_history = title:d_osterreich
+	}
+	resolve_title_and_vassal_change = scope:change
+	#Try to make it the primary title, unless it's the Emperor doing this.
+	hidden_effect = {
+		if = {
+			limit = { primary_title.tier <= tier_kingdom }
+			set_primary_title_to = title:k_austria
+		}
+	}
+	#Save d_austria's current de jure liege for future reference.
+	title:d_osterreich.de_jure_liege = { save_scope_as = previous_kingdom }
+	#Transfer custom_core_austria (d_austria & d_steyermark) to the new Archduchy.
+	hidden_effect = {
+		title:k_austria = {
+			set_de_jure_liege_title = scope:previous_kingdom.de_jure_liege
+		}
+
+		every_county_in_region = {
+			region = custom_core_austria
+			duchy = { add_to_list = austrian_heartlands_list }
+		}
+		every_in_list = {
+			list = austrian_heartlands_list
+			limit = {
+				NOT = { de_jure_liege = title:k_austria }
+			}
+			set_de_jure_liege_title = title:k_austria
+		}
+
+	}
+	#Sort Carinthia.
+	if = {
+		limit = { completely_controls = title:d_carinthia }
+		title:d_carinthia = { set_de_jure_liege_title = title:k_austria }
+	}
+	else = { custom_tooltip = form_austria_kingdom_decision_effect_stretch_goals_tt }
+	#Sort d_krain, giving it to k_austria, the de jure liege of d_croatia, or leaving it as-is, depending on if it borders any part of scope:previous_kingdom other than d_istria.
+	if = {
+		limit = {
+			completely_controls = title:d_krain
+			#d_krain must be part of d_osterreich's former kingdom.
+			title:d_krain.de_jure_liege = scope:previous_kingdom
+		}
+		title:d_krain = { set_de_jure_liege_title = title:k_austria }
+	}
+	else_if = {
+		limit = {
+			#Krain must be part of d_osterreich's former kingdom.
+			title:d_krain.de_jure_liege = scope:previous_kingdom
+			#Cannot border any other part of the former kingdom other than Istria.
+			NOR = {
+				title:d_slavonia.de_jure_liege = scope:previous_kingdom
+				title:d_croatia.de_jure_liege = scope:previous_kingdom
+				title:d_friuli.de_jure_liege = scope:previous_kingdom
+			}
+			#Check d_carinthia separately, since before the effect is run (i.e., in the decision tooltip) its liege will still be scope:previous_kingdom.
+			completely_controls = title:d_carinthia
+		}
+		hidden_effect = {
+			title:d_krain = { set_de_jure_liege_title = title:d_croatia.de_jure_liege }
+			save_scope_value_as = {
+				name = krain_isolated
+				value = yes
+			}
+		}
+	}
+	#Sort d_istria, giving it to k_austria, the de jure liege of d_croatia, or leaving it as-is, depending on if it borders any part of scope:previous_kingdom other than d_krain.
+	if = {
+		limit = {
+			completely_controls = title:d_istria
+			#d_istria must be part of d_osterreich's former kingdom.
+			title:d_istria.de_jure_liege = scope:previous_kingdom
+		}
+		title:d_istria = { set_de_jure_liege_title = title:k_austria }
+	}
+	else_if = {
+		limit = {
+			#d_istria must be part of d_osterreich's former kingdom.
+			title:d_istria.de_jure_liege = scope:previous_kingdom
+			#Cannot border any other part of the former kingdom.
+			NOR = {
+				title:d_croatia.de_jure_liege = scope:previous_kingdom
+				title:d_friuli.de_jure_liege = scope:previous_kingdom
+			}
+			#Check d_krain separately, since before the effect is run (i.e., in the decision tooltip) its liege will still be scope:previous_kingdom.
+			completely_controls = title:d_carinthia
+		}
+		hidden_effect = {
+			title:d_istria = { set_de_jure_liege_title = title:d_croatia.de_jure_liege }
+			save_scope_value_as = {
+				name = istria_isolated
+				value = yes
+			}
+		}
+	}
+	#Sort notice of what's happening to Istria/Krain.
+	if = {
+		limit = {
+			exists = scope:krain_isolated
+			exists = scope:istria_isolated
+		}
+		custom_tooltip = form_austria_kingdom_decision_effect_stretch_fail_both_tt
+	}
+	else_if = {
+		limit = { exists = scope:krain_isolated }
+		custom_tooltip = form_austria_kingdom_decision_effect_stretch_fail_krain_tt
+	}
+	else_if = {
+		limit = { exists = scope:istria_isolated}
+		custom_tooltip = form_austria_kingdom_decision_effect_stretch_fail_istria_tt
+	}
+	#Sundry other rewards.
+	add_prestige = major_prestige_gain
+	if = {
+		limit = {
+			NOT = { has_realm_law = single_heir_succession_law }
+		}
+		add_realm_law_skip_effects = single_heir_succession_law
+	}
+	#Check to see if we're using that strong hook!
+	if = {
+		limit = {
+			NOT = { dynasty = title:e_hre.holder.dynasty }
+		}
+		use_hook = title:e_hre.holder
+	}
+}
+
+decision_restore_carantania_effect = {
+	title:d_krain = { add_to_list = carantania_de_jure_list }
+	title:d_carinthia = { add_to_list = carantania_de_jure_list }
+	title:d_steyermark = { add_to_list = carantania_de_jure_list }
+
+	dynasty = { add_dynasty_prestige = monumental_dynasty_prestige_gain }
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:k_carantania = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+
+	if = {
+		limit = {
+			NOT = {
+				any_in_list = {
+					list = carantania_de_jure_list
+					is_titular = yes
+				}
+			}
+		}
+		custom_tooltip = decision_restore_carantania_de_jure_regular_tooltip
+		hidden_effect = {
+			title:d_krain = { set_de_jure_liege_title = title:k_carantania }
+			title:d_carinthia = { set_de_jure_liege_title = title:k_carantania }
+			title:d_steyermark = { set_de_jure_liege_title = title:k_carantania }
+		}
+	}
+	else = {
+		every_in_list = {
+			list = carantania_de_jure_list
+			limit = {
+				is_titular = no
+			}
+			set_de_jure_liege_title = title:k_carantania
+		}
+	}
+	every_sub_realm_duchy = {
+		limit = {
+			NOR = {
+				is_in_list = carantania_de_jure_list
+			}
+			any_title_to_title_neighboring_duchy = {
+				is_in_list = carantania_de_jure_list
+			}	
+		}
+		custom_tooltip = decision_restore_carantania_de_jure_tooltip
+		hidden_effect = { set_de_jure_liege_title = title:k_carantania }
+	}
+	if = {
+		limit = {
+			capital_province.duchy = { is_in_list = carantania_de_jure_list }
+			NOT = { title:k_carantania = root.capital_county }
+		}
+		root = { custom_tooltip = decision_restore_carantania_change_capital_tooltip }
+		title:k_carantania = {
+			set_capital_county = root.capital_county
+		}
+	}
+	root.capital_county = {
+		if = {
+			limit = {
+				NOT = {	culture = root.culture }
+			}
+			set_county_culture = root.culture 
+		}
+		add_county_modifier = {
+			modifier = restore_carantania_modifier
+			years = 100
+		}
+	}
+}
+
+form_carolingian_empire_scripted_effect = {
+	save_scope_as = scoped_ruler
+	title:e_hre.holder ?= { save_scope_as = scoped_emperor }
+	#De jure shifts.
+	hidden_effect = {
+		title:k_france = { set_de_jure_liege_title = title:e_france }
+		title:k_burgundy = { set_de_jure_liege_title = title:e_france }
+		title:k_aquitaine = { set_de_jure_liege_title = title:e_france }
+		title:k_brittany = { set_de_jure_liege_title = title:e_france }
+		title:k_frisia = { set_de_jure_liege_title = title:e_france }
+		title:k_lotharingia = { set_de_jure_liege_title = title:e_france }
+		title:k_bavaria = { set_de_jure_liege_title = title:e_france }
+		title:k_east_francia = { set_de_jure_liege_title = title:e_france }
+		title:k_italy = { set_de_jure_liege_title = title:e_france }
+		title:k_navarra = { set_de_jure_liege_title = title:e_france }
+		title:k_aragon = { set_de_jure_liege_title = title:e_france }
+		if = {
+			limit = {
+				OR = {
+					#exists = title:k_austria.holder
+					title:k_austria = { is_titular = yes }
+					title:e_hre = {
+						any_in_de_jure_hierarchy = {
+							continue = { tier >= tier_kingdom }
+							this = title:k_austria
+						}
+					}
+				}
+			}
+			title:k_austria = { set_de_jure_liege_title = title:e_france }
+		}
+		if = {
+			limit = {
+				OR = {
+					#exists = title:k_switzerland.holder
+					title:k_switzerland = { is_titular = yes }
+					title:e_hre = {
+						any_in_de_jure_hierarchy = {
+							continue = { tier >= tier_kingdom }
+							this = title:k_switzerland
+						}
+					}
+				}
+			}
+			title:k_switzerland = { set_de_jure_liege_title = title:e_france }
+		}
+	}
+	# Prestige
+	add_prestige = major_prestige_gain
+	# Law
+	if = {
+		limit = {
+			NOT = { has_realm_law = single_heir_succession_law }
+		}
+		add_realm_law_skip_effects = single_heir_succession_law
+	}
+	# HRE goes bye-bye
+	if = {
+		limit = { exists = scope:scoped_emperor }
+		destroy_title = title:e_hre
+		scope:scoped_emperor ?= {
+			add_prestige = major_prestige_loss
+			add_opinion = {
+				target = scope:scoped_ruler
+				modifier = pretender_opinion
+			}
+		}
+	}
+	# Innovations
+	culture:french = {
+		if = {
+			limit = {
+				NOT = { has_innovation = innovation_knighthood }
+			}
+			add_innovation = innovation_knighthood
+		}
+		if = {
+			limit = {
+				NOT = { has_innovation = innovation_royal_prerogative }
+			}
+			add_innovation = innovation_royal_prerogative
+		}
+		if = {
+			limit = {
+				NOT = { has_innovation = innovation_heraldry }
+			}
+			add_innovation = innovation_heraldry
+		}
+	}
+}
+
+unite_burgundies_scripted_effect = {
+	add_prestige = medium_prestige_gain
+	save_scope_as = scoped_ruler
+	liege = { save_scope_as = former_liege }
+	#De jure shifts.
+	hidden_effect = {
+		title:d_burgundy = {
+			set_de_jure_liege_title = title:k_burgundy
+		}
+		title:d_provence = { #Just in case they drifted in the meantime.
+			set_de_jure_liege_title = title:k_burgundy
+		}
+		title:d_savoie = {
+			set_de_jure_liege_title = title:k_burgundy
+		}
+		title:d_dauphine = {
+			set_de_jure_liege_title = title:k_burgundy
+		}
+		title:d_upper_burgundy = {
+			set_de_jure_liege_title = title:k_burgundy
+		}
+	}
+	if = {
+		limit = {
+			culture:occitan = {
+				NOT = {
+					has_innovation = innovation_guilds
+				}
+			}
+		}
+		culture:occitan = {
+			add_innovation = innovation_guilds
+		}
+	}
+	if = {
+		limit = {
+			culture:occitan = {
+				NOT = {
+					has_innovation = innovation_burhs
+				}
+			}
+		}
+		culture:occitan = {
+			add_innovation = innovation_burhs
+		}
+	}
+	if = {
+		limit = {
+			culture:occitan = {
+				NOT = {
+					has_innovation = innovation_baliffs
+				}
+			}
+		}
+		culture:occitan = {
+			add_innovation = innovation_baliffs
+		}
+	}
+	#Make ruler independent and give Burgundy to him.
+	create_title_and_vassal_change = {
+		type = independency
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	change_liege_or_become_independent = {
+		CHANGE = scope:change
+		VASSAL = this
+	}
+	hidden_effect = {
+		add_truce_both_ways = {
+			character = scope:former_liege
+			days = 1825
+			name = TRUCE_GRANT_INDEPENDENCE_ROOT
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = new_burgundy
+		add_claim_on_loss = no
+	}
+	title:k_burgundy = {
+		change_title_holder = {
+			holder = root
+			change = scope:new_burgundy
+		}
+	}
+	resolve_title_and_vassal_change = scope:new_burgundy
+	scope:former_liege = {
+		add_prestige = major_prestige_loss
+		add_unpressed_claim = title:k_burgundy #Give chance to retaliate
+		add_opinion = {
+			target = scope:scoped_ruler
+			modifier = pretender_opinion
+		}
+	}
+}
+
+form_outremer_scripted_effect = {
+	add_prestige = medium_prestige_gain
+	add_piety = medium_piety_gain
+
+	#Saving Scope to refer to it fervor localization
+	title:e_outremer = {
+		save_scope_as = outremer_title
+	}
+	faith = {
+		change_fervor = {
+			value = 15
+			desc = fervor_gain_formed_outremer
+		}
+	}
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:e_outremer = {
+		change_title_holder = {
+			holder = root
+			change = scope:change
+		}
+		hidden_effect = {
+			copy_title_history = title:k_jerusalem
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+	hidden_effect = { set_primary_title_to = title:e_outremer }
+	if = { #The Sunni Caliphate is dismantled
+		limit = {
+			faith:ashari = { exists = religious_head }
+		}
+		root = { destroy_title = title:d_sunni }
+	}
+	culture = {	save_scope_as = former_culture }
+	capital_county.title_province.culture = { save_scope_as = capital_culture }
+
+	# If the player's capital is Arabic and the player is not, hybridize with the capital culture
+	if = {
+		limit = {
+			scope:capital_culture != scope:former_culture
+			NOT = { scope:former_culture = { has_cultural_pillar = heritage_arabic } }
+			scope:capital_culture = { has_cultural_pillar = heritage_arabic }
+			culture = {
+				OR = {
+					is_hybrid_culture = no
+					AND = {
+						NOT = { has_cultural_pillar = heritage_arabic }
+						NOT = { any_parent_culture = { has_cultural_pillar = heritage_arabic } }
+					}
+				}
+			}
+		}
+		scope:capital_culture = { save_scope_as = hybrid_culture }
+		create_hybrid_culture = scope:capital_culture
+	}
+
+	# If the player has not become Arabic, hybridize with Mashiriqi (Levantine)
+	else_if = {
+		limit = {
+			NOT = { scope:former_culture = { has_cultural_pillar = heritage_arabic } }
+			culture = {
+				OR = {
+					is_hybrid_culture = no
+					AND = {
+						NOT = { has_cultural_pillar = heritage_arabic }
+						NOT = { any_parent_culture = { has_cultural_pillar = heritage_arabic } }
+					}
+				}
+			}
+		}
+		culture:levantine = { save_scope_as = hybrid_culture }
+		create_hybrid_culture = culture:levantine
+	}
+
+	# If the player has become Arabic, hybridize with Occitan
+	else_if = {
+		limit = {
+			culture = {
+				OR = {
+					is_hybrid_culture = no
+					AND = {
+						NOT = { has_cultural_pillar = heritage_arabic }
+						NOT = { any_parent_culture = { has_cultural_pillar = heritage_arabic } }
+					}
+				}
+			}
+		}
+		culture:occitan = { save_scope_as = hybrid_culture }
+		create_hybrid_culture = culture:occitan
+	}
+	#If the player is already a European-Arabic hybrid, just save the existing culture
+	else = {
+		scope:former_culture = { save_scope_as = new_culture }
+	}
+
+	if = {
+		limit = { exists = scope:new_culture }
+		capital_county = { set_county_culture = scope:new_culture }
+		scope:new_culture = {
+			if = {
+				limit = {
+					OR = {
+						has_cultural_pillar = heritage_frankish
+						any_parent_culture = { has_cultural_pillar = heritage_frankish }
+					}
+				}
+				set_name_list = name_list_outremer
+			}
+			if = {
+				limit = {
+					NOT = { has_innovation = innovation_men_at_arms }
+				}
+				add_innovation = innovation_men_at_arms
+			}
+			if = {
+				limit = {
+					NOT = { has_innovation = innovation_desert_tactics }
+				}
+				add_innovation = innovation_desert_tactics
+			}
+			hidden_effect = {
+				if = {
+					limit = {
+						NOT = { has_same_culture_language = scope:former_culture }
+					}
+					set_language_from = scope:former_culture
+				}
+				if = {
+					limit = {
+						exists = scope:hybrid_culture
+						NOT = { has_same_culture_heritage = scope:hybrid_culture }
+					}
+					set_heritage_from = scope:hybrid_culture
+				}
+			}
+		}
+	}
+	else = {
+		show_as_tooltip = {
+			if = {
+				limit = { exists = scope:hybrid_culture }
+				custom_tooltip = outremer_decision_hybrid_tt
+			}
+		}
+	}
+}
+
+restore_sunni_caliphate_scripted_effect = {
+	add_piety = major_piety_gain
+	save_scope_as = reformer
+	create_title_and_vassal_change = {
+		type = returned
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:d_sunni = {
+		save_scope_as = sunni_caliphate
+		change_title_holder = {
+			holder = scope:reformer
+			change = scope:change
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+	faith:ashari = {
+		change_fervor = {
+			value = 15
+			desc = fervor_gain_restored_sunni_caliphate
+		}
+	}
+}
+create_israel_scripted_effect = {
+	save_scope_as = scoped_ruler
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+		add_claim_on_loss = no
+	}
+	title:k_israel = {
+		change_title_holder = {
+			holder = scope:scoped_ruler
+			change = scope:change
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+	hidden_effect = {
+		set_primary_title_to = title:k_israel
+		title:d_palestine = {
+			set_de_jure_liege_title = title:k_israel
+		}
+		title:d_urdunn = {
+			set_de_jure_liege_title = title:k_israel
+		}
+		title:d_oultrejourdain = {
+			set_de_jure_liege_title = title:k_israel
+		}
+		title:k_israel = {
+			set_de_jure_liege_title = title:k_jerusalem.de_jure_liege
+		}
+	}
+}
+create_rum_scripted_effect = {
+	add_prestige = medium_prestige_gain
+	#If under a liege, make independent.
+	if = {
+		limit = {
+			top_liege != this
+		}
+		if = {
+			limit = {
+				NOT = {
+					exists = scope:former_liege
+				}
+			}
+			liege = {
+				save_scope_as = former_liege
+			}
+		}
+		create_title_and_vassal_change = {
+			type = independency
+			save_scope_as = change
+			add_claim_on_loss = no
+		}
+		change_liege_or_become_independent = {
+			CHANGE = scope:change
+			VASSAL = this
+		}
+		hidden_effect = {
+			add_truce_both_ways = {
+				character = scope:former_liege
+				days = 1825
+				name = TRUCE_GRANT_INDEPENDENCE_ROOT
+			}
+		}
+		resolve_title_and_vassal_change = scope:change
+	}
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = new_rum
+		add_claim_on_loss = no
+	}
+	title:k_rum = {
+		change_title_holder = {
+			holder = root
+			change = scope:new_rum
+		}
+		set_can_be_named_after_dynasty = no
+		set_can_use_nomadic_naming = no
+	}
+	resolve_title_and_vassal_change = scope:new_rum
+	if = {
+		limit = {
+			exists = scope:former_liege
+		}
+		scope:former_liege = {
+			add_prestige = major_prestige_loss
+			add_unpressed_claim = title:k_rum #Give chance to retaliate
+			add_opinion = {
+				target = root
+				modifier = pretender_opinion
+			}
+		}
+	}
+	hidden_effect = { set_primary_title_to = title:k_rum }
+}
+
+declare_bloodline_holy_decision_effect = {
+	save_scope_as = progenitor_holy_blood
+	if = {
+		limit = {
+			NOT = {
+				has_character_flag = con_blood_leg
+			}
+		}
+		add_character_flag = con_blood_leg
+		hidden_effect = {
+			legend_seed_great_deed_dynasty_effect = yes
+		}
+	}
+
+	faith = {
+		set_variable = {
+			name = variable_savior_found
+			value = yes
+		}
+		change_fervor = {
+			value = 25
+			desc = fervor_gain_holy_bloodline
+		}
+	}
+	if = { #Temporal.
+		limit = {
+			root.faith.religious_head = root
+		}
+		add_trait = savior
+		root.dynasty = {
+			add_dynasty_prestige = 1000
+			add_dynasty_prestige_level = 1
+		}
+	}
+	else = { #Spiritual.
+		add_trait = paragon
+		root.dynasty = {
+			add_dynasty_prestige = 500
+		}
+	}
+
+	every_child = {
+		even_if_dead = yes
+		trigger_event = major_decisions.0101
+
+		every_child = {
+			even_if_dead = yes
+			limit = {
+				OR = {
+					is_grandchild_of = scope:progenitor_holy_blood
+					is_great_grandchild_of = scope:progenitor_holy_blood
+				}
+			}
+			trigger_event = major_decisions.0101
+
+			every_child = {
+				even_if_dead = yes
+				limit = {
+					OR = {
+						is_grandchild_of = scope:progenitor_holy_blood
+						is_great_grandchild_of = scope:progenitor_holy_blood
+					}
+				}
+				trigger_event = major_decisions.0101
+			}
+		}
+	}
+}
+
+sicilian_parliament_building_scripted_effect = {
+	#this is the County title.
+	title_province = {
+		set_variable = {
+			name = variable_sicilian_parliament_county
+			value = yes
+		}
+		if = {
+			limit = {
+				has_special_building_slot = no
+			}
+			add_special_building_slot = special_sicilian_parliament_01
+		}
+		add_special_building = special_sicilian_parliament_01
+	}
+}
+sicilian_parliament_kingdom_split_scripted_effect = { #If the decision is taken when the ruler doesn't hold the entirety of k_sicily, it results in the Naples/Trinacria split. (this is the ruler)
+	root = {
+		destroy_title = title:k_sicily
+	}
+	title:d_sicily = {
+		set_de_jure_liege_title = title:k_trinacria
+	}
+	title:d_benevento = {
+		set_de_jure_liege_title = title:k_naples
+	}
+	title:d_capua = {
+		set_de_jure_liege_title = title:k_naples
+	}
+	title:d_apulia = {
+		set_de_jure_liege_title = title:k_naples
+	}
+	title:d_salerno = {
+		set_de_jure_liege_title = title:k_naples
+	}
+	title:d_calabria = {
+		set_de_jure_liege_title = title:k_naples
+	}
+}
+
+empower_sicilian_parliament_decision_scripted_effect = {
+	root = {
+		if = {
+			limit = {
+				has_realm_law = crown_authority_0
+			}
+			add_realm_law_skip_effects = crown_authority_1
+		}
+		else_if = {
+			limit = {
+				has_realm_law = crown_authority_1
+			}
+			add_realm_law_skip_effects = crown_authority_2
+		}
+		else_if = {
+			limit = {
+				has_realm_law = crown_authority_2
+			}
+			add_realm_law_skip_effects = crown_authority_3
+		}
+	}
+	if = {
+		limit = { has_title = title:k_sicily }
+		title:k_sicily = {
+			every_in_de_jure_hierarchy = {
+				custom = empower_sicilian_parliament_decision_every_province_custom
+				limit = {
+					tier = tier_county
+					title_province = { geographical_region = custom_sicily }
+					 holder = {
+						OR = {
+							this = root
+							target_is_liege_or_above = root
+						}
+					}
+				}
+				title_province = {
+					add_province_modifier = {
+						modifier = parliamentary_bureaucracy_modifier
+						years = 150
+					}
+				}
+			}
+		}
+	}
+	else_if = {
+		limit = { has_title = title:k_naples }
+		title:k_naples = {
+			every_in_de_jure_hierarchy = {
+				custom = empower_sicilian_parliament_decision_every_province_custom
+				limit = {
+					tier = tier_county
+					title_province = { geographical_region = custom_sicily }
+					 holder = {
+						OR = {
+							this = root
+							target_is_liege_or_above = root
+						}
+					}
+				}
+				title_province = {
+					add_province_modifier = {
+						modifier = parliamentary_bureaucracy_modifier
+						years = 150
+					}
+				}
+			}
+		}
+	}
+	else_if = {
+		limit = { has_title = title:k_trinacria }
+		title:k_trinacria = {
+			every_in_de_jure_hierarchy = {
+				custom = empower_sicilian_parliament_decision_every_province_custom
+				limit = {
+					tier = tier_county
+					title_province = { geographical_region = custom_sicily }
+					 holder = {
+						OR = {
+							this = root
+							target_is_liege_or_above = root
+						}
+					}
+				}
+				title_province = {
+					add_province_modifier = {
+						modifier = parliamentary_bureaucracy_modifier
+						years = 150
+					}
+				}
+			}
+		}
+	}
+}
+
+promote_gothic_innovations_decision_scripted_effect = {
+	if = {
+		limit = {
+			has_realm_law = crown_authority_0
+		}
+		add_realm_law_skip_effects= crown_authority_1
+	}
+	else_if = {
+		limit = {
+			has_realm_law = crown_authority_1
+		}
+		add_realm_law_skip_effects = crown_authority_2
+	}
+	else_if = {
+		limit = {
+			has_realm_law = crown_authority_2
+		}
+		add_realm_law_skip_effects = crown_authority_3
+	}
+	culture = {
+		if = {
+			limit = {
+				NOT = { has_innovation = innovation_french_peerage }
+			}
+			add_innovation = innovation_french_peerage
+		}
+	}
+	if = {
+		limit = {
+			this = { completely_controls = title:d_valois }
+		}
+		title:c_ile_de_france = {
+			title_province = {
+				add_province_modifier = {
+					modifier = flourishing_culture_modifier
+					years = 150
+				}
+			}
+		}
+	}
+	if = {
+		limit = {
+			this = { completely_controls = title:d_orleans }
+		}
+		title:c_orleans = {
+			title_province = {
+				add_province_modifier = {
+					modifier = flourishing_culture_modifier
+					years = 150
+				}
+			}
+		}
+	}
+	if = {
+		limit = {
+			this = { completely_controls = title:d_provence }
+		}
+		title:c_nice = {
+			title_province = {
+				add_province_modifier = {
+					modifier = flourishing_culture_modifier
+					years = 150
+				}
+			}
+		}
+	}
+	if = {
+		limit = {
+			this = { completely_controls = title:d_toulouse }
+		}
+		title:c_toulouse = {
+			title_province = {
+				add_province_modifier = {
+					modifier = flourishing_culture_modifier
+					years = 150
+				}
+			}
+		}
+	}
+}
+
+promote_hungarian_settlement_decision_scripted_effect = {
+	if = {
+		limit = {
+			culture = culture:mogyer
+		}
+
+		# Convert my culture to Hungarian Culture
+		set_culture = culture:hungarian
+		culture:hungarian = {
+			reset_culture_creation_date = yes
+			get_all_innovations_from = culture:mogyer
+		}
+
+		# Convert my courtiers to Hungarian
+		hidden_effect = {
+			every_courtier = {
+				limit = {
+					culture = culture:mogyer
+				}
+				set_culture = culture:hungarian
+			}
+		}
+
+		# Convert my vassals to Hungarian
+		every_vassal_or_below = {
+			limit = {
+				culture = culture:mogyer
+			}
+
+			custom = promote_hungarian_settlement_decision_every_vassal_custom
+			set_culture = culture:hungarian
+
+			# Convert their courtiers as well
+			hidden_effect = {
+				every_courtier = {
+					limit = {
+						culture = culture:mogyer
+					}
+					set_culture = culture:hungarian
+				}
+			}
+		}
+	}
+
+	title:k_hungary = {
+		every_in_de_jure_hierarchy = {
+			custom = promote_hungarian_settlement_decision_every_province_custom
+			limit = {
+				tier = tier_county
+				culture = culture:mogyer
+				title_province = { geographical_region = custom_hungary }
+				holder = {
+					OR = {
+						this = root
+						target_is_liege_or_above = root
+					}
+				}
+			}
+			set_county_culture = culture:hungarian
+			add_county_modifier = {
+				modifier = hungarian_resettlement_modifier
+				years = 100
+			}
+			custom_tooltip = promote_hungarian_settlement_decision_increased_development
+			custom_tooltip = promote_hungarian_settlement_decision_convert_county
+			hidden_effect = {
+				if = {
+					limit = {
+						development_level < 5
+					}
+					change_development_level = 1
+				}
+				random_list = {
+					30 = {
+						# Nothing happens
+					}
+					30 = {
+						trigger = {
+							NOT = {
+								faith = { has_doctrine = special_doctrine_ecumenical_christian }
+							}
+						}
+						set_county_faith = root.faith
+					}
+					30 = {
+						trigger = {
+							NOT = {
+								faith = { has_doctrine = special_doctrine_ecumenical_christian }
+							}
+							any_neighboring_county = {
+								faith = { has_doctrine = special_doctrine_ecumenical_christian }
+							}
+						}
+						random_neighboring_county = {
+							limit = {
+								faith = { has_doctrine = special_doctrine_ecumenical_christian }
+							}
+							save_scope_as = neighboring_county
+						}
+						set_county_faith = scope:neighboring_county.faith
+					}
+				}
+			}
+		}
+	}
+}
+
+revive_magyar_paganism_decision_scripted_effect = {
+	#Change yourself, and any willing vassals/family, over to Magyar Paganism.
+	set_character_faith_with_conversion = faith:magyar_pagan
+	#Gain nickname for your troubles.
+	give_nickname = nick_the_apostate
+	#Magyar_group counties of your old religion may defect back to the old ways.
+	custom_tooltip = revive_magyar_paganism_decision_scripted_effect.county_conversions.tt
+	hidden_effect = {
+		primary_title = {
+			every_in_de_facto_hierarchy = {
+				limit = {
+					tier = tier_county
+					culture = { has_cultural_pillar = heritage_magyar }
+					exists = scope:old_faith
+					religion = scope:old_faith.religion
+				}
+				#Mogyers remember the old ways best, and have a high chance to flip.
+				if = {
+					limit = { culture = culture:mogyer }
+					random = {
+						chance = 70
+						set_county_faith = faith:magyar_pagan
+					}
+				}
+				#Slightly up the chances for the apostate.
+				else_if = {
+					limit = { holder = root }
+					random = {
+						chance = 50
+						set_county_faith = faith:magyar_pagan
+					}
+				}
+				#Other magyar_group cultures still have a moderate chance to flip.
+				else = {
+					random = {
+						chance = 30
+						set_county_faith = faith:magyar_pagan
+					}
+				}
+			}
+		}
+	}
+	#Make flipping counties deliriously happy about the whole affair.
+	primary_title = {
+		every_in_de_facto_hierarchy = {
+			limit = {
+				tier = tier_county
+				faith = faith:magyar_pagan
+			}
+			custom = hungarian_resettlement.every_converted_province
+			add_county_modifier = {
+				modifier = magyar_appreciation_modifier
+				years = 25
+			}
+		}
+	}
+	#Finally, give magyar_pagans a hefty fervour boost, just so that they don't immediately convert back.
+	hidden_effect = {
+		faith:magyar_pagan = {
+			save_temporary_scope_as = magyar_faith
+			change_fervor = {
+				value = 100
+				desc = fervor_gain_magyar_revivalism
+			}
+		}
+	}
+}
+
+restore_dumnonia_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:k_cornwall = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+
+	hidden_effect = {
+		title:d_somerset = { save_scope_as = cornwall_somerset }
+		title:d_gloucester = { save_scope_as = cornwall_gloucester }
+		title:d_cornwall = { set_de_jure_liege_title = title:k_cornwall }
+		if = {	#If owned, annex Somerset/Wessex.
+			limit = {
+				title:d_somerset = { holder = root }
+			}
+			title:d_somerset = { set_de_jure_liege_title = title:k_cornwall }
+		}
+		if = {	#If owned, annex Gloucestershire/Hwicce.
+			limit = {
+				title:d_gloucester = { holder = root }
+			}
+			title:d_gloucester = { set_de_jure_liege_title = title:k_cornwall }
+		}
+	}
+	custom_tooltip = restore_dumnonia_decision_effects_de_jure_tt
+}
+
+form_cumbria_decision_scripted_effect = {
+	dynasty = { add_dynasty_prestige = monumental_dynasty_prestige_gain }
+	house = { 
+		add_house_modifier = {
+			modifier = form_cumbria_decision_house_modifier
+			years = 100
+		}
+	}
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:k_cumbria = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	title:d_cumbria = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	spawn_army = {
+		location = root.capital_province
+		inheritable = no
+		levies = 500
+		men_at_arms = {
+			type = teulu
+			stacks = 5
+		}
+		men_at_arms = {
+			type = bowmen
+			stacks = 5
+		}
+		men_at_arms = {
+			type = light_footmen
+			stacks = 5
+		}
+		name = cumbrian_loyalists
+	}
+	title:d_galloway = { set_de_jure_liege_title = title:k_cumbria }
+	title:c_lanarkshire = { set_de_jure_liege_title = title:d_galloway }
+	custom_tooltip = form_cumbria_decision_de_jure_duchy
+	hidden_effect = {
+		title:c_westmorland = { set_de_jure_liege_title = title:d_cumbria }
+		title:c_cumberland = { set_de_jure_liege_title = title:d_cumbria }
+		title:c_annandale = { set_de_jure_liege_title = title:d_cumbria }
+	}
+}
+
+revive_armenian_empire_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:e_armenia = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+
+	hidden_effect = {
+		title:k_armenia = { save_scope_as = armenian_armenia }
+		title:k_georgia = { save_scope_as = armenian_georgia }
+		title:k_daylam = { save_scope_as = armenian_daylam }
+		title:k_jazira = { save_scope_as = armenian_jazira }
+		title:k_syria = { save_scope_as = armenian_syria }
+		title:k_jerusalem = { save_scope_as = armenian_jerusalem }
+		title:k_anatolia = { save_scope_as = armenian_anatolia }
+		title:k_pontus = { save_scope_as = armenian_pontus }
+		title:e_armenia = { save_scope_as = armenian_armenia_empire }
+		title:k_armenia = { set_de_jure_liege_title = title:e_armenia }
+		if = {
+			limit = {
+				title:k_armenia = { is_title_created = yes }
+			}
+			create_title_and_vassal_change = {
+				type = usurped
+				save_scope_as = title_change_2
+				add_claim_on_loss = no
+			}
+			title:k_armenia = {
+				change_title_holder = {
+					holder = root
+					change = scope:title_change_2
+				}
+			}
+			resolve_title_and_vassal_change = scope:title_change_2
+		}
+		else_if = {
+			limit = {
+				title:k_armenia = { is_title_created = no }
+			}
+			create_title_and_vassal_change = {
+				type = created
+				save_scope_as = title_change_2
+				add_claim_on_loss = no
+			}
+			title:k_armenia = {
+				change_title_holder = {
+					holder = root
+					change = scope:title_change_2
+				}
+			}
+			resolve_title_and_vassal_change = scope:title_change_2
+		}
+		if = {	#If any have drifted out, then k_armenia's constituent duchies are flipped back.
+			limit = {
+				title:d_greater_armenia = {
+					NOT = { target_is_de_jure_liege_or_above = title:k_armenia }
+				}
+			}
+			title:d_greater_armenia = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If any have drifted out, then k_armenia's constituent duchies are flipped back.
+			limit = {
+				title:d_vaspurakan = {
+					NOT = { target_is_de_jure_liege_or_above = title:k_armenia }
+				}
+			}
+			title:d_vaspurakan = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If any have drifted out, then k_armenia's constituent duchies are flipped back.
+			limit = {
+				title:d_mesopotamia = {
+					NOT = { target_is_de_jure_liege_or_above = title:k_armenia }
+				}
+			}
+			title:d_mesopotamia = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned & de jure has not drifted, annex Daylam & exempt Azerbaijan from de jure flipping to Armenia.
+			limit = {
+				title:k_daylam = { holder = root  }
+				title:d_azerbaijan = {	target_is_de_jure_liege_or_above = title:k_daylam }
+			}
+			title:k_daylam = { set_de_jure_liege_title = title:e_armenia }
+		}
+		else_if = {	#If owned & de jure has drifted, annex Daylam & flip Azerbaijan to Armenia.
+			limit = {
+				title:k_daylam = { holder = root  }
+				NOT = {
+					title:d_azerbaijan = {	target_is_de_jure_liege_or_above = title:k_daylam }
+				}
+			}
+			title:k_daylam = { set_de_jure_liege_title = title:e_armenia }
+			title:d_azerbaijan = { set_de_jure_liege_title = title:k_armenia }
+		}
+		else = {
+			title:d_azerbaijan = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned & de jure has not drifted, annex Daylam & exempt Shirvan from de jure flipping to Armenia.
+			limit = {
+				title:k_daylam = { holder = root  }
+				title:d_shirvan = {	target_is_de_jure_liege_or_above = title:k_daylam }
+			}
+			title:k_daylam = { set_de_jure_liege_title = title:e_armenia }
+		}
+		else_if = {	#If owned & de jure has drifted, annex Daylam & flip Shirvan to Armenia.
+			limit = {
+				title:k_daylam = { holder = root  }
+				NOT = {
+					title:d_shirvan = {	target_is_de_jure_liege_or_above = title:k_daylam }
+				}
+			}
+			title:k_daylam = { set_de_jure_liege_title = title:e_armenia }
+			title:d_shirvan = { set_de_jure_liege_title = title:k_armenia }
+		}
+		else = {
+			title:d_shirvan = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned & de jure has not drifted, annex Georgia & exempt ducal Georgia from de jure flipping to Armenia.
+			limit = {
+				title:k_georgia = { holder = root  }
+				title:d_georgia = {	target_is_de_jure_liege_or_above = title:k_georgia }
+			}
+			title:k_georgia = { set_de_jure_liege_title = title:e_armenia }
+		}
+		else_if = {	#If owned & de jure has drifted, annex Georgia & flip ducal Georgia to Armenia.
+			limit = {
+				title:k_georgia = { holder = root  }
+				NOT = {
+					title:d_georgia = {	target_is_de_jure_liege_or_above = title:k_georgia }
+				}
+			}
+			title:k_georgia = { set_de_jure_liege_title = title:e_armenia }
+			title:d_georgia = { set_de_jure_liege_title = title:k_armenia }
+		}
+		else = {
+			title:d_georgia = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned & de jure has not drifted, annex Anatolia & exempt Cilicia from de jure flipping to Armenia.
+			limit = {
+				title:k_anatolia = { holder = root  }
+				title:d_cilicia = {	target_is_de_jure_liege_or_above = title:k_anatolia }
+			}
+			title:k_anatolia = { set_de_jure_liege_title = title:e_armenia }
+		}
+		else_if = {	#If owned & de jure has drifted, annex Anatolia & flip Cilicia to Armenia.
+			limit = {
+				title:k_anatolia = { holder = root  }
+				NOT = {
+					title:d_cilicia = {	target_is_de_jure_liege_or_above = title:k_anatolia }
+				}
+			}
+			title:k_anatolia = { set_de_jure_liege_title = title:e_armenia }
+			title:d_cilicia = { set_de_jure_liege_title = title:k_armenia }
+		}
+		else = {
+			title:d_cilicia = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned & de jure has not drifted, annex Jazira & exempt Diyarbakr from de jure flipping to Armenia.
+			limit = {
+				title:k_jazira = { holder = root  }
+				title:d_diyarbakr = {	target_is_de_jure_liege_or_above = title:k_jazira }
+			}
+			title:k_jazira = { set_de_jure_liege_title = title:e_armenia }
+		}
+		else_if = {	#If owned & de jure has drifted, annex Jazira & flip Diyarbakr to Armenia.
+			limit = {
+				title:k_jazira = { holder = root  }
+				NOT = {
+					title:d_diyarbakr = {	target_is_de_jure_liege_or_above = title:k_jazira }
+				}
+			}
+			title:k_jazira = { set_de_jure_liege_title = title:e_armenia }
+			title:d_diyarbakr = { set_de_jure_liege_title = title:k_armenia }
+		}
+		else = {
+			title:d_diyarbakr = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned & de jure has not drifted, annex Syria & exempt Edessa from de jure flipping to Armenia.
+			limit = {
+				title:k_syria = { holder = root  }
+				title:d_edessa = {	target_is_de_jure_liege_or_above = title:k_syria }
+			}
+			title:k_syria = { set_de_jure_liege_title = title:e_armenia }
+		}
+		else_if = {	#If owned & de jure has drifted, annex Syria & flip Edessa to Armenia.
+			limit = {
+				title:k_syria = { holder = root  }
+				NOT = {
+					title:d_edessa = {	target_is_de_jure_liege_or_above = title:k_syria }
+				}
+			}
+			title:k_syria = { set_de_jure_liege_title = title:e_armenia }
+			title:d_edessa = { set_de_jure_liege_title = title:k_armenia }
+		}
+		else = {
+			title:d_edessa = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned & de jure has not drifted, annex Syria & exempt Antioch from de jure flipping to Armenia.
+			limit = {
+				title:k_syria = { holder = root  }
+				title:d_antioch = {	target_is_de_jure_liege_or_above = title:k_syria }
+			}
+			title:k_syria = { set_de_jure_liege_title = title:e_armenia }
+		}
+		else_if = {	#If owned & de jure has drifted, annex Syria & flip Antioch to Armenia.
+			limit = {
+				title:k_syria = { holder = root  }
+				NOT = {
+					title:d_antioch = {	target_is_de_jure_liege_or_above = title:k_syria }
+				}
+			}
+			title:k_syria = { set_de_jure_liege_title = title:e_armenia }
+			title:d_antioch = { set_de_jure_liege_title = title:k_armenia }
+		}
+		else = {
+			title:d_antioch = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned & Kurdistan is already part of Jazira, annex Jazira & exempt Kurdistan from de jure flipping to Armenia.
+			limit = {
+				title:k_jazira = { holder = root  }
+				title:d_kurdistan = { target_is_de_jure_liege_or_above = title:k_jazira }
+			}
+			title:k_jazira = { set_de_jure_liege_title = title:e_armenia }
+		}
+		else_if = {	#If owned & Kurdistan is not part of Jazira, but Jazira is owned entirely, annex Jazira & flip Kurdistan to Jazira, because bordergore.
+			limit = {
+				title:k_jazira = { holder = root  }
+				NOT = {
+					title:d_kurdistan = { target_is_de_jure_liege_or_above = title:k_jazira }
+				}
+			}
+			title:k_jazira = { set_de_jure_liege_title = title:e_armenia }
+			title:d_kurdistan = { set_de_jure_liege_title = title:k_jazira }
+		}
+		else = {
+			title:d_kurdistan = { set_de_jure_liege_title = title:k_armenia }
+		}
+		if = {	#If owned, annex Pontus.
+			limit = {
+				title:k_pontus = { holder = root  }
+			}
+			title:k_pontus = { set_de_jure_liege_title = title:e_armenia }
+		}
+		if = {	#If owned, annex Jerusalem.
+			limit = {
+				title:k_jerusalem = { holder = root  }
+			}
+			title:k_jerusalem = { set_de_jure_liege_title = title:e_armenia }
+		}
+	}
+	custom_tooltip = create_armenian_empire_decision_effects_de_jure_tt_a
+	custom_tooltip = create_armenian_empire_decision_effects_de_jure_tt_b
+}
+
+form_dai_viet_empire_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:e_viet = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	root.dynasty = {
+		add_dynasty_prestige = major_dynasty_prestige_gain
+	}
+
+	if = {
+		limit = {
+			title:k_viet = {
+				is_title_created = yes 
+				NOT = {
+					holder = ROOT
+				}
+			}
+		}
+		create_title_and_vassal_change = {
+			type = usurped
+			save_scope_as = title_change_2
+			add_claim_on_loss = no
+		}
+		title:k_viet = {
+			change_title_holder = {
+				holder = root
+				change = scope:title_change_2
+			}
+		}
+		resolve_title_and_vassal_change = scope:title_change_2
+	}
+	else_if = {
+		limit = {
+			title:k_viet = { is_title_created = no }
+		}
+		create_title_and_vassal_change = {
+			type = created
+			save_scope_as = title_change_2
+			add_claim_on_loss = no
+		}
+		title:k_viet = {
+			change_title_holder = {
+				holder = root
+				change = scope:title_change_2
+			}
+		}
+		resolve_title_and_vassal_change = scope:title_change_2
+	}
+	#Viet controls
+	if = {	#If owned, annex Dai Viet.
+		limit = {
+			title:k_viet = { holder = root  }
+		}
+		title:k_viet = { set_de_jure_liege_title = title:e_viet }
+	}
+	if = {	#If owned, annex Champa.
+		limit = {
+			title:k_champa = { holder = root  }
+		}
+		title:k_champa = { set_de_jure_liege_title = title:e_viet }
+	}
+	if = {	#If any have drifted out, then k_viet's constituent duchies are flipped back.
+		limit = {
+			title:d_hai_dong = {
+				NOT = { target_is_de_jure_liege_or_above = title:k_viet }
+			}
+		}
+		title:d_hai_dong = { set_de_jure_liege_title = title:k_viet }
+	}
+	if = {	#If any have drifted out, then k_viet's constituent duchies are flipped back.
+		limit = {
+			title:d_lam_tay = {
+				NOT = { target_is_de_jure_liege_or_above = title:k_viet }
+			}
+		}
+		title:d_lam_tay = { set_de_jure_liege_title = title:k_viet }
+	}
+	if = {	#If any have drifted out, then k_viet's constituent duchies are flipped back.
+		limit = {
+			title:d_nghe_an = {
+				NOT = { target_is_de_jure_liege_or_above = title:k_viet }
+			}
+		}
+		title:d_nghe_an = { set_de_jure_liege_title = title:k_viet }
+	}
+	if = {	#If any have drifted out, then k_viet's constituent duchies are flipped back.
+		limit = {
+			title:d_hai_dong = {
+				NOT = { target_is_de_jure_liege_or_above = title:k_viet }
+			}
+		}
+		title:d_thang_long = { set_de_jure_liege_title = title:k_viet }
+	}
+	#Champa controls
+	if = {	#If any have drifted out, then k_champa's constituent duchies are flipped back.
+		limit = {
+			title:d_indrapura = {
+				NOT = { target_is_de_jure_liege_or_above = title:k_champa }
+			}
+		}
+		title:d_indrapura = { set_de_jure_liege_title = title:k_champa }
+	}
+	if = {	#If any have drifted out, then k_champa's constituent duchies are flipped back.
+		limit = {
+			title:d_vijaya = {
+				NOT = { target_is_de_jure_liege_or_above = title:k_champa }
+			}
+		}
+		title:d_vijaya = { set_de_jure_liege_title = title:k_champa }
+	}
+	if = {	#If any have drifted out, then k_champa's constituent duchies are flipped back.
+		limit = {
+			title:d_baigaur = {
+				NOT = { target_is_de_jure_liege_or_above = title:k_champa }
+			}
+		}
+		title:d_baigaur = { set_de_jure_liege_title = title:k_champa }
+	}
+
+	if = {
+		limit = {
+			government_has_flag = government_is_meritocratic
+		}
+		add_realm_law = single_heir_succession_law
+	}
+}
+
+form_majapahit_empire_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:e_majapahit = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	root.dynasty = {
+		add_dynasty_modifier = majapahit_empire_founding_modifier
+	}
+
+	hidden_effect = {
+		title:k_yavakadvipa = { save_scope_as = javanese_yavakadvipa }
+		title:d_SUM_palembang = { save_scope_as = javanese_palembang }
+		title:d_JAV_taruma = { save_scope_as = javanese_taruma }
+		title:d_JAV_mataram = { save_scope_as = javanese_mataram }
+		title:c_JAV_madura = { save_scope_as = javanese_madura }
+		title:e_majapahit = { save_scope_as = javanese_majapahit_empire }
+		title:k_yavakadvipa = { set_de_jure_liege_title = title:e_majapahit }
+		if = {
+			limit = {
+				title:k_yavakadvipa = {
+					is_title_created = yes 
+					NOT = {
+						holder = ROOT
+					}
+				}
+			}
+			create_title_and_vassal_change = {
+				type = usurped
+				save_scope_as = title_change_2
+				add_claim_on_loss = no
+			}
+			title:k_yavakadvipa = {
+				change_title_holder = {
+					holder = root
+					change = scope:title_change_2
+				}
+			}
+			resolve_title_and_vassal_change = scope:title_change_2
+		}
+		else_if = {
+			limit = {
+				title:k_yavakadvipa = { is_title_created = no }
+			}
+			create_title_and_vassal_change = {
+				type = created
+				save_scope_as = title_change_2
+				add_claim_on_loss = no
+			}
+			title:k_yavakadvipa = {
+				change_title_holder = {
+					holder = root
+					change = scope:title_change_2
+				}
+			}
+			resolve_title_and_vassal_change = scope:title_change_2
+		}
+		if = {
+			limit = {
+				title:d_SUM_palembang = {
+					NOT = { target_is_de_jure_liege_or_above = title:k_yavakadvipa }
+				}
+			}
+			title:d_SUM_palembang = { set_de_jure_liege_title = title:k_yavakadvipa }
+		}
+		if = {
+			limit = {
+				title:d_JAV_taruma = {
+					NOT = { target_is_de_jure_liege_or_above = title:k_yavakadvipa }
+				}
+			}
+			title:d_JAV_taruma = { set_de_jure_liege_title = title:k_yavakadvipa }
+		}
+		if = {
+			limit = {
+				title:d_JAV_mataram = {
+					NOT = { target_is_de_jure_liege_or_above = title:k_yavakadvipa }
+				}
+			}
+			title:d_JAV_mataram = { set_de_jure_liege_title = title:k_yavakadvipa }
+		}
+		if = {
+			limit = {
+				title:c_JAV_madura = {
+					NOT = { target_is_de_jure_liege_or_above = title:d_JAV_mataram }
+				}
+			}
+			title:c_JAV_madura = { set_de_jure_liege_title = title:d_JAV_mataram }
+		}
+		if = {	#If owned, annex Champa.
+			limit = {
+				title:k_yavakadvipa = { holder = root  }
+			}
+			title:k_yavakadvipa = { set_de_jure_liege_title = title:e_majapahit }
+		}
+	}
+	custom_tooltip = form_majapahit_empire_decision_effects_de_jure_tt_a
+	custom_tooltip = form_majapahit_empire_decision_effects_de_jure_tt_b
+	custom_tooltip = form_majapahit_empire_decision_effects_de_jure_tt_c
+}
+
+form_ryukyu_empire_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:e_ruucuu = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	capital_county = {
+		every_county_province = {
+			add_province_modifier = ryukyu_empire_founding_province_modifier
+		}
+	}
+
+	hidden_effect = {
+		title:k_ruucuu = { save_scope_as = ryukyuan_ruucuu_kingdom }
+		title:d_ruucuu = { save_scope_as = ryukyuan_ruucuu_duchy }
+		title:e_ruucuu = { save_scope_as = ryukyuan_ruucuu_empire }
+		title:k_ruucuu = { set_de_jure_liege_title = title:e_ruucuu }
+		if = {
+			limit = {
+				title:k_ruucuu = {
+					is_title_created = yes 
+					NOT = {
+						holder = ROOT
+					}
+				}
+			}
+			create_title_and_vassal_change = {
+				type = usurped
+				save_scope_as = title_change_2
+				add_claim_on_loss = no
+			}
+			title:k_ruucuu = {
+				change_title_holder = {
+					holder = root
+					change = scope:title_change_2
+				}
+			}
+			resolve_title_and_vassal_change = scope:title_change_2
+		}
+		else_if = {
+			limit = {
+				title:k_ruucuu = { is_title_created = no }
+			}
+			create_title_and_vassal_change = {
+				type = created
+				save_scope_as = title_change_2
+				add_claim_on_loss = no
+			}
+			title:k_ruucuu = {
+				change_title_holder = {
+					holder = root
+					change = scope:title_change_2
+				}
+			}
+			resolve_title_and_vassal_change = scope:title_change_2
+		}
+		if = {
+			limit = {
+				title:d_ruucuu = {
+					NOT = { target_is_de_jure_liege_or_above = title:k_ruucuu }
+				}
+			}
+			custom_tooltip = form_ryukyu_empire_decision_effects_de_jure_tt_b
+			title:d_ruucuu = { set_de_jure_liege_title = title:k_ruucuu }
+		}
+		if = {
+			limit = {
+				title:c_ucinaa = {
+					NOT = { target_is_de_jure_liege_or_above = title:d_ruucuu }
+				}
+			}
+			title:c_ucinaa = { set_de_jure_liege_title = title:d_ruucuu }
+		}
+		if = {
+			limit = {
+				title:c_amami = {
+					NOT = { target_is_de_jure_liege_or_above = title:d_ruucuu }
+				}
+			}
+			title:c_amami = { set_de_jure_liege_title = title:d_ruucuu }
+		}
+	}
+	custom_tooltip = form_ryukyu_empire_decision_effects_de_jure_tt_a
+}
+
+form_siam_kingdom_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:k_siam = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	add_prestige_experience = major_fame_gain
+
+	hidden_effect = {
+		title:k_siam = { save_scope_as = siam_kingdom }
+		title:d_sukhothai = { save_scope_as = sukhotai_duchy }
+		title:d_lop_buri = { save_scope_as = lop_buri }
+		title:d_sukhothai = { set_de_jure_liege_title = title:k_siam }
+		title:d_lop_buri = { set_de_jure_liege_title = title:k_siam }
+		every_held_title = { # add other duchies if I hold any in the region
+			limit = {
+				tier = tier_duchy
+				any_de_jure_county = {
+					title_province = {
+						OR = {
+							geographical_region = world_asia_thailand
+							geographical_region = world_asia_malaysia
+						}
+					}
+				}
+				NOT = {
+					this = title:d_sukhothai
+					this = title:d_lop_buri
+				}
+			}
+			set_de_jure_liege_title = title:k_siam
+		}
+	}
+	custom_tooltip = form_siam_kingdom_decision_effects_de_jure_tt_a
+}
+
+form_brunei_kingdom_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:k_brunei = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	dynasty = {
+		add_dynasty_prestige = massive_dynasty_prestige_gain
+	}
+
+	hidden_effect = {
+		title:k_brunei = { save_scope_as = brunei_kingdom }
+		title:d_BOR_barune = { save_scope_as = barune_duchy }
+		title:d_BOR_santubong = { save_scope_as = santubong_duchy }
+		title:c_BOR_berau = { save_scope_as = berau_county }
+
+		title:d_BOR_barune = { set_de_jure_liege_title = title:k_brunei }
+		title:d_BOR_santubong = { set_de_jure_liege_title = title:k_brunei }
+		title:c_BOR_berau = { set_de_jure_liege_title = title:d_BOR_barune }
+	}
+	custom_tooltip = form_brunei_kingdom_decision_effects_de_jure_tt_a
+	custom_tooltip = form_brunei_kingdom_decision_effects_de_jure_tt_b
+	custom_tooltip = form_brunei_kingdom_decision_empire_unlock
+}
+
+form_brunei_empire_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:e_brunei = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	dynasty = {
+		add_dynasty_prestige = monumental_dynasty_prestige_gain
+	}
+	give_nickname = nick_the_pious
+
+	hidden_effect = {
+		title:e_brunei = { save_scope_as = brunei_empire }
+		title:k_brunei = { save_scope_as = brunei_kingdom }
+		title:k_tanjungnagara = { save_scope_as = tanjungnagara_kingdom }
+		title:d_PHI_sandao = { save_scope_as = sandao_duchy }
+		title:d_BOR_barune = { save_scope_as = barune_duchy }
+		title:c_PHI_sulu = { save_scope_as = sulu_county }
+
+		title:k_brunei = { set_de_jure_liege_title = title:e_brunei }
+		title:k_tanjungnagara = { set_de_jure_liege_title = title:e_brunei }
+		title:d_PHI_sandao = { set_de_jure_liege_title = title:k_brunei }
+		title:c_PHI_sulu = { set_de_jure_liege_title = title:d_BOR_barune }
+	}
+	custom_tooltip = form_brunei_empire_decision_effects_de_jure_tt_a
+	custom_tooltip = form_brunei_empire_decision_effects_de_jure_tt_b
+	custom_tooltip = form_brunei_empire_decision_effects_de_jure_tt_c
+}
+
+restore_holy_roman_empire_decision_scripted_effect = {
+	save_scope_as = founder
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:e_hre = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	set_primary_title_to = title:e_hre
+
+	#Papal hook management.
+	if = {
+		limit = {
+			faith.religious_head = {
+				exists = this
+				opinion = {
+					target = root
+					value < high_positive_opinion
+				}
+			}
+			OR = {
+				has_weak_hook = faith.religious_head
+				has_strong_usable_hook = faith.religious_head
+			}
+		}
+		use_hook = faith.religious_head
+	}
+
+	#Sort title laws.
+	if = {
+		limit = {
+			OR = {
+				has_title = title:k_east_francia
+				any_vassal = {
+					has_title = title:k_east_francia
+				}
+			}
+		}
+		destroy_title = title:k_east_francia	#Make Germany inalienable.
+	}
+	title:e_hre = {
+		add_title_law = princely_elective_succession_law
+		if = {	#Add Salic law.
+			limit = {
+				root = {
+					OR = {
+						has_realm_law = male_preference_law
+						has_realm_law = male_only_law
+					}
+				}
+			}
+			add_title_law = male_only_law
+		}
+		if = {	#Ignore Salic law.
+			limit = {
+				root = { has_realm_law = equal_law }
+			}
+			add_title_law = equal_law
+		}
+		if = {	#Invert Salic law. Take that, Clovis, y'big nerd.
+			limit = {
+				root = {
+					OR = {
+						has_realm_law = female_preference_law
+						has_realm_law = female_only_law
+					}
+				}
+			}
+			add_title_law = female_only_law
+		}
+		custom_tooltip = hre_elector_list_creation_tt
+	}
+
+	#Add de jures.
+	hidden_effect = {
+		if = {	#If Germania is nae a thing, merge it into the HRE.
+			limit = {
+				OR = {
+					has_title = title:k_east_francia
+					has_title = title:k_bavaria
+					has_title = title:k_lotharingia
+					has_title = title:k_frisia
+					any_vassal = {
+						OR = {
+							has_title = title:k_east_francia
+							has_title = title:k_bavaria
+							has_title = title:k_lotharingia
+							has_title = title:k_frisia
+						}
+					}
+				}
+				OR = {
+					NOT = { exists = title:e_germany.holder }
+					title:e_germany.holder ?= root
+				}
+			}
+			title:e_germany = {
+				every_in_de_jure_hierarchy = {
+					limit = { tier = tier_kingdom }
+					set_de_jure_liege_title = title:e_hre
+				}
+			}
+		}
+		every_held_title = {
+			title_tier = kingdom
+			limit = {
+				NOT = {	#The Pope retains vague dibs on Italy.
+					any_this_title_or_de_jure_above = { this = title:e_italy }
+				}
+				save_temporary_scope_as = this_title
+				#root = { completely_controls = scope:this_title }
+			}
+			set_de_jure_liege_title = title:e_hre
+		}
+		every_vassal = {
+			every_held_title = {
+				title_tier = kingdom
+				limit = {
+					NOT = {	#The Pope retains vague dibs on Italy.
+						any_this_title_or_de_jure_above = { this = title:e_italy }
+					}
+					save_temporary_scope_as = this_title
+					#prev = { completely_controls = scope:this_title }
+				}
+				set_de_jure_liege_title = title:e_hre
+			}
+		}
+		if = { # Merge Francia into the HRE under certain conditions
+			limit = {
+				OR = {
+					NOT = { exists = title:e_france.holder }
+					title:e_france.holder ?= root
+				}
+				OR = {
+					title:k_france = { # If core West Francia is part of the HRE
+						target_is_de_jure_liege_or_above = title:e_hre
+					}
+					calc_true_if = { # Or 2+ of the other francian Kingdoms
+						amount >= 2
+						title:k_burgundy = {
+							target_is_de_jure_liege_or_above = title:e_hre
+						}
+						title:k_aquitaine = {
+							target_is_de_jure_liege_or_above = title:e_hre
+						}
+						title:k_brittany = {
+							target_is_de_jure_liege_or_above = title:e_hre
+						}
+					}
+				}
+			}
+			title:e_france = {
+				every_in_de_jure_hierarchy = {
+					limit = { tier = tier_kingdom }
+					set_de_jure_liege_title = title:e_hre
+				}
+			}
+		}
+		every_vassal = {
+			limit = {
+				is_ai = yes
+			}
+			every_held_title = {
+				title_tier = kingdom
+				root = {
+					destroy_title = prev
+				}
+			}
+		}
+		every_held_title = {
+			title_tier >= kingdom
+			limit = {
+				NOT = {
+					this = title:e_hre
+				}
+				save_temporary_scope_as = this_title
+			}
+			root = {
+				destroy_title = prev
+			}
+		}
+	}
+	custom_tooltip = restore_holy_roman_empire_decision_effects_de_jure.tt
+
+	#And add a bit of prestige for the trouble.
+	add_prestige = massive_prestige_value
+}
+
+found_kingdom_of_bosnia_decision_scripted_effect = {
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:k_bosnia = {
+		change_title_holder = {
+			holder = scope:founder
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+
+	title:d_bosna = { set_de_jure_liege_title = title:k_bosnia }
+	title:d_lower_bosna = { set_de_jure_liege_title = title:k_bosnia }
+	title:d_usora = { set_de_jure_liege_title = title:k_bosnia }
+}
+
+found_kingdom_of_livonia_decision_scripted_effect = {
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:k_livonia = {
+		change_title_holder = {
+			holder = scope:founder
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+
+	title:d_latgalians = { set_de_jure_liege_title = title:k_livonia }
+	title:d_courland = { set_de_jure_liege_title = title:k_livonia }
+	title:d_livonia = { set_de_jure_liege_title = title:k_livonia }
+	if = {
+		limit = {
+			title:d_esthonia = { holder = root }
+		}
+		title:d_esthonia = { set_de_jure_liege_title = title:k_livonia }
+	}
+	if = {
+		limit = {
+			has_faith = faith:baltic_pagan
+			root.culture = { NOT = { has_innovation = innovation_longboats } }
+		}
+		root.culture = { add_innovation = innovation_longboats }
+	}
+}
+
+unite_bene_israel_effect = {
+	add_prestige = major_prestige_gain
+	add_piety = major_piety_gain
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	title:k_bene_israel = {
+		change_title_holder = {
+			holder = scope:founder
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+
+	title:d_chera_nadu = { set_de_jure_liege_title = title:k_bene_israel }
+	title:d_konkana = { set_de_jure_liege_title = title:k_bene_israel }
+	if = {
+		limit = {
+			title:d_lata = { holder = root }
+		}
+		title:d_lata = { set_de_jure_liege_title = title:k_bene_israel }
+	}
+	if = {
+		limit = {
+			title:d_nasikya = { holder = root }
+		}
+		title:d_nasikya = { set_de_jure_liege_title = title:k_bene_israel }
+	}
+	random_held_title = {
+		title_tier = barony
+		limit = {
+			is_holy_site_of = faith:malabarism
+		}
+		county = { set_county_culture = culture:kochinim }
+		county = { set_county_faith = faith:malabarism }
+	}
+}
+
+hre_elector_list_save_effect = {
+	ordered_in_global_list = {
+		variable = hre_elector_list
+		max = 7
+		check_range_bounds = no
+		order_by = tier
+		save_temporary_scope_as = hre_elector_title
+		title:e_hre = {
+			if = {
+				limit = { NOT = { has_variable = hre_elector_1 } }
+				set_variable = { name = hre_elector_1 value = scope:hre_elector_title }
+			}
+			else_if = {
+				limit = { NOT = { has_variable = hre_elector_2 } }
+				set_variable = { name = hre_elector_2 value = scope:hre_elector_title }
+			}
+			else_if = {
+				limit = { NOT = { has_variable = hre_elector_3 } }
+				set_variable = { name = hre_elector_3 value = scope:hre_elector_title }
+			}
+			else_if = {
+				limit = { NOT = { has_variable = hre_elector_4 } }
+				set_variable = { name = hre_elector_4 value = scope:hre_elector_title }
+			}
+			else_if = {
+				limit = { NOT = { has_variable = hre_elector_5 } }
+				set_variable = { name = hre_elector_5 value = scope:hre_elector_title }
+			}
+			else_if = {
+				limit = { NOT = { has_variable = hre_elector_6 } }
+				set_variable = { name = hre_elector_6 value = scope:hre_elector_title }
+			}
+			else_if = {
+				limit = { NOT = { has_variable = hre_elector_7 } }
+				set_variable = { name = hre_elector_7 value = scope:hre_elector_title }
+			}
+		}
+	}
+}
+
+favour_the_countryside_basques_decision_generic_effects_scripted_effect = {
+	scope:religious_leader = {
+		# If you weren't Basque, become so.
+		if = {
+			limit = { favour_the_countryside_basques_counts_as_basque_trigger = no }
+			# Now, we need to work out which Basque culture you should be.
+			## First, we gather our candidates.
+			### Going through counties.
+			every_sub_realm_county = {
+				limit = {
+					favour_the_countryside_basques_counts_as_basque_trigger = yes
+					NOT = {
+						culture = { is_in_list = realm_basque_cultures_list }
+					}
+				}
+				culture = { add_to_list = realm_basque_cultures_list }
+			}
+			### Plus vassals.
+			every_vassal_or_below = {
+				limit = {
+					favour_the_countryside_basques_counts_as_basque_trigger = yes
+					NOT = {
+						culture = { is_in_list = realm_basque_cultures_list }
+					}
+				}
+				culture = { add_to_list = realm_basque_cultures_list }
+			}
+			### And those close to you.
+			every_close_or_extended_family_member = {
+				limit = {
+					favour_the_countryside_basques_counts_as_basque_trigger = yes
+					NOT = {
+						culture = { is_in_list = realm_basque_cultures_list }
+					}
+				}
+				culture = { add_to_list = realm_basque_cultures_list }
+			}
+			every_consort = {
+				limit = {
+					favour_the_countryside_basques_counts_as_basque_trigger = yes
+					NOT = {
+						culture = { is_in_list = realm_basque_cultures_list }
+					}
+				}
+				culture = { add_to_list = realm_basque_cultures_list }
+			}
+			every_relation = {
+				type = friend
+				limit = {
+					favour_the_countryside_basques_counts_as_basque_trigger = yes
+					NOT = {
+						culture = { is_in_list = realm_basque_cultures_list }
+					}
+				}
+				culture = { add_to_list = realm_basque_cultures_list }
+			}
+			every_relation = {
+				type = lover
+				limit = {
+					favour_the_countryside_basques_counts_as_basque_trigger = yes
+					NOT = {
+						culture = { is_in_list = realm_basque_cultures_list }
+					}
+				}
+				culture = { add_to_list = realm_basque_cultures_list }
+			}
+			## Next, we process the list.
+			if = {
+				limit = {
+					any_in_list = {
+						list = realm_basque_cultures_list
+						exists = this
+					}
+				}
+				ordered_in_list = {
+					list = realm_basque_cultures_list
+					order_by = {
+						value = 0
+						save_temporary_scope_as = culture_temp
+						# Culture counties are added differently depending on whether they're inside or outside the realm
+						every_culture_county = {
+							# Every culture county in your realm adds 10.
+							if = {
+								limit = {
+									holder = {
+										OR = {
+											this = scope:religious_leader
+											any_liege_or_above = { this = scope:religious_leader  }
+										}
+									}
+								}
+								add = 10
+							}
+							# Every culture county outside your realm adds 5.
+							else = { add = 5 }
+						}
+						scope:religious_leader = {
+							# Vassals add weight depending on their rank.
+							every_vassal = {
+								if = {
+									limit = { culture = scope:culture_temp }
+									# Every king-tier vassal adds 50.
+									if = {
+										limit = { highest_held_title_tier = tier_kingdom }
+										add = 50
+									}
+									# Every duke-tier vassal adds 25.
+									else_if = {
+										limit = { highest_held_title_tier = tier_duchy }
+										add = 25
+									}
+									# Every count-tier vassal adds 10.
+									else_if = {
+										limit = { highest_held_title_tier = tier_county }
+										add = 10
+									}
+									# Barons are unimportant.
+								}
+							}
+							# Every close family member adds 15.
+							every_close_family_member = {
+								limit = { culture = scope:culture_temp }
+								add = 15
+							}
+							# Every extended family members adds 5.
+							every_extended_family_member = {
+								limit = { culture = scope:culture_temp }
+								add = 5
+							}
+							# Every soulmate adds 50.
+							every_relation = {
+								type = soulmate
+								limit = { culture = scope:culture_temp }
+								add = 50
+							}
+							# Every best friend adds 50.
+							every_relation = {
+								type = best_friend
+								limit = { culture = scope:culture_temp }
+								add = 50
+							}
+							# Every lover adds 15.
+							every_relation = {
+								type = lover
+								limit = {
+									culture = scope:culture_temp
+									NOT = { has_relation_soulmate = scope:religious_leader }
+								}
+								add = 15
+							}
+							# Every friend adds 15.
+							every_relation = {
+								type = friend
+								limit = {
+									culture = scope:culture_temp
+									NOT = { has_relation_best_friend = scope:religious_leader }
+								}
+								add = 15
+							}
+						}
+					}
+					save_scope_as = chosen_basque_culture
+				}
+			}
+			## Finally, we try to convert.
+			if = {
+				limit = { exists = scope:chosen_basque_culture }
+				convert_family_culture_and_notify_vassals_effect = {
+					CONVERTER = scope:religious_leader
+					OLD_CULTURE = scope:religious_leader.culture
+					NEW_CULTURE = scope:chosen_basque_culture
+				}
+			}
+			# If this hasn't worked at all, and they've got _any_ counties left, we just switch you to the regular Basque.
+			else_if = {
+				limit = {
+					culture:basque = {
+						any_culture_county = { exists = this }
+					}
+				}
+				convert_family_culture_and_notify_vassals_effect = {
+					CONVERTER = scope:religious_leader
+					OLD_CULTURE = scope:religious_leader.culture
+					NEW_CULTURE = culture:basque
+				}
+			}
+			# Otherwise, we presume that the Basque presence in the region is extinct or negligible (at least on the macro level), so we leave your culture alone.
+		}
+		# Assign a new nickname, if appropriate.
+		if = {
+			limit = {
+				OR = {
+					has_any_nickname = no
+					has_bad_nickname = yes
+				}
+			}
+			# If you're not already a pagan, guess what folks call you?
+			if = {
+				limit = {
+					NOT = {
+						faith = { has_doctrine = pagan_hostility_doctrine }
+					}
+				}
+				give_nickname = nick_the_pagan
+			}
+			# Otherwise, you're probably an invading Viking and you deserve to get memed.
+			else = { give_nickname = nick_the_mountain_king }
+		}
+		# Switch to the new faith.
+		add_character_flag = {
+			flag = delay_player_faith_conversion_notification_event
+			days = 1
+		}
+		# Configure Basque paganism's variable set-up.
+		faith:basque_pagan = {
+			# Remove the restrictions on converting to Basque paganism.
+			remove_variable = block_conversion_till_decision_taken
+			# And, since you're inherently creating a new priestly structure
+			## This is mostly done here for immersive reasons; we don't want to imply that Basque paganism already had a distinct organised religious hierarchy in 867 by just applying this on game start, even though you'll always have to have it to access the faith.
+			set_variable = { name = has_been_reformed }
+			remove_doctrine = unreformed_faith_doctrine
+		}
+		# Finally, convert.
+		## We do this here so that it's reformed by the time you switch (giving you a better chance with vassal conversion rates).
+		set_character_faith_with_conversion = faith:basque_pagan
+	}
+}
+
+favour_the_countryside_basques_decision_fundamentalist_path_scripted_effect = {
+	faith:basque_pagan = {
+		# First, we remove Christian Syncretism & replace it with Warmonger.
+		remove_doctrine = tenet_christian_syncretism
+		add_doctrine = tenet_warmonger
+		# Then, we switch on over from Pluralist to Fundamentalist.
+		## We disguise some of these changes for neatness, as there's a lot to process.
+		hidden_effect = { remove_doctrine = doctrine_pluralism_pluralistic }
+		add_doctrine = doctrine_pluralism_fundamentalist
+		# No HoF becomes a spiritual HoF, so that you can make use of your Warmonger GHWs.
+		hidden_effect = { remove_doctrine = doctrine_no_head }
+		add_doctrine = doctrine_spiritual_head
+		# Plus, set the faith's fervour to a middling/low level, since you've messed with it.
+		change_fervor = {
+			value = -50
+			desc = fervour_loss_temporal_meddling
+		}
+	}
+	# Create the new HoF.
+	hidden_effect = {
+		scope:religious_leader = {
+			set_up_dynamic_spiritual_hof_title_effect = { CREATOR = scope:religious_leader }
+		}
+	}
+	custom_tooltip = favour_the_countryside_basques_decision.tt.spiritual_hof_acquired
+	# We get a small modifier for clergy approval, since they're a bit peeved at the tenet-messing.
+	add_character_modifier = fp2_friend_of_the_old_ways_modifier
+}
+
+favour_the_countryside_basques_decision_righteous_path_scripted_effect = {
+	faith:basque_pagan = {
+		# First, we remove Christian Syncretism & replace it with Sanctity of Nature.
+		remove_doctrine = tenet_christian_syncretism
+		add_doctrine = tenet_sanctity_of_nature
+		# Then, we switch on over from Pluralist to Righteous.
+		## We disguise some of these changes for neatness, as there's a lot to process.
+		hidden_effect = { remove_doctrine = doctrine_pluralism_pluralistic }
+		add_doctrine = doctrine_pluralism_righteous
+		# No HoF becomes you as the temporal HoF, as you're focusing more on the non-Christian parts of the faith.
+		hidden_effect = {
+			remove_doctrine = doctrine_no_head
+			remove_doctrine = doctrine_theocracy_temporal
+			remove_doctrine = doctrine_clerical_succession_spiritual_appointment
+		}
+		add_doctrine = doctrine_temporal_head
+		add_doctrine = doctrine_theocracy_lay_clergy
+		add_doctrine = doctrine_clerical_succession_temporal_fixed_appointment
+		# Plus, set the faith's fervour to a middling/low level, since you've messed with it.
+		change_fervor = {
+			value = -50
+			desc = fervour_loss_temporal_meddling
+		}
+	}
+	# Create the new HoF.
+	hidden_effect = {
+		scope:religious_leader = {
+			set_up_dynamic_temporal_hof_title_effect = { NEW_HOLDER = scope:religious_leader }
+		}
+	}
+	custom_tooltip = favour_the_countryside_basques_decision.tt.temporal_hof_acquired
+	# We get a small modifier for clergy approval, since they're a bit peeved at the tenet-messing.
+	add_character_modifier = fp2_friend_of_the_old_ways_modifier
+}
+
+favour_the_countryside_basques_decision_pluralist_path_scripted_effect = {
+	faith:basque_pagan = {
+		# First, we mostly only need to remove Christian Syncretism & replace it with Islamic Syncretism.
+		remove_doctrine = tenet_christian_syncretism
+		add_doctrine = tenet_islamic_syncretism
+		# Then set the faith's fervour to a middling/low level, since you've messed with it.
+		change_fervor = {
+			value = -50
+			desc = fervour_loss_temporal_meddling
+		}
+	}
+	# Bonus opinion with every neighbouring Islamic ruler & their vassals, who appreciate the direction you're going in.
+	## Compile a list.
+	top_liege = {
+		if = {
+			limit = { religion = religion:islam_religion }
+			add_to_list = pleased_rulers
+		}
+		every_vassal_or_below = {
+			limit = { religion = religion:islam_religion }
+			add_to_list = pleased_rulers
+		}
+	}
+	every_neighboring_and_across_water_top_liege_realm_owner = {
+		if = {
+			limit = { religion = religion:islam_religion }
+			add_to_list = pleased_rulers
+		}
+		every_vassal_or_below = {
+			limit = { religion = religion:islam_religion }
+			add_to_list = pleased_rulers
+		}
+	}
+	## And apply some opinions.
+	every_in_list = {
+		list = pleased_rulers
+		custom = favour_the_countryside_basques_decision.tt.all_neighbouring_islamic_rulers
+		add_opinion = {
+			target = scope:religious_leader
+			modifier = pleased_opinion
+			opinion = 30
+		}
+	}
+	# We get a small modifier for clergy approval, since they're a bit peeved at the tenet-messing.
+	add_character_modifier = fp2_friend_of_the_old_ways_modifier
+}
+
+favour_the_countryside_basques_decision_default_path_scripted_effect = {
+	faith:basque_pagan = {
+		# Here, we're not fiddling with the faith's traditions at all, so we get a chonky fervour bonus for the sudden limelight.
+		change_fervor = {
+			value = 100
+			desc = fervour_gain_unexpected_resurgence
+		}
+	}
+	# Plus a massive chunk of piety experience...
+	add_piety_experience = 2000
+	# ... and a more powerful clergy-approval modifier.
+	add_character_modifier = fp2_champion_of_the_old_ways_modifier
+}
+
+create_kingdom_of_saxony_effect = {
+	if = {
+		limit = {
+			NOR = {
+				root = $CHARACTER$
+				exists = scope:new_saxon_king
+			}
+		}
+		# Grant every held title in Saxony to the new holder
+		root = {
+			every_held_title = {
+				limit = {
+					OR = {
+						title:k_saxony = { is_de_jure_liege_or_above_target = prev }
+						title:k_sorbia = { is_de_jure_liege_or_above_target = prev }
+					}
+					NOT = {
+						holder = { capital_county = prev }
+					}
+				}
+				create_title_and_vassal_change = {
+					type = granted
+					save_scope_as = title_change
+					add_claim_on_loss = no
+				}
+				change_title_holder = {
+					holder = $CHARACTER$
+					change = scope:title_change
+				}
+				resolve_title_and_vassal_change = scope:title_change
+			}
+		}
+	}
+	if = {
+		limit = { exists = title:k_sorbia.holder }
+		destroy_title = title:k_sorbia
+	}
+	title:k_sorbia = {
+		every_in_de_jure_hierarchy = {
+			limit = { tier = tier_duchy }
+			set_de_jure_liege_title = title:k_saxony
+		}
+	}
+	title:k_saxony = { set_coa = k_saxon_electorate }
+	title:k_saxony = { set_de_jure_liege_title = title:e_hre }
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	if = {
+		limit = {
+			has_title = title:e_hre
+		}
+		hidden_effect = {
+			title:k_saxony = {
+				change_title_holder = {
+					holder = $CHARACTER$
+					change = scope:title_change
+				}
+			}
+		}
+	}
+	else = {
+		title:k_saxony = {
+			change_title_holder = {
+				holder = $CHARACTER$
+				change = scope:title_change
+			}
+		}
+	}
+	every_vassal = {
+		limit = {
+			primary_title = {
+				OR = {
+					title:k_saxony = { is_de_jure_liege_or_above_target = prev }
+					title:k_sorbia = { is_de_jure_liege_or_above_target = prev }
+				}
+			}
+			NOT = { this = $CHARACTER$ }
+			NOT = { any_liege_or_above = { this = $CHARACTER$ } }
+		}
+		change_liege = {
+			liege = $CHARACTER$
+			change = scope:title_change
+		}
+	}
+	hidden_effect = {
+		if = {
+			limit = {
+				NOR = {
+					$CHARACTER$ = root
+					$CHARACTER$ = { is_vassal_or_below_of = root }
+				}
+			}
+			$CHARACTER$ = {
+				change_liege = {
+					liege = root
+					change = scope:title_change
+				}
+			}
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	hidden_effect = {
+		$CHARACTER$ = { save_scope_as = new_saxon_king }
+		every_player = {
+			limit = {
+				this != prev
+				or = {
+					is_vassal_or_below_of = title:e_hre.holder
+					AND = {
+						exists = title:e_west_slavia
+						is_vassal_or_below_of = title:e_west_slavia.holder
+					}
+					title:e_hre = { is_neighbor_to_realm = prev }
+					primary_title = {
+						title:e_west_slavia = { is_de_jure_liege_or_above_target = prev }
+					}
+				}
+			}
+			trigger_event =  middle_europe_decisions.0018
+		}
+	}
+}
+
+restore_old_vasconia_decision_scripted_effect = {
+	save_scope_as = founder
+	# Give Navarra if not held
+	if = {
+		limit = {
+			NOT = { has_title = title:k_navarra }
+		}
+		create_title_and_vassal_change = {
+			type = created
+			save_scope_as = title_change
+			add_claim_on_loss = no
+		}
+		title:k_navarra = {
+			change_title_holder = {
+				holder = root
+				change = scope:title_change
+			}
+		}
+		resolve_title_and_vassal_change = scope:title_change
+	}
+	title:k_navarra = { set_title_name = k_vasconia }
+	hidden_effect = {
+		# Transfer de jure
+		every_in_list = {
+			list = vasconia_duchies
+			limit = {
+				save_temporary_scope_as = duchy_temp
+				root = { completely_controls = scope:duchy_temp }
+				NOT = { de_jure_liege = title:k_navarra }
+			}
+			add_to_list = vasconia_transfers
+			set_de_jure_liege_title = title:k_navarra
+		}
+		# Destroy held superseded kingdoms (no de jure land left)
+		every_in_list = {
+			list = vasconia_kingdoms
+			limit = {
+				holder = root
+				any_direct_de_jure_vassal_title = { count < 1 }
+			}
+			add_to_list = superseded_kingdoms
+			save_scope_as = superseded_kingdom
+			root = { destroy_title = scope:superseded_kingdom }
+		}
+	}
+}
+
+restore_old_vasconia_decision_tooltip_scripted_effect = {
+	custom_tooltip = restore_old_vasconia_decision_vasconia_past_tt
+	show_as_tooltip = {
+		every_in_list = {
+			list = vasconia_transfers
+			set_de_jure_liege_title = title:k_navarra
+		}
+		every_in_list = {
+			list = superseded_kingdoms
+			save_scope_as = superseded_kingdom
+			root = { destroy_title = scope:superseded_kingdom }
+		}
+	}
+}
+
+create_beth_nahrain_scripted_effect = {
+	#Create Beth Nahrain
+	hidden_effect = {
+		every_held_title = {
+			limit = {
+				tier = tier_empire
+			}
+			every_in_de_jure_hierarchy = {
+				limit = {
+					tier = tier_kingdom
+				}
+				set_de_jure_liege_title = title:e_beth_nahrain
+			}
+		}
+	}
+}
+
+promote_culture_beth_nahrain_scripted_effect = {
+	every_sub_realm_county = {
+		custom = promote_culture_beth_nahrain_modifier_custom_desc
+		limit = {
+			NOT = {
+				culture = { has_cultural_pillar = heritage_syriac }
+			}
+			title_province = { geographical_region = custom_beth_nahrain }
+		}
+		add_county_modifier = {
+			modifier = promote_culture_beth_nahrain_modifier
+			years = 50
+		}
+	}
+	if = {
+		limit = {
+			faith = faith:nestorian
+		}
+		faith:nestorian = {
+			change_fervor = {
+				value = 100
+				desc = middle_east_major_decisions.1020_fervor
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			NOT = {
+				exists = scope:suppress_tooltips
+			}
+		}
+		custom_tooltip = middle_east_major_decisions.1020.lack_nestorian
+	}
+}
+
+learning_beth_nahrain_scripted_effect = {
+	house ?= {
+		add_house_modifier = {
+			modifier = learning_beth_nahrain_house_modifier
+			years = 100
+		}
+	}
+	add_piety_experience = monumental_piety_value
+}
+
+martial_beth_nahrain_scripted_effect = {
+	house ?= {
+		add_house_modifier = {
+			modifier = martial_beth_nahrain_house_modifier
+			years = 100
+		}
+	}
+	add_prestige_experience = monumental_prestige_value
+}
+
+nestorian_faith_beth_nahrain_scripted_effect = {
+	add_trait = crusader_king
+	add_piety_experience = monumental_piety_value
+}
+
+no_faith_beth_nahrain_scripted_effect = {
+	faith:nestorian = {
+		change_fervor = {
+			value = 100
+			desc = middle_east_major_decisions.1020_fervor
+		}
+	}
+	set_character_faith_with_conversion = faith:nestorian
+	add_piety = monumental_piety_gain
+}
+
+found_empire_of_hindustan_scripted_effect = {
+	save_scope_as = founder
+
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	if = {
+		limit = {
+			completely_controls = title:k_punjab #This will always be true but it keeps the decision text easier to read before you fulfill the criteria
+			NOT = { has_title = title:k_punjab }
+		}
+		title:k_punjab = {
+			change_title_holder = {
+				holder = root
+				change = scope:title_change
+			}
+		}
+	}
+	if = {
+		limit = {
+			completely_controls = title:k_delhi #This will always be true but it keeps the decision text easier to read before you fulfill the criteria
+			NOT = { has_title = title:k_delhi }
+		}
+		title:k_delhi = {
+			change_title_holder = {
+				holder = root
+				change = scope:title_change
+			}
+		}
+	}
+	if = {
+		limit = {
+			OR = {
+				NOT = { title:d_kuru.holder = root }
+				AND = {
+					exists = title:d_kuru.holder
+					title:d_kuru.holder = {
+						is_ai = yes
+					}
+				}
+			}
+		}
+		title:d_kuru = {
+			change_title_holder = {
+				holder = root
+				change = scope:title_change
+			}
+		}
+	}
+	if = {
+		limit = {
+			NOT = { title:c_delhi.holder = root }
+		}
+		title:c_delhi = {
+			change_title_holder = {
+				holder = root
+				change = scope:title_change
+			}
+		}
+	}
+	title:e_hindustan = {
+		change_title_holder = {
+			holder = root
+			change = scope:title_change
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	set_primary_title_to = title:e_hindustan
+
+	hidden_effect = {
+		title:k_delhi = {
+			set_de_jure_liege_title = title:e_hindustan
+		}
+		title:k_punjab = {
+			set_de_jure_liege_title = title:e_hindustan
+		}
+		every_held_title = {
+			limit = {
+				tier = tier_kingdom
+				OR = {
+					de_jure_liege = title:e_bengal
+					de_jure_liege = title:e_deccan
+					de_jure_liege = title:e_rajastan
+				}
+			}
+			set_de_jure_liege_title = title:e_hindustan
+		}
+		#Areas that have had more muslim influence wants to avoid border gore and gets added even if not held - unless controlled by an independent Emperor of Rajastan:
+		if = {
+			limit = {
+				NOT = {
+					title:k_sindh.holder.liege = {
+						has_title = title:e_rajastan
+					}
+				}
+			}
+			title:k_sindh = {
+				set_de_jure_liege_title = title:e_hindustan
+			}
+		}
+		if = {
+			limit = {
+				NOT = {
+					title:k_kashmir.holder.liege = {
+						has_title = title:e_rajastan
+					}
+				}
+			}
+			title:k_kashmir = {
+				set_de_jure_liege_title = title:e_hindustan
+			}
+		}
+		add_character_flag = e_hindustan #For title flavorization
+	}
+	#If the new Emperor of Hindustan holds any of the Indian Empires these are destroyed and their kingdoms added to Hindustan too
+	#This is not inside the hidden block to not hide that the empires are destroyed.
+	if = {
+		limit = {
+			has_title = title:e_bengal
+		}
+		hidden_effect = {
+			title:e_bengal = {
+				every_in_de_jure_hierarchy = {
+					limit = {
+						tier = tier_kingdom
+					}
+					set_de_jure_liege_title = title:e_hindustan
+				}
+			}
+		}
+		destroy_title = title:e_bengal
+	}
+	if = {
+		limit = {
+			has_title = title:e_deccan
+		}
+		hidden_effect = {
+			title:e_deccan = {
+				every_in_de_jure_hierarchy = {
+					limit = {
+						tier = tier_kingdom
+					}
+					set_de_jure_liege_title = title:e_hindustan
+				}
+			}
+		}
+		destroy_title = title:e_deccan
+	}
+	if = {
+		limit = {
+			has_title = title:e_rajastan
+		}
+		hidden_effect = {
+			title:e_rajastan = {
+				every_in_de_jure_hierarchy = {
+					limit = {
+						tier = tier_kingdom
+					}
+					set_de_jure_liege_title = title:e_hindustan
+				}
+			}
+		}
+		destroy_title = title:e_rajastan
+	}
+	custom_tooltip = found_empire_of_hindustan_decision_effects_de_jure_tt
+	hidden_effect = {
+		if = { # Let's see if you have ultimo and save that if so
+			limit = {
+				has_realm_law = single_heir_succession_law_youngest
+			}
+			save_scope_as = set_ultimo_temp_scope
+		}
+	}
+	if = {
+		limit = { has_dlc_feature = admin_gov }
+		convert_to_administrative_from_feudalism_effect = { GOVERNMENT_TO_ADOPT = flag:administrative }
+	}
+	hidden_effect = {
+		if = { # If you had ultimo, you get to keep it. Otherwise, you get primo for free.
+			limit = {
+				exists = scope:set_ultimo_temp_scope
+			}
+			add_realm_law = single_heir_succession_law_youngest
+		}
+		else = {
+			add_realm_law = single_heir_succession_law
+		}
+	}
+	add_legitimacy_effect = { LEGITIMACY = massive_legitimacy_gain }
+	dynasty ?= { add_dynasty_prestige = massive_dynasty_prestige_value }
+}

--- a/common/scripted_effects/10_dlc_tgp_japan_scripted_effects.txt
+++ b/common/scripted_effects/10_dlc_tgp_japan_scripted_effects.txt
@@ -1,0 +1,4116 @@
+﻿japan_establish_house_fief_effect = {
+	save_scope_as = house_fiefer
+	save_scope_as = new_head
+	# Dynasty
+	if = {
+		limit = { tgp_japan_cadet_creates_dynasty_trigger = yes }
+		if = {
+			limit = { exists = var:new_japanese_house_name }
+			create_dynasty = {
+				name = {
+					first_valid = {
+						triggered_desc = {
+							trigger = { scope:new_head.var:new_japanese_house_name ?= flag:japanese_house_random_barony }
+							desc = japanese_house_random_barony
+						}
+						triggered_desc = {
+							trigger = { scope:new_head.var:new_japanese_house_name ?= flag:japanese_house_primary_county }
+							desc = japanese_house_primary_county
+						}
+						triggered_desc = {
+							trigger = { scope:new_head.var:new_japanese_house_name ?= flag:japanese_house_domicile_barony }
+							desc = japanese_house_domicile_barony
+						}
+						triggered_desc = {
+							trigger = { scope:new_head.var:new_japanese_house_name ?= flag:japanese_house_domicile_county }
+							desc = japanese_house_domicile_county
+						}
+						triggered_desc = {
+							trigger = { scope:new_head.var:new_japanese_house_name ?= flag:japanese_house_first_name }
+							desc = japanese_house_first_name
+						}
+						triggered_desc = {
+							trigger = { scope:new_head.var:new_japanese_house_name ?= flag:custom }
+							desc = japanese_house_name_custom
+						}
+						desc = japanese_house_name_flag
+					}
+				}
+				save_scope_as = new_dynasty
+			}
+		}
+		else = {
+			create_dynasty = { save_scope_as = new_dynasty }
+		}
+		house = {
+			set_house_name = japanese_dynasty_name
+			save_scope_as = new_house
+		}
+	}
+	# House
+	else_if = {
+		limit = { is_house_head = no }
+		if = {
+			limit = { exists = var:new_japanese_house_name }
+			found_cadet_house_decision_effect = {
+				CHARACTER = root
+				PRESTIGE = 0
+			}
+			house = { save_scope_as = new_house }
+		}
+		else = {
+			create_cadet_branch = { save_scope_as = new_house }
+		}
+	}
+	# Government
+	change_government = japan_feudal_government
+	# Old Dynasty
+	if = {
+		limit = { exists = scope:new_house }
+		# Rename old NF title
+		if = {
+			limit = {
+				scope:old_head ?= this
+				exists = scope:old_nf_title
+			}
+			#scope:old_nf_title = { set_title_name_dynamic = japanese_noble_family_name }
+		}
+		else = {
+			create_noble_family_effect = { GOVERNMENT_GIVER = this }
+			scope:new_title = {
+				#set_title_name_dynamic = japanese_noble_family_name
+				set_coa = scope:new_house
+			}
+		}
+		# Upset old Clan Head
+		scope:old_head ?= {
+			if = {
+				limit = { is_ai = yes }
+				add_opinion = {
+					modifier = established_house_fief_old_clan_head_opinion
+					target = root
+				}
+			}
+			trigger_event = tgp_japan_decision.9005
+		}
+	}
+	# Crime to Regent
+	top_liege ?= {
+		if = {
+			limit = {
+				scope:new_head = {
+					is_landed = yes
+					NOR = { 
+						var:petition_liege_house_fief_allowed_flag ?= scope:new_head.top_liege
+						top_liege = {
+							government_has_flag = government_is_japan_feudal
+						}
+					}
+				}
+			}
+			show_as_tooltip = {
+				add_opinion = {
+					modifier = established_house_fief_regent_crime
+					target = scope:new_head
+				}
+			}
+			hidden_effect = {
+				send_interface_message = {
+					type = event_toast_effect_bad
+					title = tgp_japan_establish_house_fief_kampaku_toast
+					left_icon = scope:new_head
+					right_icon = scope:new_head.primary_title
+					show_as_tooltip = {
+						scope:new_head = { change_government = japan_feudal_government }
+					}
+					add_opinion = {
+						modifier = established_house_fief_regent_crime
+						target = scope:new_head
+					}
+				}
+			}
+		}
+	}
+	create_character_memory = { type = establish_house_fief_memory }
+	ordered_memory = {
+		memory_type = establish_house_fief_memory
+		order_by = memory_creation_date
+		set_variable = {
+			name = title
+			value = root.primary_title
+		}
+	}
+	add_achievement_flag_effect = { FLAG = achievement_a_house_of_my_own_flag }
+}
+
+set_house_of_all_descendants_effect = {
+	if = {
+		limit = { any_child = { count >= 1 } }
+		every_child = { # Children
+			limit = { house ?= $OLD_HOUSE$ }
+			set_house = $NEW_HOUSE$
+			every_child = { # Grandchildren
+				limit = { house ?= $OLD_HOUSE$ }
+				set_house = $NEW_HOUSE$
+				every_child = { # Great-grandchildren
+					limit = { house ?= $OLD_HOUSE$ }
+					set_house = $NEW_HOUSE$
+					every_child = { # Great-grandchildren
+						limit = { house ?= $OLD_HOUSE$ }
+						set_house = $NEW_HOUSE$
+					}
+				}
+			}
+		}
+	}
+}
+
+japan_set_house_effect = {
+	house = { save_scope_as = old_house }
+	$NEW_HOUSE$ = { save_scope_as = new_house }
+	set_house = scope:new_house
+	custom_tooltip = {
+		text = tgp_japan_establish_house_fief_direct_descendents_effect
+		if = {
+			limit = { exists = $NEW_HOUSE$ }
+			set_house_of_all_descendants_effect = {
+				OLD_HOUSE = scope:old_house
+				NEW_HOUSE = scope:new_house
+			}
+		}
+	}
+}
+
+japan_dynasty_tracker_setup_effect = {
+	# FUJIWARA
+	dynasty:japanese_fujiwara ?= { add_to_list = fujiwara_list }
+	dynasty:japanese_fujiwara_oshu ?= { add_to_list = fujiwara_list }
+	every_in_list = {
+		list = fujiwara_list
+		set_variable = { name = fujiwara_flag }
+	}
+	# MINAMOTO
+	dynasty:japanese_minamoto_daigo ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_kazan ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_koko ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_gosanjo ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_montoku ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_murakami ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_ninmyo ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_saga ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_sanjo ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_seiwa ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_uda ?= { add_to_list = minamoto_list }
+	dynasty:japanese_minamoto_yozei ?= { add_to_list = minamoto_list }
+	every_in_list = {
+		list = minamoto_list
+		set_variable = { name = minamoto_flag }
+		#dynasty_founder.house ?= { set_house_name = "dynn_Minamoto" } # For easier parsing of house names
+	}
+	# TAIRA
+	dynasty:japanese_taira_kanmu ?= { add_to_list = taira_list }
+	dynasty:japanese_taira_koko ?= { add_to_list = taira_list }
+	dynasty:japanese_taira_montoku ?= { add_to_list = taira_list }
+	dynasty:japanese_taira_ninmyo ?= { add_to_list = taira_list }
+	every_in_list = {
+		list = taira_list
+		set_variable = { name = taira_flag }
+		#dynasty_founder.house ?= { set_house_name = "dynn_Taira" } # For easier parsing of house names
+	}
+}
+
+fill_external_japanese_manor_building_effect = {
+	switch = {
+		trigger = has_domicile_building_or_higher
+		japanese_manor_main_05 = {
+			while = {
+				limit = { free_external_domicile_building_slots >= 1 }
+				add_random_external_estate_building = yes
+			}
+		}
+		japanese_manor_main_04 = {
+			while = {
+				limit = { free_external_domicile_building_slots >= 2 }
+				add_random_external_japanese_manor_building = yes
+			}
+		}
+		japanese_manor_main_03 = {
+			while = {
+				limit = { free_external_domicile_building_slots >= 3 }
+				add_random_external_japanese_manor_building = yes
+			}
+		}
+		japanese_manor_main_02 = {
+			while = {
+				limit = { free_external_domicile_building_slots >= 4 }
+				add_random_external_japanese_manor_building = yes
+			}
+		}
+		japanese_manor_main_01 = {
+			while = {
+				limit = { free_external_domicile_building_slots >= 5 }
+				add_random_external_japanese_manor_building = yes
+			}
+		}
+	}
+}
+
+add_random_external_japanese_manor_building = {
+	if = {
+		limit = { free_external_domicile_building_slots >= 1 }
+		random_list = {
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_fields_01 }
+				}
+				add_domicile_building = japanese_fields_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_fields_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_fields_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_shrine_01 }
+					owner.house = { has_house_aspiration_parameter = unlocks_japanese_manor_shrine }
+				}
+				add_domicile_building = japanese_shrine_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_shrine_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_shrine_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_brewery_01 }
+					owner.house = { has_house_aspiration_parameter = unlocks_japanese_manor_brewery }
+				}
+				add_domicile_building = japanese_brewery_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_brewery_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_brewery_02
+				}
+			}
+			10 = {
+				trigger = {
+					owner = { government_has_flag = government_is_administrative }
+					NOT = { has_domicile_building_or_higher = japanese_archive_01 }
+					owner.house = { has_house_aspiration_parameter = unlocks_japanese_manor_archive }
+				}
+				add_domicile_building = japanese_archive_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_archive_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_archive_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_armory_01 }
+					owner.house = { has_house_aspiration_parameter = unlocks_japanese_manor_armory }
+				}
+				add_domicile_building = japanese_armory_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_armory_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_armory_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_watch_house_01 }
+					owner.house = { has_house_aspiration_parameter = unlocks_japanese_manor_watch_house }
+				}
+				add_domicile_building = japanese_watch_house_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_watch_house_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_watch_house_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_horse_pastures_01 }
+				}
+				add_domicile_building = japanese_horse_pastures_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_horse_pastures_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_horse_pastures_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_tea_plantation_01 }
+				}
+				add_domicile_building = japanese_tea_plantation_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_tea_plantation_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_tea_plantation_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_stables_01 }
+				}
+				add_domicile_building = japanese_stables_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_stables_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_stables_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_workshop_01 }
+				}
+				add_domicile_building = japanese_workshop_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_workshop_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_workshop_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_tea_house_01 }
+					owner.house = { has_house_aspiration_parameter = unlocks_japanese_manor_tea_house }
+				}
+				add_domicile_building = japanese_tea_house_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_tea_house_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_tea_house_02
+				}
+			}
+			10 = {
+				trigger = {
+					NOT = { has_domicile_building_or_higher = japanese_garden_01 }
+				}
+				add_domicile_building = japanese_garden_01
+				if = {
+					limit = {
+						has_domicile_building_or_higher = japanese_garden_01
+						has_domicile_building_or_higher = japanese_manor_main_03
+					}
+					add_domicile_building = japanese_garden_02
+				}
+			}
+		}
+	}
+}
+
+add_random_internal_japanese_manor_building = {
+	random_list = {
+		10 = {
+			trigger = {
+				NOT = { has_domicile_building_or_higher = japanese_main_tax_collectors_01 }
+				domicile_building_has_free_internal_slot = japanese_manor_main_01
+			}
+			add_domicile_building = japanese_main_tax_collectors_01
+			if = {
+				limit = { has_domicile_building = japanese_manor_main_03 }
+				add_domicile_building = japanese_main_tax_collectors_02
+			}
+		}
+		10 = {
+			trigger = {
+				NOT = { has_domicile_building_or_higher = japanese_main_carpenter_01 }
+				domicile_building_has_free_internal_slot = japanese_manor_main_01
+			}
+			add_domicile_building = japanese_main_carpenter_01
+			if = {
+				limit = { has_domicile_building = japanese_manor_main_03 }
+				add_domicile_building = japanese_main_carpenter_02
+			}
+		}
+		10 = {
+			trigger = {
+				NOT = { has_domicile_building_or_higher = sarugaku_stage_01 }
+				domicile_building_has_free_internal_slot = japanese_manor_main_01
+			}
+			add_domicile_building = sarugaku_stage_01
+			if = {
+				limit = { has_domicile_building = japanese_manor_main_03 }
+				add_domicile_building = sarugaku_stage_02
+			}
+		}
+		10 = {
+			trigger = {
+				NOT = { has_domicile_building_or_higher = japanese_manor_office_01 }
+				domicile_building_has_free_internal_slot = japanese_manor_main_01
+			}
+			add_domicile_building = japanese_manor_office_01
+			if = {
+				limit = { has_domicile_building = japanese_manor_main_03 }
+				add_domicile_building = japanese_manor_office_02
+			}
+		}
+		10 = {
+			trigger = {
+				NOT = { has_domicile_building_or_higher = japanese_manor_servants_quarters_01 }
+				domicile_building_has_free_internal_slot = japanese_manor_main_01
+			}
+			add_domicile_building = japanese_manor_servants_quarters_01
+			if = {
+				limit = { has_domicile_building = japanese_manor_main_03 }
+				add_domicile_building = japanese_manor_servants_quarters_02
+			}
+		}
+		10 = {
+			trigger = {
+				NOT = { has_domicile_building_or_higher = japanese_manor_library_confucian_01 }
+				domicile_building_has_free_internal_slot = japanese_manor_main_01
+			}
+			add_domicile_building = japanese_manor_library_confucian_01
+			if = {
+				limit = { has_domicile_building = japanese_manor_main_03 }
+				add_domicile_building = japanese_manor_library_confucian_02
+			}
+		}
+	}
+}
+
+japan_clear_flavour_flags_effect = {
+	remove_global_variable = shogunate_established
+	remove_global_variable = tenno_restored
+	remove_character_flag = shogun_flag
+	remove_character_flag = ceremonial_liege_flag
+	remove_character_flag = joko_flag
+}
+
+japanese_become_shogun_reward_effect = {
+	# Setup
+	japan_clear_flavour_flags_effect = yes
+	set_global_variable = {
+		name = shogunate_established
+		value = yes
+	}
+	add_character_flag = shogun_flag
+
+	# Rewards
+	if = {
+		limit = { has_dlc_feature = legends }
+		create_legend_seed = {
+			type = legitimizing
+			quality = illustrious
+			chronicle = great_deed_dynasty
+			properties = {
+				dynasty = root.dynasty
+				founder = root
+				title = primary_title
+			}
+		}
+	}
+	add_dread = massive_dread_gain
+	add_legitimacy = monumental_legitimacy_gain
+	add_realm_law = japanese_bureaucracy_1
+	dynasty = { add_dynasty_prestige = monumental_dynasty_prestige_gain }
+	culture = {
+		if = {
+			limit = { has_cultural_tradition = tradition_tgp_imperial_peace }
+			custom_tooltip = {
+				text = tradition_tgp_bushido_tt
+				remove_culture_tradition = tradition_tgp_imperial_peace
+				add_culture_tradition = tradition_tgp_bushido
+			}
+		}
+		else = { custom_tooltip = unlocks_bushido_tradition_tooltip }
+	}
+	every_vassal = {
+		custom = every_japan_admin_vassal_custom_bullet
+		limit = {
+			government_has_flag = government_is_japan_administrative
+		}
+		show_as_tooltip = { change_government = japan_feudal_government }
+	}
+}
+
+restore_ceremonial_liege_faction_combined_effect = {
+	top_liege = {
+		save_temporary_scope_as = regent_temp
+		primary_title = {
+			save_temporary_scope_as = realm_temp
+			var:administrative_ui_special_title.holder ?= { save_temporary_scope_as = ceremonial_liege_temp }
+		}
+	}
+	if = {
+		limit = { scope:regent_temp != scope:ceremonial_liege_temp }
+		faction_demand_regent_transfer_effect = {
+			NEW_REGENT = scope:ceremonial_liege_temp
+			REASON = faction_demand
+		}
+	}
+	# GLOBAL VAR
+	japan_clear_flavour_flags_effect = yes
+	set_global_variable = {
+		name = tenno_restored
+		value = yes
+	}
+	show_as_tooltip = { restore_ceremonial_liege_faction_reward_effect = yes }
+	# Event for Ceremonial Liege
+	scope:ceremonial_liege_temp = { trigger_event = tgp_japan_decision.9301 }
+}
+
+restore_ceremonial_liege_faction_reward_effect = {
+	top_liege = {
+		save_temporary_scope_as = regent_temp
+		primary_title = {
+			save_temporary_scope_as = realm_temp
+			var:administrative_ui_special_title.holder = { save_temporary_scope_as = ceremonial_liege_temp }
+		}
+	}
+	scope:ceremonial_liege_temp = {
+		custom_tooltip = tenno_duchy_creation_tt
+		if = {
+			limit = { has_legitimacy = yes }
+			add_legitimacy = major_legitimacy_gain
+		}
+		else = {
+			show_as_tooltip = { add_legitimacy = major_legitimacy_gain }
+		}
+		if = {
+			limit = {
+				NOT = { has_realm_law = single_heir_succession_law }
+			}
+			add_realm_law_skip_effects = single_heir_succession_law
+		}
+	}
+}
+
+restore_ceremonial_liege_faction_titles_effect = {
+	top_liege = {
+		save_temporary_scope_as = regent_temp
+		primary_title = {
+			save_temporary_scope_as = realm_temp
+			var:administrative_ui_special_title.holder = { save_temporary_scope_as = ceremonial_liege_temp }
+		}
+	}
+	create_title_and_vassal_change = {
+		type = faction_demand
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	scope:realm_temp = { # Give top liege title to the Emperor
+		change_title_holder_include_vassals = {
+			holder = scope:ceremonial_liege_temp
+			change = scope:title_change
+		}
+		holder ?= {
+			every_held_title = {
+				limit = {
+					tier > tier_barony
+					is_landless_type_title = no
+				}
+				add_to_list = target_titles
+			}
+		}
+	}
+	hidden_effect = {
+		every_in_list = {
+			list = target_titles
+			change_title_holder_include_vassals = {
+				holder = scope:ceremonial_liege_temp
+				change = scope:title_change
+			}
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+}
+
+assign_japanese_house_name_options_effect = {
+	random_list = {
+		### AKI
+		### AKITA (NUSHIRO)
+		1 = { # OKAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_kawa TITLE = title:c_nushiro } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_nushiro }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_kawa }
+		}
+		1 = { # YURI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yuri TITLE = title:c_nushiro } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_nushiro }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yuri }
+		}
+		### AWA
+		1 = { # MIYOSHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Miyoshi TITLE = title:c_awa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_awa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Miyoshi }
+		}
+		1 = { # TAGUCHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Taguchi TITLE = title:c_awa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_awa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Taguchi }
+		}
+		### BINGO
+		1 = { # OTA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_ta TITLE = title:c_bingo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bingo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_ta }
+		}
+		### BITCHU
+		1 = { # SENOO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Seno_o TITLE = title:c_bitchu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bitchu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Seno_o }
+		}
+		### BIZEN
+		1 = { # NAMBA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Namba TITLE = title:c_bizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Namba }
+		}
+		### BUNGO
+		1 = { # ANAMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Anami TITLE = title:c_bungo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bungo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Anami }
+		}
+		1 = { # HONDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Honda TITLE = title:c_bungo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bungo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Honda }
+		}
+		1 = { # MITAI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mitai TITLE = title:c_bungo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bungo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mitai }
+		}
+		1 = { # OGATA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ogata TITLE = title:c_bungo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bungo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ogata }
+		}
+		1 = { # ONO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_no TITLE = title:c_bungo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bungo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_no }
+		}
+		1 = { # SHIGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shiga TITLE = title:c_bungo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bungo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shiga }
+		}
+		1 = { # WASADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Wasada TITLE = title:c_bungo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bungo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Wasada }
+		}
+		1 = { # USUKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Usuki TITLE = title:c_bungo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_bungo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Usuki }
+		}
+		### BUZEN
+		1 = { # YAMAGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yamaga TITLE = title:c_buzen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_buzen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yamaga }
+		}
+		### CHIKUGO
+		1 = { # KAMACHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kamachi TITLE = title:c_chikugo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_chikugo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kamachi }
+		}
+		### CHIKUZEN
+		1 = { # AKIZUKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Akizuki TITLE = title:c_chikugo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_chikugo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Akizuki }
+		}
+		1 = { # HARADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Harada TITLE = title:c_chikugo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_chikugo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Harada }
+		}
+		### DEWA (TOKISARA)
+		1 = { # SAGAE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sagae TITLE = title:c_tokisara } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tokisara }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sagae }
+		}
+		### ECHIGO
+		1 = { # HANJO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kanazu TITLE = title:c_echigo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kanazu }
+		}
+		1 = { # IROBE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Irobe TITLE = title:c_echigo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Irobe }
+		}
+		1 = { # KAJI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kaji TITLE = title:c_echigo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kaji }
+		}
+		1 = { # KANAZU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kanazu TITLE = title:c_echigo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kanazu }
+		}
+		1 = { # NAKAJO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_NakajO_ TITLE = title:c_echigo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_NakajO_ }
+		}
+		1 = { # OGUNI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Oguni TITLE = title:c_echigo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Oguni }
+		}
+		1 = { # SADO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sado TITLE = title:c_echigo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sado }
+		}
+		1 = { # YASUDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yasuda TITLE = title:c_echigo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yasuda }
+		}
+		### ECHIZEN
+		1 = { # AKATSUKA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Akatsuka TITLE = title:c_echizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Akatsuka }
+		}
+		1 = { # ICHIJI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ichiji TITLE = title:c_echizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ichiji }
+		}
+		1 = { # MIKATA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mikata TITLE = title:c_echizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mikata }
+		}
+		1 = { # ODA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Oda TITLE = title:c_echizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Oda }
+		}
+		1 = { # NANJO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_NanjO_ TITLE = title:c_echizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_NanjO_ }
+		}
+		1 = { # TSUTSUMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tsutsumi TITLE = title:c_echizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_echizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tsutsumi }
+		}
+		### ETCHU
+		### HARIMA
+		1 = { # AKAMATSU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Akamatsu TITLE = title:c_harima } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_harima }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Akamatsu }
+		}
+		1 = { # BESSHO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Bessho TITLE = title:c_harima } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_harima }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Bessho }
+		}
+		1 = { # URAKAMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Urakami TITLE = title:c_harima } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_harima }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Urakami }
+		}
+		### HIDA
+		1 = { # USHIMARU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ushimaru TITLE = title:c_hida } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hida }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ushimaru }
+		}
+		### HIGO
+		1 = { # ASO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Aso TITLE = title:c_higo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_higo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Aso }
+		}
+		1 = { # KIKUCHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kikuchi TITLE = title:c_higo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_higo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kikuchi }
+		}
+		1 = { # KUMABE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kumabe TITLE = title:c_higo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_higo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kumabe }
+		}
+		1 = { # TAKEZAKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Takezaki TITLE = title:c_higo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_higo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Takezaki }
+		}
+		### HITACHI
+		1 = { # AKASU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Akasu TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Akasu }
+		}
+		1 = { # ASABA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Asaba TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Asaba }
+		}
+		1 = { # HATTA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hatta TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hatta }
+		}
+		1 = { # ISA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Isa TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Isa }
+		}
+		1 = { # KATAOKA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kataoka TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kataoka }
+		}
+		1 = { # MIMURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mimura TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mimura }
+		}
+		1 = { # NAMEKATA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Namekata TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Namekata }
+		}
+		1 = { # NEMOTO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nemoto TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nemoto }
+		}
+		1 = { # NISSAI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nissai TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nissai }
+		}
+		1 = { # ONOZAKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Onozaki TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Onozaki }
+		}
+		1 = { # SATAKE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Satake TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Satake }
+		}
+		1 = { # SHIDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shida TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shida }
+		}
+		1 = { # TAKEDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Takeda TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Takeda }
+		}
+		1 = { # TOMURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tomura TITLE = title:c_hitachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tomura }
+		}
+		### HIZEN
+		1 = { # MATSURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Matsura TITLE = title:c_hizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Matsura }
+		}
+		1 = { # YASUTOMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yasutomi TITLE = title:c_hizen } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_hizen }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yasutomi }
+		}
+		### HOKI
+		### HYUGA
+		### INABA
+		1 = { # HIKIDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hikida TITLE = title:c_inaba } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_inaba }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hikida }
+		}
+		1 = { # SAJI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Saji TITLE = title:c_inaba } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_inaba }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Saji }
+		}
+		### ISAWA
+		1 = { # SHIBA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shiba TITLE = title:c_isawa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_isawa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shiba }
+		}
+		### ISE
+		1 = { # HATTORI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hattori TITLE = title:c_yamato } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_yamato }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hattori }
+		}
+		1 = { # IGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Iga TITLE = title:c_ise } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_ise }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Iga }
+		}
+		1 = { # ITO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_ItO_ TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_ItO_ }
+		}
+		1 = { # KANBE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kanbe TITLE = title:c_ise } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_ise }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kanbe }
+		}
+		1 = { # KUKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kuki TITLE = title:c_ise } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_ise }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kuki }
+		}
+		1 = { # SEKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Seki TITLE = title:c_ise } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_ise }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Seki }
+		}
+		1 = { # SHIMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shima TITLE = title:c_ise } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_ise }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shima }
+		}
+		### IWAKI
+		1 = { # TAMURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tamura TITLE = title:c_iwaki } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iwaki }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tamura }
+		}
+		1 = { # WATARI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Watari TITLE = title:c_iwaki } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iwaki }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Watari }
+		}
+		### IWASHIRO
+		1 = { # DATE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Date TITLE = title:c_iwase } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iwase }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Date }
+		}
+		1 = { # SUGIME
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sugime TITLE = title:c_iwase } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iwase }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sugime }
+		}
+		### IWASE
+		1 = { # ASAKA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Asaka TITLE = title:c_iwase } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iwase }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Asaka }
+		}
+		### IYO
+		1 = { # KONO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_KO_no TITLE = title:c_iyo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iyo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_KO_no }
+		}
+		### IZU
+		1 = { # AKAZAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Akazawa TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Akazawa }
+		}
+		1 = { # AMANO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Amano TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Amano }
+		}
+		1 = { # EMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ema TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ema }
+		}
+		1 = { # HOJO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_HO_jO_ TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_HO_jO_ }
+		}
+		1 = { # ITO 2
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_ItO__2 TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_ItO__2 }
+		}
+		1 = { # KANO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kano TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kano }
+		}
+		1 = { # KAWAZU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kawazu TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kawazu }
+		}
+		1 = { # OMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_mi TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_mi }
+		}
+		1 = { # TASHIRO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tashiro TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tashiro }
+		}
+		1 = { # USAMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Usami TITLE = title:c_izu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Usami }
+		}
+		### IWAMI
+		1 = { # MASUDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Masuda TITLE = title:c_iwami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iwami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Masuda }
+		}
+		### IZUMO
+		1 = { # MISAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Misawa TITLE = title:c_izumo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izumo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Misawa }
+		}
+		1 = { # MITOYA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mitoya TITLE = title:c_izumo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izumo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mitoya }
+		}
+		1 = { # NOGI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nogi TITLE = title:c_izumo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izumo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nogi }
+		}
+		### KAGA
+		1 = { # KUMASAKA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kumasaka TITLE = title:c_kaga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kaga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kumasaka }
+		}
+		1 = { # TOGASHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Togashi TITLE = title:c_kaga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kaga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Togashi }
+		}
+		### KAI
+		1 = { # AKIYAMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Akiyama TITLE = title:c_kai } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kai }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Akiyama }
+		}
+		1 = { # ASARI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Asari TITLE = title:c_kai } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kai }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Asari }
+		}
+		1 = { # ICHIJO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_IchijO_ TITLE = title:c_kai } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kai }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_IchijO_ }
+		}
+		1 = { # ITSUMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Henmi TITLE = title:c_kai } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kai }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Henmi }
+		}
+		1 = { # KAGAMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kagami TITLE = title:c_kai } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kai }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kagami }
+		}
+		1 = { # NANBU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nanbu TITLE = title:c_kai } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kai }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nanbu }
+		}
+		1 = { # OGASAWARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ogasawara TITLE = title:c_kai } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kai }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ogasawara }
+		}
+		### KAWACHI
+		1 = { # IZUMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Izumi TITLE = title:c_kawachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kawachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Izumi }
+		}
+		1 = { # TAKAYASU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Takayasu TITLE = title:c_kawachi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kawachi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Takayasu }
+		}
+		### KAZUSA
+		1 = { # ANZAI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Anzai TITLE = title:c_kazusa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kazusa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Anzai }
+		}
+		1 = { # HANYU 2
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_HanyU__2 TITLE = title:c_kazusa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kazusa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_HanyU__2 }
+		}
+		1 = { # INTO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_IntO_ TITLE = title:c_kazusa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kazusa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_IntO_ }
+		}
+		1 = { # KANEDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kaneda TITLE = title:c_kazusa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kazusa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kaneda }
+		}
+		1 = { # NAGASA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nagasa TITLE = title:c_awa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_awa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nagasa }
+		}
+		1 = { # OBU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Obu TITLE = title:c_kazusa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kazusa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Obu }
+		}
+		1 = { # SAKUMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sakuma TITLE = title:c_kazusa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kazusa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sakuma }
+		}
+		### KII
+		1 = { # AKATA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Akata TITLE = title:c_kii } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Akata }
+		}
+		1 = { # ITOGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Itoga TITLE = title:c_kii } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Itoga }
+		}
+		1 = { # HOZUMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hozumi TITLE = title:c_kii } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hozumi }
+		}
+		1 = { # SHINGU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_ShingU_ TITLE = title:c_kii } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_ShingU_ }
+		}
+		1 = { # SUZUKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Suzuki TITLE = title:c_kii } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Suzuki }
+		}
+		1 = { # UI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ui TITLE = title:c_kii } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ui }
+		}
+		1 = { # YAMAMOTO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yamamoto TITLE = title:c_kii } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yamamoto }
+		}
+		1 = { # YUASA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yuasa TITLE = title:c_kii } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yuasa }
+		}
+		### KOZUKE
+		1 = { # AKAHORI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Akahori TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Akahori }
+		}
+		1 = { # AOYAMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Aoyama TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Aoyama }
+		}
+		1 = { # IWAMATSU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Iwamatsu TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Iwamatsu }
+		}
+		1 = { # JINBO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Jinbo TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Jinbo }
+		}
+		1 = { # MOMONOI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Momonoi TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Momonoi }
+		}
+		1 = { # NITTA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nitta TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nitta }
+		}
+		1 = { # OBATA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Obata TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Obata }
+		}
+		1 = { # SATOMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Satomi TITLE = title:c_mino } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mino }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Satomi }
+		}
+		1 = { # TOKUGAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tokugawa TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tokugawa }
+		}
+		1 = { # YAMANA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yamana TITLE = title:c_kozuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_kozuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yamana }
+		}
+		### MIKAWA
+		1 = { # ASUKE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Asuke TITLE = title:c_mikawa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mikawa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Asuke }
+		}
+		1 = { # HOSOKAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hosokawa TITLE = title:c_mikawa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mikawa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hosokawa }
+		}
+		1 = { # IMAGAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Imagawa TITLE = title:c_mikawa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mikawa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Imagawa }
+		}
+		1 = { # ISSHIKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Isshiki TITLE = title:c_higo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_higo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Isshiki }
+		}
+		1 = { # KIRA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kira TITLE = title:c_mikawa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mikawa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kira }
+		}
+		1 = { # MAKINO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Makino TITLE = title:c_mikawa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mikawa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Makino }
+		}
+		1 = { # MATSUDAIRA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Matsudaira TITLE = title:c_mikawa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mikawa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Matsudaira }
+		}
+		1 = { # NIKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Niki TITLE = title:c_mikawa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mikawa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Niki }
+		}
+		### MIMASAKA
+		1 = { # KATSUTA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Katsuta TITLE = title:c_mimasaka } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mimasaka }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Katsuta }
+		}
+		1 = { # SHINMEN
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shinmen TITLE = title:c_mimasaka } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mimasaka }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shinmen }
+		}
+		### MINO
+		1 = { # ASANO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Asano TITLE = title:c_mino } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mino }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Asano }
+		}
+		1 = { # FUKUSHIMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Fukushima TITLE = title:c_mino } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mino }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Fukushima }
+		}
+		1 = { # IKEDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ikeda TITLE = title:c_mino } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mino }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ikeda }
+		}
+		1 = { # KIDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kida TITLE = title:c_mino } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mino }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kida }
+		}
+		1 = { # TOKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Toki_JP TITLE = title:c_mino } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mino }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Toki_JP }
+		}
+		1 = { # TOYOYAMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Toyoyama TITLE = title:c_mino } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mino }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Toyoyama }
+		}
+		### MUSASHI
+		1 = { # ADACHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Adachi TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Adachi }
+		}
+		1 = { # ASAMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Asami TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Asami }
+		}
+		1 = { # CHICHIBU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Chichibu TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Chichibu }
+		}
+		1 = { # INAGE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Inage TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Inage }
+		}
+		1 = { # INOMATA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Inomata TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Inomata }
+		}
+		1 = { # KANEKO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kaneko TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kaneko }
+		}
+		1 = { # KASAI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kasai TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kasai }
+		}
+		1 = { # KASUKABE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kasukabe TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kasukabe }
+		}
+		1 = { # KAWAGOE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kawagoe TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kawagoe }
+		}
+		1 = { # KAWASAKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kawasaki TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kawasaki }
+		}
+		1 = { # KUMAGAI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kumagai TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kumagai }
+		}
+		1 = { # HATAKEYAMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hatakeyama TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hatakeyama }
+		}
+		1 = { # HIKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hiki TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hiki }
+		}
+		1 = { # HIRUKAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hirukawa TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hirukawa }
+		}
+		1 = { # INAZAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Inazawa TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Inazawa }
+		}
+		1 = { # MOKUSAI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mokusai TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mokusai }
+		}
+		1 = { # MURAYAMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Murayama TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Murayama }
+		}
+		1 = { # NARITA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Narita TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Narita }
+		}
+		1 = { # NOMOTO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nomoto TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nomoto }
+		}
+		1 = { # NOYO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Noyo TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Noyo }
+		}
+		1 = { # OI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_i TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_i }
+		}
+		1 = { # OYAMADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Oyamada TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Oyamada }
+		}
+		1 = { # TOSHIMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Toshima TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Toshima }
+		}
+		1 = { # SHINAGAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shinagawa TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shinagawa }
+		}
+		1 = { # USHIODA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ushioda TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ushioda }
+		}
+		1 = { # YOKOYAMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yokoyama TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yokoyama }
+		}
+		1 = { # YOMODA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yomoda TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yomoda }
+		}
+		### NAGATO
+		### NOTO
+		1 = { # TOKUDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tokuda TITLE = title:c_noto } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_noto }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tokuda }
+		}
+		### OKI
+		### OMI
+		1 = { # AMAGO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Amago TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Amago }
+		}
+		1 = { # AMENOMORI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Amenomori TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Amenomori }
+		}
+		1 = { # HAYAMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hayami TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hayami }
+		}
+		1 = { # IBA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Iba_JP TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Iba_JP }
+		}
+		1 = { # KUTSUKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kutsuki TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kutsuki }
+		}
+		1 = { # MIKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Miki TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Miki }
+		}
+		1 = { # OHARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_hara TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_hara }
+		}
+		1 = { # SASAKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sasaki TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sasaki }
+		}
+		1 = { # TANAKA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tanaka TITLE = title:c_omi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tanaka }
+		}
+		### OSUMI
+		1 = { # KIMOTSUKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kimotsuki TITLE = title:c_osumi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_osumi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kimotsuki }
+		}
+		1 = { # KITAHARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kitahara TITLE = title:c_osumi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_osumi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kitahara }
+		}
+		### OWARI
+		1 = { # HACHISUKA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hachisuka TITLE = title:c_owari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hachisuka }
+		}
+		1 = { # HOTTA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hotta TITLE = title:c_owari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hotta }
+		}
+		1 = { # NIWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Niwa TITLE = title:c_owari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Niwa }
+		}
+		1 = { # OGAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ogawa TITLE = title:c_owari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ogawa }
+		}
+		1 = { # OKADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Okada TITLE = title:c_owari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Okada }
+		}
+		1 = { # OSADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Osada TITLE = title:c_owari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Osada }
+		}
+		1 = { # YAMADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yamada TITLE = title:c_owari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yamada }
+		}
+		1 = { # YASUDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yasuda TITLE = title:c_owari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yasuda }
+		}
+		### SAGAMI
+		1 = { # AIHARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Aihara TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Aihara }
+		}
+		1 = { # AIKO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_AikO_ TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_AikO_ }
+		}
+		1 = { # ASHINA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ashina_JP TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ashina_JP }
+		}
+		1 = { # DOI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Doi TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Doi }
+		}
+		1 = { # EBINA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ebina TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ebina }
+		}
+		1 = { # HATANO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hatano TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hatano }
+		}
+		1 = { # KAGAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kagawa TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kagawa }
+		}
+		1 = { # KAJIWARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kajiwara TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kajiwara }
+		}
+		1 = { # KOBAYAKAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kobayakawa TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kobayakawa }
+		}
+		1 = { # MATANO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Matano TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Matano }
+		}
+		1 = { # MIURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Miura TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Miura }
+		}
+		1 = { # MORI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mori_JP TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mori_JP }
+		}
+		1 = { # NAGAE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nagae TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nagae }
+		}
+		1 = { # NAGAO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nagao TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nagao }
+		}
+		1 = { # NAKAMURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nakamura TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nakamura }
+		}
+		1 = { # NIKAIDO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nikaido TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nikaido }
+		}
+		1 = { # OBA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_ba TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_ba }
+		}
+		1 = { # OKAZAKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Okazaki TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Okazaki }
+		}
+		1 = { # OTAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_tawa TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_tawa }
+		}
+		1 = { # OTOMO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_tomo TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_tomo }
+		}
+		1 = { # SAWARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sawara TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sawara }
+		}
+		1 = { # SHIBUYA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shibuya TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shibuya }
+		}
+		1 = { # SOGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Soga TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Soga }
+		}
+		1 = { # SUGIMOTO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sugimoto TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sugimoto }
+		}
+		1 = { # TOKIWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tokiwa TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tokiwa }
+		}
+		1 = { # TSUCHIYA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tsuchiya TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tsuchiya }
+		}
+		1 = { # YAMAUCHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yamauchi TITLE = title:c_sagami } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yamauchi }
+		}
+		### SANUKI
+		1 = { # SOGO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_SogO_ TITLE = title:c_sanuki } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sanuki }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_SogO_ }
+		}
+		### SATSUMA
+		1 = { # SHIMAZU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shimazu TITLE = title:c_satsuma } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_satsuma }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shimazu }
+		}
+		1 = { # TOGO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_TO_gO_ TITLE = title:c_satsuma } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_satsuma }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_TO_gO_ }
+		}
+		1 = { # YAMADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yamada TITLE = title:c_satsuma } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_satsuma }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yamada }
+		}
+		### SETTSU
+		1 = { # MINASE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Minase TITLE = title:c_settsu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_settsu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Minase }
+		}
+		1 = { # MIZOKUI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mizokui TITLE = title:c_settsu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_settsu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mizokui }
+		}
+		1 = { # NOSE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nose TITLE = title:c_settsu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_settsu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nose }
+		}
+		1 = { # TADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tada TITLE = title:c_settsu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_settsu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tada }
+		}
+		1 = { # WATANABE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Watanabe TITLE = title:c_settsu } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_settsu }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Watanabe }
+		}
+		### SHINANO
+		1 = { # AIDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Aida TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Aida }
+		}
+		1 = { # ATOBE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Atobe TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Atobe }
+		}
+		1 = { # DEURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Deura TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Deura }
+		}
+		1 = { # HIGUCHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Higuchi TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Higuchi }
+		}
+		1 = { # HOSHINA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hoshina TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hoshina }
+		}
+		1 = { # IIDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Iida TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Iida }
+		}
+		1 = { # IINUMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Iinuma TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Iinuma }
+		}
+		1 = { # IMAI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Imai TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Imai }
+		}
+		1 = { # INA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ina TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ina }
+		}
+		1 = { # INOUE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Inoue TITLE = title:c_musashi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Inoue }
+		}
+		1 = { # KATAGIRI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Katagiri TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Katagiri }
+		}
+		1 = { # KOSAKA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kosaka TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kosaka }
+		}
+		1 = { # KISO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kiso TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kiso }
+		}
+		1 = { # KURITA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kurita TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kurita }
+		}
+		1 = { # MOCHIZUKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mochizuki TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mochizuki }
+		}
+		1 = { # MURAKAMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Murakami TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Murakami }
+		}
+		1 = { # NAKANO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nakano TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nakano }
+		}
+		1 = { # NATSUME
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Natsume TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Natsume }
+		}
+		1 = { # NEZU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nezu TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nezu }
+		}
+		1 = { # NISHINA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nishina TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nishina }
+		}
+		1 = { # ODAGIRI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Odagiri TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Odagiri }
+		}
+		1 = { # SANADA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sanada TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sanada }
+		}
+		1 = { # SHIODA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shioda TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shioda }
+		}
+		1 = { # TOMONO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Tomono TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tomono }
+		}
+		1 = { # UEDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ueda TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ueda }
+		}
+		1 = { # UNNO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Unno TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Unno }
+		}
+		1 = { # YASHIRO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yashiro TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yashiro }
+		}
+		1 = { # YODA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yoda TITLE = title:c_shinano } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yoda }
+		}
+		### SHIMOSA
+		1 = { # CHIBA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Chiba TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Chiba }
+		}
+		1 = { # HARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hara TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hara }
+		}
+		1 = { # KOKUBU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kokubu TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kokubu }
+		}
+		1 = { # OSUGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_suga TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_suga }
+		}
+		1 = { # SHIMOKOBE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_ShimokO_be TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_ShimokO_be }
+		}
+		1 = { # SOMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_SO_ma TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_SO_ma }
+		}
+		1 = { # SOSA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_SO_sa TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_SO_sa }
+		}
+		1 = { # TAKEISHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Takeishi TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Takeishi }
+		}
+		1 = { # TO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_TO_ TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_TO_ }
+		}
+		1 = { # YUKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_YU_ki TITLE = title:c_shimosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_YU_ki }
+		}
+		### SHIMOTSUKE
+		1 = { # ASHIKAGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ashikaga TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ashikaga }
+		}
+		1 = { # HAGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Haga TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Haga }
+		}
+		1 = { # ITAKURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Itakura TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Itakura }
+		}
+		1 = { # NASU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Nasu TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nasu }
+		}
+		1 = { # ONODERA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Onodera TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Onodera }
+		}
+		1 = { # OYAMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Oyama TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Oyama }
+		}
+		1 = { # SANO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sano TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sano }
+		}
+		1 = { # SHIONOYA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shionoya TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shionoya }
+		}
+		1 = { # UJIIE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Uji_ie TITLE = title:c_shimotsuke } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Uji_ie }
+		}
+		### SUO
+		1 = { # MIGATA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Migata TITLE = title:c_suo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Migata }
+		}
+		1 = { # OUCHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_uchi TITLE = title:c_suo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_uchi }
+		}
+		1 = { # TOIDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Toida TITLE = title:c_suo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Toida }
+		}
+		1 = { # WASHIZU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Washizu TITLE = title:c_suo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Washizu }
+		}
+		1 = { # YAMAGUCHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yamaguchi TITLE = title:c_suo } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yamaguchi }
+		}
+		### SURUGA
+		1 = { # ABE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Abe TITLE = title:c_suruga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suruga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Abe }
+		}
+		1 = { # ANO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ano TITLE = title:c_suruga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suruga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ano }
+		}
+		1 = { # IRIE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Irie TITLE = title:c_suruga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suruga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Irie }
+		}
+		1 = { # KAMBARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kambara TITLE = title:c_suruga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suruga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kambara }
+		}
+		1 = { # KIKKAWA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kikkawa TITLE = title:c_suruga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suruga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kikkawa }
+		}
+		1 = { # MAKI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Maki TITLE = title:c_suruga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suruga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Maki }
+		}
+		1 = { # OKABE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Okabe TITLE = title:c_suruga } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_suruga }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Okabe }
+		}
+		### TAGA
+		1 = { # HIZUME
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hizume TITLE = title:c_korehari } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_korehari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hizume }
+		}
+		### TAJIMA
+		1 = { # ASAKURA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Asakura TITLE = title:c_tajima } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tajima }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Asakura }
+		}
+		### TANBA
+		1 = { # ASHIDA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ashida TITLE = title:c_tanba } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tanba }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ashida }
+		}
+		1 = { # OTA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_ta TITLE = title:c_tanba } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tanba }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_ta }
+		}
+		1 = { # UESUGI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Uesugi TITLE = title:c_tanba } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tanba }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Uesugi }
+		}
+		### TOSA
+		1 = { # CHOSOKABE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_ChO_sokabe TITLE = title:c_tosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_ChO_sokabe }
+		}
+		1 = { # HASUIKE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Hasuike TITLE = title:c_tosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hasuike }
+		}
+		1 = { # KOSOKABE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_KO_sokabe TITLE = title:c_tosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_KO_sokabe }
+		}
+		1 = { # SOGABE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sogabe TITLE = title:c_tosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sogabe }
+		}
+		1 = { # YASU
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Yasu TITLE = title:c_tosa } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tosa }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yasu }
+		}
+		### TOTOMI
+		1 = { # HARAISHI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Haraishi TITLE = title:c_totomi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_totomi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Haraishi }
+		}
+		1 = { # II
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ii TITLE = title:c_totomi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_totomi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ii }
+		}
+		1 = { # ISHITANI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ishitani TITLE = title:c_totomi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_totomi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ishitani }
+		}
+		1 = { # SAGARA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Sagara TITLE = title:c_totomi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_totomi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Sagara }
+		}
+		1 = { # TOYODA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Toyoda TITLE = title:c_totomi } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_totomi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Toyoda }
+		}
+		### TSUGARU
+		### TSUSHIMA
+		1 = { # SO
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_SO_ TITLE = title:c_tsushima } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tsushima }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_SO_ }
+		}
+		### UGO
+		### UZEN
+		1 = { # MOGAMI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Mogami TITLE = title:c_tokisara } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tokisara }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Mogami }
+		}
+		1 = { # OZONE
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_zone TITLE = title:c_tokisara } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tokisara }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_zone }
+		}
+		1 = { # SHIRATORI
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Shiratori TITLE = title:c_tokisara } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tokisara }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Shiratori }
+		}
+		### YAMATO
+		1 = { # KASUGA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Kasuga TITLE = title:c_yamato } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_yamato }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kasuga }
+		}
+		1 = { # IKOMA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_Ikoma TITLE = title:c_yamato } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_yamato }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ikoma }
+		}
+		1 = { # OMIYA
+			trigger = { japan_house_name_county_trigger = { FLAG = flag:dynn_O_miya TITLE = title:c_yamato } }
+			japanese_new_house_name_modifiers = { TITLE = title:c_yamato }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_miya }
+		}
+		### OTHER / SHARED
+		1 = { # FURUICHI
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Furuichi TITLE = title:c_kawachi }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Furuichi TITLE = title:c_omi }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Furuichi TITLE = title:c_settsu }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Furuichi TITLE = title:c_yamato }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_kawachi }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			japanese_new_house_name_modifiers = { TITLE = title:c_settsu }
+			japanese_new_house_name_modifiers = { TITLE = title:c_yamato }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Furuichi }
+		}
+		1 = { # HAYASHI
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Hayashi TITLE = title:c_kaga }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Hayashi TITLE = title:c_owari }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_kaga }
+			japanese_new_house_name_modifiers = { TITLE = title:c_owari }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hayashi }
+		}
+		1 = { # HONJO
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Furuichi TITLE = title:c_echigo }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Furuichi TITLE = title:c_musashi }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_echigo }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_HonjO_ }
+		}
+		1 = { # HIRAGA
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Hiraga TITLE = title:c_shinano }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Hiraga TITLE = title:c_tokisara }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_shinano }
+			japanese_new_house_name_modifiers = { TITLE = title:c_tokisara }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Hiraga }
+		}
+		1 = { # ISHIKAWA
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Ishikawa TITLE = title:c_kawachi }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Ishikawa TITLE = title:c_iwaki }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_kawachi }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iwaki }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Ishikawa }
+		}
+		1 = { # KODAMA
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Kodama TITLE = title:c_hoki }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Kodama TITLE = title:c_musashi }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_hoki }
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kodama }
+		}
+		1 = { # NAKAMURA
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Nakamura TITLE = title:c_hitachi }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Nakamura TITLE = title:c_sagami }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Nakamura TITLE = title:c_shimotsuke }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			japanese_new_house_name_modifiers = { TITLE = title:c_shimotsuke }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nakamura }
+		}
+		1 = { # SHINGU
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_ShingU_ TITLE = title:c_kii }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_ShingU_ TITLE = title:c_iwase }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_kii }
+			japanese_new_house_name_modifiers = { TITLE = title:c_iwase }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_ShingU_ }
+		}
+		1 = { # TAKAOKA
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Takaoka TITLE = title:c_hitachi }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Takaoka TITLE = title:c_izumo }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_hitachi }
+			japanese_new_house_name_modifiers = { TITLE = title:c_izumo }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Takaoka }
+		}
+		1 = { # WADA
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Wada TITLE = title:c_kawachi }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Wada TITLE = title:c_sagami }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_kawachi }
+			japanese_new_house_name_modifiers = { TITLE = title:c_sagami }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Wada }
+		}
+		1 = { # YAMAGATA
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Yamagata TITLE = title:c_aki }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Yamagata TITLE = title:c_mino }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_aki }
+			japanese_new_house_name_modifiers = { TITLE = title:c_mino }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yamagata }
+		}
+		1 = { # YOSHIDA
+			trigger = {
+				OR = {
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Yoshida TITLE = title:c_musashi }
+					japan_house_name_county_trigger = { FLAG = flag:dynn_Yoshida TITLE = title:c_omi }
+				}
+			}
+			japanese_new_house_name_modifiers = { TITLE = title:c_musashi }
+			japanese_new_house_name_modifiers = { TITLE = title:c_omi }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Yoshida }
+		}
+		### FUJIWARA
+		3 = { # ANDO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_AndO_ }
+		}
+		3 = { # ENDO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_EndO_ }
+		}
+		3 = { # GOTO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_GotO_ }
+		}
+		3 = { # KATO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_KatO_ }
+		}
+		3 = { # KONDO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_KondO_ }
+		}
+		3 = { # KUDO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_KudO_ }
+		}
+		3 = { # MUTO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_MutO_ }
+		}
+		3 = { # SAITO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_SaitO_ }
+		}
+		3 = { # SATO
+			trigger = { dynasty ?= { exists = var:fujiwara_flag } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_SatO_ }
+		}
+	}
+}
+
+assign_japanese_house_name_options_kyoto_effect = {
+	### YAMASHIRO (KYOTO)
+	random_list = {
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_Awata } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Awata }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_Awataguchi } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Awataguchi }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_GojO_ } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_GojO_ }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_IchijO_ } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_IchijO_ }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_Kitabatake } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Kitabatake }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_Konoe } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Konoe }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_KyO_goku } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_KyO_goku }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_Nakamikado } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Nakamikado }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_NijO_ } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_NijO_ }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_O_inomikado } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_O_inomikado }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_Rokkaku } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Rokkaku }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_RokujO_ } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_RokujO_ }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_SanjO_ } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_SanjO_ }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_ShijO_ } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_ShijO_ }
+		}
+		1 = {
+			trigger = { japan_house_name_trigger = { FLAG = flag:dynn_Tsuchimikado } }
+			add_to_variable_list = { name = japanese_house_names target = flag:dynn_Tsuchimikado }
+		}
+	}
+}
+
+faction_demand_regent_transfer_effect = {
+	top_liege = {
+		save_temporary_scope_as = old_regent_temp
+		primary_title = {
+			save_temporary_scope_as = primary_title_temp
+			title_capital_county = { save_temporary_scope_as = preferred_capital_temp }
+		}
+	}
+	$NEW_REGENT$ = {
+		save_temporary_scope_as = new_regent_temp
+		if = {
+			limit = { government_has_flag = government_is_japan_feudal }
+			save_temporary_scope_as = japan_feudal
+		}
+	}
+	# COUNTIES
+	create_title_and_vassal_change = {
+		type = $REASON$
+		save_scope_as = title_change
+		add_claim_on_loss = no
+	}
+	scope:old_regent_temp = { # Give landed titles to the new Regent
+		show_as_tooltip = {
+			primary_title = { # Give top liege title to the new Regent
+				change_title_holder_include_vassals = {
+					holder = scope:new_regent_temp
+					change = scope:title_change
+				}
+			}
+		}
+		hidden_effect = {
+			every_held_title = {
+				limit = {
+					tier > tier_barony # we don't want to try and pass off baronies
+					is_landless_type_title = no
+					is_noble_family_title = no
+					NOT = { exists = var:ceremonial_title } # we don't want to hand away the ceremonial throne, which is not landless
+				}
+				change_title_holder_include_vassals = {
+					holder = scope:new_regent_temp
+					change = scope:title_change
+				}
+			}
+			change_liege = {
+				liege = scope:new_regent_temp
+				change = scope:title_change
+			}
+		}
+	}
+	resolve_title_and_vassal_change = scope:title_change
+	scope:new_regent_temp = { 
+		if = {
+			limit = {
+				has_title = scope:preferred_capital_temp # do I own the preferred capital?
+				capital_county != scope:preferred_capital_temp # and is my capital not the preferred capital?
+			}
+			set_realm_capital = scope:preferred_capital_temp # now my capital is the preferred capital
+		}
+		# GOVERNMENT
+		if = {
+			limit = {
+				exists = scope:japan_feudal
+				NOT = { government_has_flag = government_is_japan_feudal }
+			}
+			change_government = japan_feudal_government
+		}
+	}
+}
+
+tgp_japan_schoolhouse_education_boost_effect = {
+	save_scope_as = student
+	house.house_head.domicile ?= {
+		if = {
+			limit = { 
+				has_domicile_parameter = japanese_schoolhouse_education_boost_1
+			}
+			switch = {
+				trigger = has_domicile_building
+				japanese_schoolhouse_01 = { scope:student = { education_point_add_general_effect = { VALUE = 1 } } }
+				japanese_schoolhouse_02 = { scope:student = { education_point_add_general_effect = { VALUE = 2 } } }
+				japanese_schoolhouse_03 = { scope:student = { education_point_add_general_effect = { VALUE = 3 } } }
+				japanese_schoolhouse_04 = { scope:student = { education_point_add_general_effect = { VALUE = 4 } } }
+				japanese_schoolhouse_04 = { scope:student = { education_point_add_general_effect = { VALUE = 5 } } }
+				japanese_schoolhouse_04 = { scope:student = { education_point_add_general_effect = { VALUE = 6 } } }
+			}
+		}
+	}
+}
+
+tgp_restore_japanese_monarchy_decision_effect = {
+	save_scope_as = kampaku
+	tgp_restore_japanese_monarchy_yamato_scion_effect = yes
+	add_prestige = major_prestige_value
+	if = {
+		limit = { government_allows = administrative }
+		change_influence = major_influence_value
+	}
+	else = { add_piety = medium_piety_value }
+	if = {
+		limit = { exists = scope:scion }
+		add_hook = {
+			type = strong_favor_hook
+			target = scope:scion
+		}
+	}
+	else = { custom_tooltip = tgp_restore_japanese_monarchy_decision_hook_tt }
+}
+
+tgp_restore_japanese_monarchy_yamato_scion_effect = {
+	title:k_chrysanthemum_throne.previous_holder ?= { save_scope_as = last_tenno }
+	dynasty:japanese_yamato.dynasty_founder.house ?= {
+		save_scope_as = house_yamato
+		if = {
+			limit = { this = scope:kampaku.house }
+			if = { # Avoid display of short tooltips after creation
+				limit = { NOT = { exists = scope:scion } }
+				custom_tooltip = tgp_restore_japanese_monarchy_yamato_scion_kampaku_tt
+			}
+			scope:kampaku = { save_scope_as = scion }
+		}
+		else_if = {
+			limit = {
+				scope:last_tenno ?= { tgp_japan_valid_restore_monarchy_scion_trigger = yes }
+			}
+			if = { # Avoid display of short tooltips after creation
+				limit = { NOT = { exists = scope:scion } }
+				custom_tooltip = tgp_restore_japanese_monarchy_yamato_scion_last_tt
+			}
+			scope:last_tenno = { save_scope_as = scion }
+		}
+		else_if = {
+			limit = {
+				scope:last_tenno ?= {
+					any_child = { tgp_japan_valid_restore_monarchy_scion_trigger = yes }
+				}
+			}
+			if = { # Avoid display of short tooltips after creation
+				limit = { NOT = { exists = scope:scion } }
+				custom_tooltip = tgp_restore_japanese_monarchy_yamato_scion_last_child_tt
+			}
+			scope:last_tenno = {
+				ordered_child = {
+					limit = { tgp_japan_valid_restore_monarchy_scion_trigger = yes }
+					order_by = age
+					save_scope_as = scion
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				scope:last_tenno ?= {
+					any_close_family_member = { tgp_japan_valid_restore_monarchy_scion_trigger = yes }
+				}
+			}
+			if = { # Avoid display of short tooltips after creation
+				limit = { NOT = { exists = scope:scion } }
+				custom_tooltip = tgp_restore_japanese_monarchy_yamato_scion_last_close_family_tt
+			}
+			scope:last_tenno = {
+				ordered_close_family_member = {
+					limit = { tgp_japan_valid_restore_monarchy_scion_trigger = yes }
+					order_by = age
+					save_scope_as = scion
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_house_member = {
+					is_ruler = no
+					can_be_combatant_based_on_gender_trigger = { ARMY_OWNER = root.top_liege }
+					is_healthy = yes
+				}
+			}
+			if = { # Avoid display of short tooltips after creation
+				limit = { NOT = { exists = scope:scion } }
+				custom_tooltip = tgp_restore_japanese_monarchy_yamato_scion_found_tt
+			}
+			ordered_house_member = {
+				limit = {
+					top_liege = root.top_liege
+					is_ruler = no
+					can_be_combatant_based_on_gender_trigger = { ARMY_OWNER = root.top_liege }
+					is_healthy = yes
+				}
+				order_by = age
+				save_scope_as = scion
+			}
+		}
+		else = {
+			tgp_restore_japanese_monarchy_yamato_creation_effect = yes
+			if = { # Avoid display of short tooltips after creation
+				limit = { NOT = { exists = scope:scion } }
+				custom_tooltip = tgp_restore_japanese_monarchy_yamato_scion_created_tt
+			}
+		}
+		# Save children for portraits
+		scope:scion = {
+			save_scope_as = background_throne_room_scope
+			ordered_child = {
+				limit = { house = scope:scion.house }
+				max = 3
+				check_range_bounds = no
+				order_by = age
+				switch = {
+					trigger = exists
+					scope:scion_child_2 = { save_scope_as = scion_child_3 }
+					scope:scion_child_1 = { save_scope_as = scion_child_2 }
+					fallback = { save_scope_as = scion_child_1 }
+				}
+			}
+		}
+	}
+}
+
+tgp_restore_japanese_monarchy_yamato_restoration_effect = {
+	add_character_flag = tgp_japan_restore_japanese_monarchy_flag
+	if = {
+		limit = { exists = scope:scion }
+		if = {
+			limit = { exists = title:k_chrysanthemum_throne.holder }
+			create_title_and_vassal_change = {
+				type = usurped
+				save_scope_as = change
+				add_claim_on_loss = yes
+			}
+		}
+		else = {
+			create_title_and_vassal_change = {
+				type = created
+				save_scope_as = change
+			}
+		}
+		title:k_chrysanthemum_throne ?= {
+			change_title_holder = {
+				holder = scope:scion
+				change = scope:change
+			}
+		}
+		if = {
+			limit = {
+				scope:scion.liege != scope:kampaku
+				scope:scion != scope:kampaku
+			}
+			scope:scion ?= {
+				change_liege = {
+					liege = scope:kampaku
+					change = scope:change
+				}
+			}
+		}
+		resolve_title_and_vassal_change = scope:change
+	}
+	remove_character_flag = tgp_japan_restore_japanese_monarchy_flag
+	hidden_effect = {
+		scope:scion = {
+			if = {
+				limit = {
+					NOT = { government_has_flag = government_is_japan_administrative }
+				}
+				change_government = japan_administrative_government
+			}
+		}
+	}
+}
+
+tgp_restore_japanese_monarchy_yamato_creation_effect = {
+	create_character = {
+		template = tgp_japan_imperial_scion_template
+		location = scope:kampaku.capital_province
+		age = { 16 38 }
+		save_scope_as = scion
+	}
+	scope:scion ?= {
+		if = {
+			limit = { is_female = yes }
+			create_character = {
+				template = tgp_japan_imperial_scion_template
+				location = scope:kampaku.capital_province
+				mother = scope:scion
+				age = { 11 12 }
+			}
+			create_character = {
+				template = tgp_japan_imperial_scion_template
+				location = scope:kampaku.capital_province
+				mother = scope:scion
+				age = { 7 8 }
+			}
+			create_character = {
+				template = tgp_japan_imperial_scion_template
+				location = scope:kampaku.capital_province
+				mother = scope:scion
+				age = { 3 4  }
+			}
+		}
+		else = {
+			create_character = {
+				template = tgp_japan_imperial_scion_template
+				location = scope:kampaku.capital_province
+				father = scope:scion
+				age = { 11 12 }
+			}
+			create_character = {
+				template = tgp_japan_imperial_scion_template
+				location = scope:kampaku.capital_province
+				father = scope:scion
+				age = { 7 8 }
+			}
+			create_character = {
+				template = tgp_japan_imperial_scion_template
+				location = scope:kampaku.capital_province
+				father = scope:scion
+				age = { 3 4 }
+			}
+		}
+	}
+}
+
+tgp_restore_japanese_government_decision_effect = {
+	japan_clear_flavour_flags_effect = yes
+	save_scope_as = kampaku
+	save_scope_as = background_throne_room_scope
+	add_character_flag = tgp_japan_restore_japanese_government_flag
+	# Change government if relevant
+	change_government = japan_administrative_government
+	if = {
+		limit = {
+			NOT = { has_realm_law = japanese_regency_succession_law }
+		}
+		add_realm_law_skip_effects = japanese_regency_succession_law
+	}
+	# Inform vassals and convert governments if relevant
+	every_vassal = {
+		custom = every_japan_feudal_vassal_custom
+		limit = { government_has_flag = government_is_japan_feudal }
+		add_opinion = {
+			target = scope:kampaku
+			modifier = restored_ritsuryo_opinion
+		}
+	}
+	if = {
+		limit = { NOT = { exists = scope:vassal } }
+		custom_tooltip = tgp_japan_restore_japanese_government_decision_civil_war_tt
+	}
+	hidden_effect = {
+		ordered_powerful_vassal = {
+			limit = {
+				is_ai = yes
+				NOR = {
+					government_allows = administrative
+					is_allied_to = scope:kampaku
+				}
+				opinion = {
+					target = scope:kampaku
+					value < 25
+				}
+				save_temporary_scope_as = vassal_temp
+				NOT = {
+					scope:kampaku = { has_usable_hook = scope:vassal_temp }
+				}
+			}
+			order_by = military_power
+			save_scope_as = rebel
+		}
+		if = {
+			limit = {
+				NOT = { exists = scope:rebel }
+			}
+			ordered_vassal = {
+				limit = {
+					is_ai = yes
+					NOT = { government_allows = administrative }
+					opinion = {
+						target = scope:kampaku
+						value < 25
+					}
+					save_temporary_scope_as = vassal_temp
+					NOT = {
+						scope:kampaku = { has_usable_hook = scope:vassal_temp }
+					}
+				}
+				order_by = military_power
+				save_scope_as = rebel
+			}
+		}
+		if = {
+			limit = { exists = scope:rebel }
+			tgp_restore_ritsuryo_civil_war_effect = {
+				REBEL = scope:rebel
+				LIEGE = scope:kampaku
+			}
+		}
+	}
+	custom_tooltip = {
+		text = tgp_japan_restore_japanese_government_decision_vassal_tt
+		every_vassal_or_below = {
+			limit = {
+				primary_title.tier >= tier_county
+				culture = { has_same_culture_heritage = scope:kampaku.culture }
+			}
+			trigger_event = {
+				id = tgp_japan_decision.9912
+				delayed = yes
+			}
+		}
+	}
+	remove_character_flag = tgp_japan_restore_japanese_government_flag
+}
+
+tgp_destroy_ceremonial_throne_effect = {
+	liege = { save_scope_as = liege }
+	save_scope_as = vassal
+	scope:vassal ?= {
+		if = {
+			limit = {
+				any_held_title = { exists = var:ceremonial_title }
+			}
+			tgp_destroy_ceremonial_liege_title_effect = yes
+		}
+		every_held_title = {
+			limit = { exists = var:administrative_ui_special_title }
+			holder ?= { tgp_destroy_ceremonial_liege_title_effect = yes }
+		}
+	}
+}
+
+tgp_destroy_ceremonial_liege_title_effect = {
+	save_scope_as = ceremonial_liege
+	random_held_title = {
+		limit = { exists = var:ceremonial_title }
+		save_scope_as = ceremonial_title
+		var:ceremonial_title = { save_scope_as = regent_title }
+	}
+	random_held_title = {
+		limit = { is_noble_family_title = yes }
+		save_scope_as = nf_title
+	}
+	# Destroy the Ceremonial Title if linked title has no holder, or is in another realm, or is a sub vassal
+	if = {
+		limit = {
+			exists = scope:ceremonial_title
+			exists = scope:regent_title
+			OR = {
+				# Linked regent title has no holder
+				NOT = { exists = scope:ceremonial_title.var:ceremonial_title.holder }
+				scope:ceremonial_title.holder.top_liege = {
+					OR = {
+						# Regent and Ceremonial titles in different realms
+						this != scope:ceremonial_title.var:ceremonial_title.holder.top_liege
+						# Regent title is not top liege's primary title
+						primary_title != scope:ceremonial_title.var:ceremonial_title
+						# Regent is not liege of Monarch
+						this != scope:ceremonial_title.holder.liege
+						# Hegemony
+						highest_held_title_tier = tier_hegemony
+					}
+				}
+			}
+		}
+		# MESSAGE
+		every_player = {
+			limit = { top_liege = scope:ceremonial_liege.top_liege }
+			send_interface_message = {
+				type = event_generic_bad
+				title = tgp_destroy_ceremonial_liege_throne_title
+				left_icon = scope:ceremonial_liege
+				right_icon = scope:liege
+				show_as_tooltip = {
+					scope:liege = { destroy_title = scope:ceremonial_title }
+					scope:ceremonial_liege = {
+						if = {
+							limit = { is_independent_ruler = no }
+							add_trait = former_emperor
+						}
+					}
+				}
+			}
+		}
+		# Actually destroy
+		scope:ceremonial_liege = {
+			if = {
+				limit = { has_treasury = yes }
+				custom_tooltip = {
+					text = treasury_emptying_effect_desc
+					empty_treasury_when_abandoning_landed_life_effect = yes # otherwise the treasury sticks around
+				}
+			}
+			if = {
+				limit = { is_independent_ruler = no }
+				add_trait = former_emperor
+			}
+		}
+		scope:ceremonial_title = { remove_variable = ceremonial_title }
+		scope:regent_title = { remove_variable = administrative_ui_special_title }
+		scope:liege = { destroy_title = scope:ceremonial_title }
+	}
+}
+
+tgp_japan_demand_administrative_refusal_effect = {
+	if = {
+		limit = {
+			scope:actor = { government_has_flag = government_is_japan_administrative }
+			scope:recipient = { government_has_flag = government_is_japan_feudal }
+		}
+		scope:actor = {
+			start_war = {
+				casus_belli = japan_demand_administrative_cb
+				target = scope:recipient
+			}
+		}
+		custom_tooltip = japan_demand_administrative_cb_warning_japan_tt
+	}
+}
+
+tgp_restore_ritsuryo_civil_war_effect = {
+	$REBEL$ = {
+		save_scope_as = actor
+		save_scope_value_as = {
+			name = war_for_hoken_flavour
+			value = yes
+		}
+		start_war = {
+			casus_belli = japan_refused_ritsuryo_cb
+			target = $LIEGE$
+		}
+	}
+	$LIEGE$ = {
+		save_scope_as = recipient
+		every_vassal = { #Vassals joining the rebel.
+			custom = vassals_joining_war_tt
+			limit = {
+				government_has_flag = government_is_japan_feudal
+				NOR = {
+					this = $REBEL$
+					is_ai = no
+					has_trait = incapable
+					is_imprisoned = yes
+					dread_modified_ai_boldness = { #Too scared to do anything.
+						dreaded_character = $LIEGE$
+						value <= -50
+					}
+					opinion = { # People who really, really like you will still back you
+						target = $LIEGE$
+						value >= 80
+					}
+					is_allied_to = $LIEGE$ 
+					is_at_war_with = $REBEL$
+					is_at_war_with = $LIEGE$
+				}
+				highest_held_title_tier > tier_barony
+				OR = {
+					#Lovers and friends always back rebel (unless also lovers/friends of the liege)
+					AND = {
+						OR = {
+							is_allied_to = $REBEL$ 
+							has_relation_lover = $REBEL$
+							has_relation_friend = $REBEL$
+						}
+						NOR = {
+							is_allied_to = $LIEGE$ 
+							has_relation_lover = $LIEGE$
+							has_relation_friend = $LIEGE$
+						}
+					}
+					#Vassals that either like recipient or have high honor will rally if the liege is being tyrannical.
+					AND = {
+						# If they can't join a faction against the liege they should not revolt
+						NOR = {
+							has_relation_lover = $LIEGE$
+							has_relation_friend = $LIEGE$
+							is_allied_to = $LIEGE$
+							is_primary_heir_of = $LIEGE$
+							$LIEGE$ = { has_strong_hook = prev }
+							has_dread_level_towards = {
+								target = $LIEGE$
+								level = 2
+							}
+						}
+						OR = {
+							ai_boldness >= 25
+							ai_honor >= 25
+							opinion = {
+								target = $REBEL$
+								value >= 40
+							}
+						}
+						NOR = {
+							$LIEGE$ = { has_revoke_title_reason = $REBEL$ }
+							trigger_if = {
+								limit = { exists = scope:landed_title }
+								$LIEGE$ = { has_claim_on = scope:landed_title }
+							}
+							faith = {
+								faith_hostility_level = {
+									target = $REBEL$.faith
+									value >= faith_hostile_level
+								}
+							}
+						}
+					}
+					#And finally, vassals that really hate their liege will join regardless (provided that they also do not hate recipient).
+					AND = {
+						opinion = {
+							target = $REBEL$
+							value >= -25
+						}
+						OR = {
+							#default threshold
+							opinion = {
+								target = $LIEGE$
+								value <= -50
+							}
+							#If tyrannical, the default threshold will be reached if at this level
+							AND = {
+								$LIEGE$ = {
+									title_revocation_is_tyrannical_trigger = { VASSAL = $REBEL$ }
+								}
+								opinion = {
+									target = $LIEGE$
+									value <= -30 #revoke_title_tyranny_gain adds -20
+								}
+							}
+						}
+					}
+				}
+			}
+			save_scope_as = joining_vassal
+			custom_tooltip = tooltip_fellow_vassal_joins_war #The war has not started when viewing the interaction screen.
+			hidden_effect = {
+				$REBEL$ = {
+					every_character_war = {
+						limit = {
+							using_cb = japan_refused_ritsuryo_cb
+							casus_belli = {
+								primary_attacker = $REBEL$
+								primary_defender = $LIEGE$
+							}
+						}
+						add_to_list = war_to_join
+					}
+				}
+				every_in_list = {
+					list = war_to_join
+					limit = {
+						NOT = { is_defender = prev }
+					}
+					hidden_effect = { set_called_to = prev }
+					add_attacker = prev
+				}
+			}
+			hidden_effect = {
+				$LIEGE$ = {
+					add_opinion = {
+						target = prev
+						modifier = rebellious_vassal_opinion
+					}
+				}
+			}
+		}
+		every_vassal = {
+			limit = {
+				is_ai = no
+				NOT = { this = $REBEL$ }
+				is_imprisoned = no
+			}
+			$REBEL$ = { save_scope_as = recipient }
+			$LIEGE$ = { save_scope_as = actor }
+			trigger_event = tgp_japan_decision.9913
+		}
+	}
+}
+
+tgp_set_historical_house_relation_effect = {
+	if = {
+		limit = {
+			house_relation_is_valid_to_start_trigger = {
+				HOUSE = this
+				OTHER_HOUSE = $OTHER_HOUSE$
+			}
+		}
+		set_house_relation = {
+			target = $OTHER_HOUSE$
+			level = $LEVEL$
+			description = house_relation_reason_historical_desc
+		}
+	}
+}
+
+tgp_setup_historical_house_relation_effect = {
+	### 867 ###
+	if = {
+		limit = { game_start_date = 867.1.1 }
+		house:house_fujiwara_ashikaga = {
+			tgp_set_historical_house_relation_effect = { # 
+				OTHER_HOUSE = house:house_minamoto_kozuke
+				LEVEL = rivalry
+			}
+		}
+	}
+	### 1066 ###
+	else_if = {
+		limit = { game_start_date = 1066.9.15 }
+		dynasty:japanese_minamoto_murakami.dynasty_founder.house = {
+			tgp_set_historical_house_relation_effect = { # 
+				OTHER_HOUSE = dynasty:japanese_fujiwara.dynasty_founder.house
+				LEVEL = friendly
+			}
+		}
+	}
+	### 1178 ###
+	else_if = {
+		limit = { game_start_date = 1178.10.1 }
+		dynasty:japanese_sugawara.dynasty_founder.house = {
+			tgp_set_historical_house_relation_effect = { # 
+				OTHER_HOUSE = dynasty:japanese_ki.dynasty_founder.house
+				LEVEL = friendly
+			}
+		}
+		house:house_minamoto_kiso = {
+			tgp_set_historical_house_relation_effect = { # Yoshikata killed by Yoshihira
+				OTHER_HOUSE = dynasty:japanese_nakahara_kiso.dynasty_founder.house
+				LEVEL = friendly
+			}
+		}
+		house:house_minamoto_kawachi = {
+			tgp_set_historical_house_relation_effect = { # Yoritomo's brothers killed by Kiyomori
+				OTHER_HOUSE = dynasty:japanese_nakahara_kiso.dynasty_founder.house
+				LEVEL = rivalry
+			}
+			tgp_set_historical_house_relation_effect = { # Marriage and historical alliance
+				OTHER_HOUSE = house:house_taira_hojo
+				LEVEL = friendly
+			}
+		}
+		house:house_kudo_kawazu = {
+			tgp_set_historical_house_relation_effect = { # Soga brothers
+				OTHER_HOUSE = house:house_kudo_ito_2
+				LEVEL = rivalry
+			}
+		}
+		house:house_taira_wada = {
+			tgp_set_historical_house_relation_effect = { # Yoshimune killed by Tsunetomo
+				OTHER_HOUSE = dynasty:japanese_nagasa.dynasty_founder.house
+				LEVEL = rivalry
+			}
+		}
+		house:house_taira_chichibu = {
+			tgp_set_historical_house_relation_effect = { # Shigetaka killed by Yoshihira
+				OTHER_HOUSE = house:house_minamoto_kawachi
+				LEVEL = rivalry
+			}
+		}
+		house:house_taira_soga = {
+			tgp_set_historical_house_relation_effect = { # Soga brothers
+				OTHER_HOUSE = house:house_minamoto_kawachi
+				LEVEL = rivalry
+			}
+		}
+		dynasty:japanese_ito.dynasty_founder.house = {
+			tgp_set_historical_house_relation_effect = { # Tadanao killed by Tametomo
+				OTHER_HOUSE = house:house_minamoto_kawachi
+				LEVEL = rivalry
+			}
+		}
+		house:house_kudo_ito_2 = {
+			tgp_set_historical_house_relation_effect = { # Sukeyasu_2 killed by Suketsune_2
+				OTHER_HOUSE = house:house_kudo_kawazu
+				LEVEL = rivalry
+			}
+		}
+		house:house_fujiwara_shijo = {
+			tgp_set_historical_house_relation_effect = { # Takasue's brothers killed by Kiyomori
+				OTHER_HOUSE = dynasty:japanese_taira_kanmu.dynasty_founder.house
+				LEVEL = rivalry
+			}
+		}
+		dynasty:japanese_fujiwara.dynasty_founder.house = {
+			tgp_set_historical_house_relation_effect = { # Yorinaga killed by Shigesada
+				OTHER_HOUSE = house:house_minamoto_mitsumasa
+				LEVEL = rivalry
+			}
+		}
+	}
+}
+
+tgp_liege_change_bloc_management_effect = {
+	$VASSAL$ = {
+		if = { # Leave if not a valid member anymore
+			limit = {
+				OR = {
+					exists = confederation.leading_house
+					exists = house.house_confederation
+				}
+			}
+			save_temporary_scope_as = vassal_temp
+			house ?= { save_temporary_scope_as = vassal_house_temp }
+			liege ?= { save_temporary_scope_as = new_liege }
+			confederation ?= {
+				save_temporary_scope_as = current_bloc_temp
+				leading_house = { save_temporary_scope_as = current_bloc_leader_temp }
+			}
+			house.house_confederation ?= {
+				save_temporary_scope_as = current_house_bloc_temp
+				leading_house = { save_temporary_scope_as = current_house_bloc_leader_temp }
+			}
+			if = {
+				limit = {
+					exists = scope:current_bloc_temp
+					exists =  scope:old_liege
+					trigger_if = { # If a vassal
+						limit = { is_independent_ruler = no }
+						scope:new_liege.liege != scope:old_liege.liege
+						scope:new_liege = {
+							is_independent_ruler = no
+						}
+					}
+					trigger_else = {
+						NOT = { scope:vassal_temp = scope:old_liege.top_liege }
+					}
+				}
+				scope:current_bloc_temp = {
+					if = {
+						limit = {
+							scope:vassal_temp = {
+								is_house_head = yes
+								house.house_confederation = scope:current_bloc_temp
+								scope:new_liege = {
+									is_independent_ruler = no
+								}
+							}
+						}
+						scope:vassal_house_temp = {
+							tgp_leave_house_bloc_effect = {
+								OPINION = flag:no
+								TRUCE = flag:yes
+							}
+						}
+					}
+					else_if = {
+						limit = { scope:vassal_temp.confederation = scope:current_bloc_temp }
+						remove_confederation_member = scope:vassal_temp
+					}
+				}
+				debug_log = "Bloc liege change member leave"
+				debug_log_scopes = yes
+			}
+			if = { # Join if not a member of valid
+				limit = {
+					is_house_head = no
+					exists = scope:current_house_bloc_temp
+					scope:vassal_house_temp.house_head.liege ?= liege
+					NOT = { confederation = scope:vassal_house_temp.house_confederation }
+				}
+				confederation ?= {
+					save_temporary_scope_as = current_bloc_temp
+					remove_confederation_member = scope:vassal_temp
+				}
+				house.house_confederation = {
+					save_temporary_scope_as = house_bloc_temp
+					add_confederation_member = scope:vassal_temp
+				}
+				debug_log = "Bloc liege change member join"
+				debug_log_scopes = yes
+			}
+		}
+	}
+}
+
+tgp_japan_assert_regional_dominion_government_decision_effect = {
+	save_scope_as = super_soryo
+	scope:super_soryo.primary_title.duchy ?= { save_scope_as = title_scope }
+	# Crime to Kampaku
+	if = {
+		limit = {
+			top_liege = { government_allows = administrative }
+		}
+		# Message for attacker
+		send_interface_toast = {
+			type = event_war_bad
+			title = tgp_japan_soryo_war_is_crime_title
+			left_icon = top_liege
+			right_icon = scope:title_scope
+			top_liege = {
+				send_interface_toast = {
+					type = event_war_bad
+					title = tgp_japan_soryo_war_is_crime_kampaku_title
+					left_icon = scope:super_soryo
+					right_icon = scope:title_scope
+					add_opinion = {
+						target = scope:super_soryo
+						modifier = admin_soryo_conquest_crime
+					}
+				}
+			}
+		}
+	}
+	if = {
+		limit = { exists = scope:title_scope.holder }
+		hidden_effect = {
+			scope:title_scope.holder = { save_scope_as = main_defender }
+			scope:super_soryo = {
+				if = {
+					limit = {
+						any_truce_target = { this = scope:main_defender }
+					}
+					cancel_truce_both_ways = scope:main_defender
+				}
+			}
+			start_war = {
+			#lets make sure this is appropriate for Japan
+				cb = domination_cb
+				target = scope:main_defender
+				target_title = scope:title_scope
+			}
+			random_character_war = {
+				limit = {
+					using_cb = domination_cb
+					primary_defender = scope:main_defender
+				}
+				save_scope_as = war
+			}
+		}
+		tgp_bloc_members_join_war_effect = { WAR = scope:war }
+		custom_tooltip = domination_war_holder_custom_tooltip
+	}
+	else_if = {
+		limit = {
+			scope:super_soryo = {
+				NOR = {
+					prestige_level >= 4
+					legitimacy_level >= 3
+				}
+			}
+			scope:title_scope ?= {
+				any_de_jure_county_holder = {
+					NOR = {
+						is_liege_or_above_of = scope:super_soryo
+						top_suzerain ?= scope:super_soryo
+						is_allied_to = scope:super_soryo
+						government_has_flag = government_is_herder
+						trigger_if = {
+							limit = {
+								exists = scope:super_soryo.confederation
+							}
+							confederation ?= scope:super_soryo.confederation
+						}	
+					}
+					#They wont join if you're too scary
+					has_dread_level_towards = {
+						target = scope:super_soryo
+						level < 2
+					}
+					#Must be strong enough to feel like they can fight you
+					current_military_strength >= {
+						value = scope:super_soryo.current_military_strength
+						multiply = 0.5
+					}
+				}
+			}
+		}
+		hidden_effect = {
+			scope:title_scope = {
+				every_de_jure_county_holder = {
+					limit = {
+						NOT = { is_liege_or_above_of = scope:super_soryo }
+					}
+					if = {
+						limit = {
+							NOR = {
+								top_suzerain ?= scope:super_soryo
+								is_allied_to = scope:super_soryo
+								government_has_flag = government_is_herder
+								trigger_if = {
+									limit = {
+										exists = scope:super_soryo.confederation
+									}
+									confederation ?= scope:super_soryo.confederation
+								}	
+							}
+							
+							#They wont join if you're too scary
+							has_dread_level_towards = {
+								target = scope:super_soryo
+								level < 2
+							}
+							#Must be strong enough to feel like they can fight you
+							current_military_strength >= {
+								value = scope:super_soryo.current_military_strength
+								multiply = 0.5
+							}
+						}
+						add_to_list = war_targets
+					}
+					else = {
+						add_to_list = potential_vassals 
+					}
+					
+				}
+				ordered_in_list = {
+					list = war_targets
+					order_by = current_military_strength
+					save_scope_as = main_defender
+				}
+			}
+			scope:super_soryo = {
+				if = {
+					limit = {
+						any_truce_target = { this = scope:main_defender }
+					}
+					cancel_truce_both_ways = scope:main_defender
+				}
+			}
+			start_war = {
+				cb = domination_cb
+				target = scope:main_defender
+				target_title = scope:title_scope
+			}
+			#find ai for war
+			random_character_war = {
+				limit = {
+					primary_attacker = scope:super_soryo
+					primary_defender = scope:main_defender
+					using_cb = domination_cb
+				}
+				save_scope_as = super_soryo_war
+				every_in_list = {
+					list = war_targets
+					limit = {
+						NOT = { is_participant_in_war = scope:super_soryo_war }
+						is_ai = yes
+					}
+					save_scope_as = super_soryo_war_target
+					scope:super_soryo_war = {
+						hidden_effect = {
+							set_called_to = scope:super_soryo_war_target
+						}
+						add_defender = scope:super_soryo_war_target
+					}
+				}
+			}
+			#send players letter to join war or bend the knee
+			every_in_list = {
+				list = war_targets
+				limit = {
+					is_ai = no
+				}
+				trigger_event = tgp_japan_decision.9963
+			}
+		}
+		if = {
+			limit = { exists = scope:war }
+			tgp_bloc_members_join_war_effect = { WAR = scope:war }
+		}
+		save_scope_value_as = {
+			name = super_soryo_war_current_enemy_strength
+			value = {
+				value = 0
+				every_in_list = {
+					list = war_targets 
+					add = {
+						value = current_military_strength
+						every_tributary = {
+							limit = {
+								vassal_contract_has_flag = tributary_contract_tributary_forced_war_override
+							}
+							add = current_military_strength
+						}
+						if = {
+							limit = { this = scope:main_defender }
+							every_ally = { add = current_military_strength }
+							if = {
+								limit = { exists = house.house_confederation }
+								top_liege = {
+									every_vassal = {
+										limit = {
+											highest_held_title_tier > tier_barony
+											house.house_confederation = scope:main_defender.house.house_confederation
+											NOT = { is_allied_to = scope:main_defender }
+										}
+										add = current_military_strength
+									}
+								}
+							}
+						}	
+					}
+				}
+			}
+		}
+		custom_tooltip = super_soryo_war_no_holder_custom_tooltip
+		custom_tooltip = super_soryo_potential_peaceful
+	}
+	else = {
+		scope:title_scope = { tgp_japan_assert_regional_dominance_war_outcome_effect = yes }
+		add_dread = 15
+		add_legitimacy = 50
+		dynasty = { add_dynasty_prestige = 150 }
+		custom_tooltip = super_soryo_reward_peaceful
+	}
+}
+
+tgp_japan_assert_regional_dominance_war_outcome_effect = {
+	create_title_and_vassal_change = {
+		type = created
+		save_scope_as = change
+	}
+	change_title_holder = {
+		holder = root
+		change = scope:change
+	}
+	every_de_jure_county = {
+		limit = {
+			holder.top_liege = root.top_liege # in same realm
+			holder.liege = root.top_liege # is not already a sub-vassal
+			NOR = {
+				holder = root # held my me
+				holder.liege = root # or my vassal
+				holder = { is_liege_or_above_of = root } # or my liege
+				this = holder.top_liege.capital_county # stop transfer of capital
+			}
+		}
+		if = {
+			limit = {
+				holder = {
+					NOT = { government_allows = administrative }
+					highest_held_title_tier <= tier_county
+				}
+			}
+			holder = {
+				change_liege = {
+					liege = root
+					change = scope:change
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				holder = {
+					OR = {
+						government_allows = administrative
+						this = root.top_liege
+					}
+				}
+			}
+			change_title_holder = {
+				holder = root
+				change = scope:change
+			}
+		}
+	}
+	resolve_title_and_vassal_change = scope:change
+}
+
+tgp_set_minamoto_taira_dynasty_prestige_effect = {
+	holder.dynasty ?= {
+		while = {
+			limit = { dynasty_prestige_level < 5 }
+			add_dynasty_prestige_level = 1
+		}
+	}
+}
+
+tgp_japan_soryo_eradicate_cb_transfer_effect = {
+	scope:loser = {
+		every_held_title = {
+			limit = {
+				# Prevent completely breaking realms
+				trigger_if = {
+					limit = {
+						scope:loser = {
+							highest_held_title_tier >= tier_kingdom
+							any_held_title = { is_landless_type_title = yes }
+						}
+					}
+					NOR = {
+						this = scope:loser.capital_county
+						this = scope:loser.capital_county.duchy
+					}
+				}
+				is_landless_type_title = no
+				tier > tier_barony
+				tier < tier_kingdom
+			}
+			add_to_list = seized_titles
+		}
+	}
+ 
+	create_title_and_vassal_change = {
+		type = conquest
+		save_scope_as = change
+		add_claim_on_loss = yes
+	}
+	
+	every_in_list = {
+		list = seized_titles
+		limit = {
+			is_landless_type_title = no
+			tier = tier_duchy
+		}
+		change_title_holder_include_vassals = {
+			holder = scope:winner
+			change = scope:change
+		}
+	}
+	every_in_list = {
+		list = seized_titles
+		limit = {
+			is_landless_type_title = no
+		}
+		change_title_holder_include_vassals = {
+			holder = scope:winner
+			change = scope:change
+		}
+	}	
+	resolve_title_and_vassal_change = scope:change
+}
+
+japanese_establish_soryo_administration_reward_effect = {
+	save_temporary_scope_as = winner_temp
+	scope:winner_temp = {
+		if = {
+			limit = {
+				NOT = { has_government = japan_feudal_government }
+			}
+			change_government = japan_feudal_government
+		}
+		if = {
+			limit = {
+				NOT = { has_realm_law = japanese_bureaucracy_0 }
+			}
+			add_realm_law = japanese_bureaucracy_0
+		}
+		house.house_confederation ?= {
+			custom_tooltip = {
+				text = japanese_establish_soryo_administration_vassal_government_tt
+				every_confederation_member = {
+					limit = { has_government = japan_administrative_government }
+					change_government = japan_feudal_government
+				}
+			}
+		}
+		custom_tooltip = japanese_establish_soryo_administration_imprison_tt
+	}
+}
+
+tgp_learn_chinese_effect_game_start = {
+	if = {
+		limit = {
+			should_learn_chinese_trigger = yes
+		}
+		learn_language = language_chinese
+	}
+}
+tgp_learn_chinese_effect_birthday = {
+	if = {
+		limit = {
+			should_learn_chinese_trigger = yes
+		}
+		learn_language = language_chinese
+		every_player = {
+			limit = {
+				OR = {
+					is_parent_of = scope:child_learned_chinese
+					this = scope:child_learned_chinese
+					has_relation_guardian = scope:child_learned_chinese
+					has_relation_elder = scope:child_learned_chinese
+				}
+			}
+			send_interface_toast = {
+				type = event_childhood_good_with_text
+				title = japanese_korean_child_learned_chinese_title
+				desc = japanese_korean_child_learned_chinese_effect
+				left_icon = scope:child_learned_chinese
+				show_as_tooltip = {
+					scope:child_learned_chinese = {
+						learn_language = language_chinese
+					}
+				}
+			}
+		}
+	}
+}
+
+create_love_artifact_poetry_effect = {
+	$OWNER$ = { save_scope_as = owner }
+
+	hidden_effect_new_object = {
+		get_artifact_quality_effect = yes
+		get_artifact_wealth_effect = yes
+
+		scope:owner = {
+			create_artifact = {
+				name = love_artifact_poetry_name
+				creator = scope:owner
+				description = love_artifact_poetry_description
+				visuals = scroll
+				type = miscellaneous
+				modifier = artifact_monthly_minor_prestige_1_modifier
+				modifier = artifact_attraction_opinion_1_modifier
+				save_scope_as = newly_created_artifact
+				wealth = scope:wealth
+				quality = scope:quality
+			}
+		}
+
+		scope:newly_created_artifact = {
+			add_scaled_artifact_modifier_minor_prestige_effect = yes
+			add_scaled_artifact_modifier_majesty_effect = yes
+		}
+	}
+}
+
+tgp_bloc_members_join_faction_effect = {
+	if = { # Japanese blocs
+		limit = { scope:faction.faction_leader.house.house_confederation.leading_house ?= scope:faction.faction_leader.house }
+		scope:faction.faction_leader.house.house_confederation ?= {
+			every_confederation_member = {
+				limit = { can_join_faction = scope:faction }
+				join_faction = scope:faction
+			}
+		}
+	}
+}
+
+tgp_bloc_members_join_war_effect = {
+	custom_tooltip = {
+		text = tgp_bloc_members_join_war_effect_tt
+		if = {
+			limit = { house.house_confederation.leading_house.house_head = this }
+			house.house_confederation ?= {
+				every_confederation_member = {
+					limit = {
+						NOT = { is_participant_in_war = $WAR$ }
+					}
+					save_temporary_scope_as = war_participant_temp
+					scope:war = { add_attacker = scope:war_participant_temp }
+				}
+			}
+		}
+	}
+}
+
+tgp_renounce_estate_effect = {
+	random_held_title = {
+		limit = { is_noble_family_title = yes }
+		current_heir = { 
+			save_scope_as = new_player
+			if = {
+				limit = {
+					root = {
+						is_ai = no
+					}
+				}
+				save_scope_as = new_human_player_character
+			}
+		}
+	}
+	add_character_modifier = { modifier = ep3_renounced_estate }
+	custom_tooltip = {
+		text = renounce_noble_family_title_decision_tt
+		send_interface_toast = {
+			type = event_toast_effect_neutral
+			title = renounce_noble_family_title_decision_toast_title
+			custom_tooltip = renounce_noble_family_title_decision_toast_desc
+			left_icon = scope:new_player
+			right_icon = root
+		}
+	}
+	if = {
+		limit = {
+			NOT = { has_trait = devoted }
+		}
+		add_trait = devoted
+	}
+	if = {
+		limit = { exists = scope:new_player }
+		hidden_effect = {
+			create_title_and_vassal_change = {
+				type = granted
+				save_scope_as = title_change
+				add_claim_on_loss = no
+			}
+			if = {
+				limit = {
+					is_governor = no
+				}
+				every_held_title = {
+					limit = { tier > tier_barony }
+					change_title_holder_include_vassals = {
+						holder = scope:new_player
+						change = scope:title_change
+					}
+				}
+			}
+			else = {
+				every_held_title = {
+					limit = { is_noble_family_title = yes }
+					change_title_holder = {
+						holder = scope:new_player
+						change = scope:title_change
+					}
+				}
+			}
+			resolve_title_and_vassal_change = scope:title_change
+			if = {
+				limit = {
+					is_ruler = yes
+				}
+				primary_title.current_heir = { save_scope_as = heir_temp }
+				create_title_and_vassal_change = {
+					type = appointment
+					save_scope_as = title_change
+					add_claim_on_loss = no
+				}
+				every_held_title = {
+					limit = { tier > tier_barony }
+					change_title_holder_include_vassals = {
+						holder = scope:heir_temp
+						change = scope:title_change
+					}
+				}
+				resolve_title_and_vassal_change = scope:title_change
+			}
+		}
+		house = {
+			if = {
+				limit = {
+					NOT = { house_head = scope:new_player }
+				}
+				set_house_head = scope:new_player
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:new_human_player_character
+			}
+			set_player_character = scope:new_human_player_character
+		}
+		progress_towards_friend_effect = {
+			REASON = friend_retired_from_governorship
+			CHARACTER = scope:new_player
+			OPINION = default_friend_opinion
+		}
+	}
+	tgp_step_down_title_recipient_tooltip_effect = yes
+	set_variable = {
+		name = appointment_trait_override
+		value = trait:intellect_good_3
+	}
+}
+
+tgp_dynasty_house_name_setup_effect = {
+	### JAPAN
+	# Fujiwara
+	dynasty:japanese_fujiwara.dynasty_founder.house ?= { set_house_name = "dynn_Fujiwara_Hok_ke" }
+	dynasty:japanese_fujiwara_oshu.dynasty_founder.house ?= { set_house_name = "dynn_Fujiwara_O_shU_" }
+	# Kiyohara
+	dynasty:japanese_kiyohara_hirozumi.dynasty_founder.house ?= { set_house_name = "dynn_Kiyohara_Hirozumi" }
+	# Minamoto
+	dynasty:japanese_minamoto_daigo.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_Daigo" }
+	dynasty:japanese_minamoto_kazan.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_Kazan" }
+	dynasty:japanese_minamoto_koko.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_KO_kO_" }
+	dynasty:japanese_minamoto_gosanjo.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_Go_SanjO_" }
+	dynasty:japanese_minamoto_montoku.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_Montoku" }
+	dynasty:japanese_minamoto_murakami.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_Murakami" }
+	dynasty:japanese_minamoto_ninmyo.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_NinmyO_" }
+	dynasty:japanese_minamoto_saga.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_Saga" }
+	dynasty:japanese_minamoto_sanjo.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_SanjO_" }
+	dynasty:japanese_minamoto_seiwa.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_Seiwa" }
+	dynasty:japanese_minamoto_uda.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_Uda" }
+	dynasty:japanese_minamoto_yozei.dynasty_founder.house ?= { set_house_name = "dynn_Minamoto_YO_zei" }
+	# Taira
+	dynasty:japanese_taira_kanmu.dynasty_founder.house ?= { set_house_name = "dynn_Taira_Kanmu" }
+	dynasty:japanese_taira_koko.dynasty_founder.house ?= { set_house_name = "dynn_Taira_KO_kO_" }
+	dynasty:japanese_taira_montoku.dynasty_founder.house ?= { set_house_name = "dynn_Taira_Montoku" }
+	dynasty:japanese_taira_ninmyo.dynasty_founder.house ?= { set_house_name = "dynn_Taira_NinmyO_" }
+	### KOREA
+	# Baek
+	dynasty:balhae_baek.dynasty_founder.house ?= { set_house_name = "dynn_Baek_Balhae" }
+	dynasty:korean_baek_daeheung.dynasty_founder.house ?= { set_house_name = "dynn_Baek_Daeheung" }
+	dynasty:korean_baek_jiksan.dynasty_founder.house ?= { set_house_name = "dynn_Baek_Jiksan" }
+	# Bak
+	dynasty:korean_bak_jukbang.dynasty_founder.house ?= { set_house_name = "dynn_Bak_Jukbang" }
+	dynasty:korean_bak_juksan.dynasty_founder.house ?= { set_house_name = "dynn_Bak_Juksan" }
+	dynasty:korean_bak_milyang.dynasty_founder.house ?= { set_house_name = "dynn_Bak_Milyang" }
+	dynasty:korean_bak_pyeongjangsa.dynasty_founder.house ?= { set_house_name = "dynn_Bak_Pyeongjangsa" }
+	dynasty:korean_bak_pyeongsan.dynasty_founder.house ?= { set_house_name = "dynn_Bak_Pyeongsan" }
+	dynasty:korean_bak_silla.dynasty_founder.house ?= { set_house_name = "dynn_Bak_Gyeongju" }
+	dynasty:korean_bak_seungju.dynasty_founder.house ?= { set_house_name = "dynn_Bak_Seungju" }
+	dynasty:korean_bak_ulleong.dynasty_founder.house ?= { set_house_name = "dynn_Bak_Ulleong" }
+	# Bok
+	dynasty:korean_bok_myeoncheon.dynasty_founder.house ?= { set_house_name = "dynn_Bok_Myeoncheon" }
+	# Chae
+	dynasty:korean_chae_eumseong.dynasty_founder.house ?= { set_house_name = "dynn_Chae_Eumseong" }
+	dynasty:korean_chae_pyeonggang.dynasty_founder.house ?= { set_house_name = "dynn_Chae_Pyeonggang" }
+	# Cheok
+	dynasty:korean_cheok_goksan.dynasty_founder.house ?= { set_house_name = "dynn_Cheok_Goksan" }
+	# Choe
+	dynasty:korean_choe_chungju.dynasty_founder.house ?= { set_house_name = "dynn_Choe_Chungju" }
+	dynasty:korean_choe_dongju.dynasty_founder.house ?= { set_house_name = "dynn_Choe_Dongju" }
+	dynasty:korean_choe_gyeongju.dynasty_founder.house ?= { set_house_name = "dynn_Choe_Gyeongju" }
+	dynasty:korean_choe_haeju.dynasty_founder.house ?= { set_house_name = "dynn_Choe_Haeju" }
+	dynasty:korean_choe_jiksan.dynasty_founder.house ?= { set_house_name = "dynn_Choe_Jiksan" }
+	dynasty:korean_choe_suwon.dynasty_founder.house ?= { set_house_name = "dynn_Choe_Suwon" }
+	dynasty:korean_choe_ubong.dynasty_founder.house ?= { set_house_name = "dynn_Choe_Ubong" }
+	# Dae
+	dynasty:balhae_dae.dynasty_founder.house ?= { set_house_name = "dynn_Dae_Balhae" }
+	# Dongseong
+	dynasty:balhae_dongseong.dynasty_founder.house ?= { set_house_name = "dynn_Dong_seong_Balhae" }
+	# Du
+	dynasty:korean_du_dureung.dynasty_founder.house ?= { set_house_name = "dynn_Du_Dureung" }
+	dynasty:korean_du_pyeongju.dynasty_founder.house ?= { set_house_name = "dynn_Du_Pyeongju" }
+	# Gang
+	dynasty:korean_gang_geumcheon.dynasty_founder.house ?= { set_house_name = "dynn_Gang_Geumcheon" }
+	dynasty:korean_gang_jinju.dynasty_founder.house ?= { set_house_name = "dynn_Gang_Jinju" }
+	dynasty:korean_gang_sincheon.dynasty_founder.house ?= { set_house_name = "dynn_Gang_Sincheon" }
+	# Geum
+	dynasty:korean_geom_bonghwa.dynasty_founder.house ?= { set_house_name = "dynn_Geom_Bonghwa" }
+	dynasty:korean_geom_nakrang.dynasty_founder.house ?= { set_house_name = "dynn_Geom_Nakrang" }
+	# Gi
+	dynasty:korean_gi_jikju.dynasty_founder.house ?= { set_house_name = "dynn_Gi_Jikju" }
+	# Gim
+	dynasty:korean_gim_ansan.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Ansan" }
+	dynasty:korean_gim_dangak.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Dangak" }
+	dynasty:korean_gim_eonyang.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Eonyang" }
+	dynasty:korean_gim_gangneung.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Gangneung" }
+	dynasty:korean_gim_gimhae.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Gimhae" }
+	dynasty:korean_gim_gwangsan.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Gwangsan" }
+	dynasty:korean_gim_pungsang.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Pungsang" }
+	dynasty:korean_gim_silla.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Silla" }
+	dynasty:korean_gim_suncheon.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Suncheon" }
+	dynasty:korean_gim_yeonan.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Yeonan" }
+	dynasty:korean_gim_yeongdong.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Yeongdong" }
+	dynasty:korean_gim_yeonggwang.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Yeonggwang" }
+	dynasty:korean_gim_ulleong.dynasty_founder.house ?= { set_house_name = "dynn_Gim_Ulleong" }
+	# Go
+	dynasty:balhae_go.dynasty_founder.house ?= { set_house_name = "dynn_Go_Balhae" }
+	dynasty:korean_go_goguryeo.dynasty_founder.house ?= { set_house_name = "dynn_Go_Goguryeo" }
+	dynasty:korean_go_jeju.dynasty_founder.house ?= { set_house_name = "dynn_Go_Jeju" }
+	# Gwak
+	dynasty:korean_gwak_cheongju.dynasty_founder.house ?= { set_house_name = "dynn_Gwak_Cheongju" }
+	# Gwon
+	dynasty:korean_gwon_andong.dynasty_founder.house ?= { set_house_name = "dynn_Gwon_Andong" }
+	# Gyeon
+	dynasty:korean_gyeon_gaeunhyeon.dynasty_founder.house ?= { set_house_name = "dynn_Gyeon_Gaeunhyeon" }
+	# Gyeong
+	dynasty:korean_gyeong_cheongju.dynasty_founder.house ?= { set_house_name = "dynn_Gyeong_Cheongju" }
+	# Han
+	dynasty:korean_han.dynasty_founder.house ?= { set_house_name = "dynn_Han_Gaeseong" }
+	dynasty:korean_han_daeheung.dynasty_founder.house ?= { set_house_name = "dynn_Han_Daeheung" }
+	dynasty:korean_han_2.dynasty_founder.house ?= { set_house_name = "dynn_Han_Giju" }
+	# Heo
+	dynasty:korean_heo_gongam.dynasty_founder.house ?= { set_house_name = "dynn_Heo_Gongam" }
+	# Hong
+	dynasty:korean_hong_namyang.dynasty_founder.house ?= { set_house_name = "dynn_Hong_Namyang" }
+	# Hwangbo
+	dynasty:korean_hwangbo.dynasty_founder.house ?= { set_house_name = "dynn_Hwangbo_Hwangju" }
+	# I
+	dynasty:korean_i_cheongju.dynasty_founder.house ?= { set_house_name = "dynn_I_Cheongju" }
+	dynasty:korean_i_gyeongwon.dynasty_founder.house ?= { set_house_name = "dynn_I_Gyeongwon" }
+	dynasty:korean_i_jeongseon.dynasty_founder.house ?= { set_house_name = "dynn_I_Jeongseon" }
+	dynasty:korean_i_jeonju.dynasty_founder.house ?= { set_house_name = "dynn_I_Jeonju" }
+	dynasty:korean_i_gwangjeong.dynasty_founder.house ?= { set_house_name = "dynn_I_Gwangjeong" }
+	dynasty:korean_i_gwangsan.dynasty_founder.house ?= { set_house_name = "dynn_I_Gwangsan" }
+	dynasty:korean_i_soeong.dynasty_founder.house ?= { set_house_name = "dynn_I_Soeong" }
+	dynasty:korean_i_suju.dynasty_founder.house ?= { set_house_name = "dynn_I_Suju" }
+	# Im
+	dynasty:korean_im_jangheung.dynasty_founder.house ?= { set_house_name = "dynn_Im_Jangheung" }
+	# Jang
+	dynasty:korean_jang_andong.dynasty_founder.house ?= { set_house_name = "dynn_Jang_Andong" }
+	# Jeong
+	dynasty:korean_jeong_cheongju.dynasty_founder.house ?= { set_house_name = "dynn_Jeong_Cheongju" }
+	dynasty:korean_jeong_dongnae.dynasty_founder.house ?= { set_house_name = "dynn_Jeong_Dongrae" }
+	dynasty:korean_jeong_haeju.dynasty_founder.house ?= { set_house_name = "dynn_Jeong_Haeju" }
+	# Jo
+	dynasty:korean_jo_hanyang.dynasty_founder.house ?= { set_house_name = "dynn_Jo_Hanyang" }
+	dynasty:korean_jo_wonju.dynasty_founder.house ?= { set_house_name = "dynn_Jo_Wonju" }
+	# Min
+	dynasty:korean_min_hwangryeo.dynasty_founder.house ?= { set_house_name = "dynn_Min_Hwangryeo" }
+	# Mok
+	dynasty:balhae_mok.dynasty_founder.house ?= { set_house_name = "dynn_Mok_Balhae" }
+	# Mun
+	dynasty:balhae_mun.dynasty_founder.house ?= { set_house_name = "dynn_Mun_Balhae" }
+	dynasty:korean_mun_gangneung.dynasty_founder.house ?= { set_house_name = "dynn_Mun_Gangneung" }
+	dynasty:korean_mun_nampyeong.dynasty_founder.house ?= { set_house_name = "dynn_Mun_Nampyeong" }
+	# Myeong
+	dynasty:korean_myeong.dynasty_founder.house ?= { set_house_name = "dynn_Myeong_Gangseo" }
+	# Nan
+	dynasty:balhae_nan.dynasty_founder.house ?= { set_house_name = "dynn_Nan_Balhae" }
+	# O
+	dynasty:balhae_o.dynasty_founder.house ?= { set_house_name = "dynn_O_Balhae" }
+	dynasty:korean_o_gochang.dynasty_founder.house ?= { set_house_name = "dynn_O_Gochang" }
+	dynasty:korean_o_naju.dynasty_founder.house ?= { set_house_name = "dynn_O_Naju" }
+	# Pyeong
+	dynasty:korean_pyeong_chungju.dynasty_founder.house ?= { set_house_name = "dynn_Pyeong_Chungju" }
+	# Ryu
+	dynasty:korean_ryu_jeongju.dynasty_founder.house ?= { set_house_name = "dynn_Ryu_Jeongju" }
+	dynasty:korean_ryu_yeomju.dynasty_founder.house ?= { set_house_name = "dynn_Ryu_Yeomju" }
+	# Seo
+	dynasty:korean_seo_icheon.dynasty_founder.house ?= { set_house_name = "dynn_Seo_Icheon" }
+	# Seop
+	dynasty:balhae_seop.dynasty_founder.house ?= { set_house_name = "dynn_Seop_Balhae" }
+	# Sin
+	dynasty:korean_sin_pyeongsan.dynasty_founder.house ?= { set_house_name = "dynn_Sin_Pyeongsan" }
+	# Song
+	dynasty:korean_song.dynasty_founder.house ?= { set_house_name = "dynn_Song_Ulju" }
+	# Tak
+	dynasty:korean_tak.dynasty_founder.house ?= { set_house_name = "dynn_Tak_Gwangsan" }
+	# Wang
+	dynasty:korean_wang.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Goryeo" }
+	dynasty:korean_wang_haeju.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Haeju" }
+	dynasty:korean_wang_gangneung.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Gangneung" }
+	dynasty:korean_wang_goryeo.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Goryeo" }
+	dynasty:korean_wang_seohae.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Seohae" }
+	# Wi
+	dynasty:balhae_wi.dynasty_founder.house ?= { set_house_name = "dynn_Wi_Balhae" }
+	# Wu
+	dynasty:korean_wu_mokcheon.dynasty_founder.house ?= { set_house_name = "dynn_U_Mokcheon" }
+	# Yang
+	dynasty:balhae_yang.dynasty_founder.house ?= { set_house_name = "dynn_Yang_Balhae" }
+	dynasty:korean_yang_anak.dynasty_founder.house ?= { set_house_name = "dynn_Yang_Anak" }
+	dynasty:korean_yang_wonju.dynasty_founder.house ?= { set_house_name = "dynn_Yang_Wonju" }
+	# Ye
+	dynasty:balhae_ye.dynasty_founder.house ?= { set_house_name = "dynn_Ye_Balhae" }
+	# Yeol
+	dynasty:balhae_yeol.dynasty_founder.house ?= { set_house_name = "dynn_Yeol_Balhae" }
+	# Yeom
+	dynasty:korean_yeom_paju.dynasty_founder.house ?= { set_house_name = "dynn_Yeom_Paju" }
+	# Yeon
+	dynasty:balhae_yeon.dynasty_founder.house ?= { set_house_name = "dynn_Yeon_Balhae" }
+	dynasty:korean_yeon_goguryeo.dynasty_founder.house ?= { set_house_name = "dynn_Yeon_Goguryeo" }
+	# Yu
+	dynasty:korean_yu.dynasty_founder.house ?= { set_house_name = "dynn_Yu_Goryeo" }
+	dynasty:korean_yu_chungju.dynasty_founder.house ?= { set_house_name = "dynn_Yu_Chungju" }
+	dynasty:korean_yu_pyeongsan.dynasty_founder.house ?= { set_house_name = "dynn_Yu_Pyeongsan" }
+	# Yun
+	dynasty:korean_yun_papyeong.dynasty_founder.house ?= { set_house_name = "dynn_Yun_Papyeong" }
+}

--- a/common/scripted_effects/10_dlc_tgp_japan_scripted_effects.txt
+++ b/common/scripted_effects/10_dlc_tgp_japan_scripted_effects.txt
@@ -532,7 +532,9 @@ japanese_become_shogun_reward_effect = {
 	add_legitimacy = monumental_legitimacy_gain
 	add_realm_law = japanese_bureaucracy_1
 	dynasty = { add_dynasty_prestige = monumental_dynasty_prestige_gain }
-	culture = {
+	#culture = { #Unop Apply to all Japonic-heritage cultures, not just decision-taker's
+	every_culture_global = {
+		limit = { has_cultural_pillar = heritage_japonic }
 		if = {
 			limit = { has_cultural_tradition = tradition_tgp_imperial_peace }
 			custom_tooltip = {
@@ -4086,7 +4088,7 @@ tgp_dynasty_house_name_setup_effect = {
 	dynasty:korean_tak.dynasty_founder.house ?= { set_house_name = "dynn_Tak_Gwangsan" }
 	# Wang
 	dynasty:korean_wang.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Goryeo" }
-	dynasty:korean_wang_haeju.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Haeju" }
+	#dynasty:korean_wang_haeju.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Haeju" } #Unop Dynasty korean_wang_haeju is commented out in vanilla
 	dynasty:korean_wang_gangneung.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Gangneung" }
 	dynasty:korean_wang_goryeo.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Goryeo" }
 	dynasty:korean_wang_seohae.dynasty_founder.house ?= { set_house_name = "dynn_Wang_Seohae" }


### PR DESCRIPTION
Fixes #417

Two related vanilla bugs in major-decision scripted effects that hardcode a single culture instead of iterating the heritage pillar the decision is gated on.

### Bug A — `form_carolingian_empire_scripted_effect`
`reform_carolingian_empire_decision` is gated by `culture = { has_cultural_pillar = heritage_frankish }`, so any Frankish-heritage culture (Occitan, German, Dutch, Flemish, etc.) can take it — but the effect grants `innovation_knighthood`, `innovation_royal_prerogative`, and `innovation_heraldry` only to `culture:french`.

Mirror the Italian unification pattern (`roman_restoration.0140`): iterate `every_culture_global` filtered by `has_cultural_pillar = heritage_frankish`.

### Bug B — `japanese_become_shogun_reward_effect`
Formalize Shogunate has no culture restriction on the decision, but the Imperial Peace → Bushido swap (or Bushido unlock) only ran on the decision taker's own culture. A ruler who hybridized/diverged/converted before taking the decision left their Japanese vassals stuck on Fragile Peace forever, since the swap never reached the other Japonic-heritage cultures in the realm.

Replace the inner `culture = { ... }` scope with `every_culture_global = { limit = { has_cultural_pillar = heritage_japonic } ... }` doing the same swap-or-tooltip work.

### Incidental
The new vanilla copy of `10_dlc_tgp_japan_scripted_effects.txt` surfaced a tiger error: `tgp_dynasty_house_name_setup_effect` references `dynasty:korean_wang_haeju`, which is commented out in vanilla `common/dynasties/05_tgp_dynasties.txt`. The call uses `?=` so it's a silent no-op in-game; commented out here too to keep tiger clean.

`make tiger` reports no new errors or warnings introduced by this change.