### PR TITLE
Add missing action_join_tributary_warcombined_label loc key

### DIFF
--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -246,6 +246,8 @@
  activity_imperial_examination_predicted_cost:0 "The cost of a [GetActivityType( 'activity_imperial_examination' ).GetNameNoTooltip] is primarily affected by the [activity_options|E] you select."
  #Exists but as action_join_tributary_war_combined_group_label
  action_join_tributary_warcombined_group_label:0 "$action_join_tributary_war_combined_group_label$"
+ #Exists but as action_join_tributary_war_combined_label
+ action_join_tributary_warcombined_label:0 "$action_join_tributary_war_combined_label$"
 
  strong_test_hook: "Strong Test Hook"
  perpetual_test_hook: "Perpetual Test Hook"


### PR DESCRIPTION
Refs #284 (#3477963837)

Adds the missing `action_join_tributary_warcombined_label` loc key, which was rendered raw in the "Current Situation" panel under "You can Join Wars".

Vanilla defines `action_join_tributary_war_combined_label` (with underscore between `war` and `combined`), but the engine asks for the underscore-stripped form. Unop already covers the matching `_group_label` variant in the same way; this commit adds the row-level companion.