### PR TITLE
Fix adopted bastard losing house when secret is exposed

### DIFF
--- a/common/scripted_effects/00_secret_effects.txt
+++ b/common/scripted_effects/00_secret_effects.txt
@@ -1419,7 +1419,10 @@ secret_exposed_owner_effects_effect = {
 		}
 
 		# Child gains the Disputed Heritage trait
-		scope:child = { add_trait = disputed_heritage }
+		if = { #Unop: Skip if the child has been adopted; the adoption has rebound them to a new family
+			limit = { scope:child = { NOT = { has_character_flag = unop_was_adopted } } }
+			scope:child = { add_trait = disputed_heritage }
+		}
 
 		# Biological parents, if alive, suffer penalties from adultery.
 		if = {
@@ -1482,10 +1485,13 @@ secret_exposed_owner_effects_effect = {
 			}
 		}
 		# Set the correct Father for the child
-		scope:child = {
-			set_father = scope:real_father
-			set_parent_house_effect = yes
-			remove_inherited_descendent_traits_effect = yes
+		if = { #Unop: Skip if the child has been adopted; the adoption has rebound them to a new family
+			limit = { scope:child = { NOT = { has_character_flag = unop_was_adopted } } }
+			scope:child = {
+				set_father = scope:real_father
+				set_parent_house_effect = yes
+				remove_inherited_descendent_traits_effect = yes
+			}
 		}
 
 		#Father becomes adulterer/fornicator (mother already suffered these penalties when she was discovered pregnant out of wedlock)

--- a/common/scripted_effects/00_secret_effects.txt
+++ b/common/scripted_effects/00_secret_effects.txt
@@ -1,0 +1,2467 @@
+﻿#Scripted effects relating to secrets
+
+#####################################################################
+# EFFECT LIST
+#####################################################################
+# !!! Remember to add all new effects with a short description here !!!
+
+#BLACKMAIL
+#blackmail_target_with_secret_effect	- adds a blackmail strong or weak blackmail hook for current scope against TARGET based on SECRET type, always use with "is_blackmailable_secret_trigger"
+
+#SECRET HANDLING
+#give_incest_secret_or_nothing_effect 	- adds incest secret if incest is shunned in my or liege's faith
+#give_incest_secret_or_nothing_with_target_effect 	- adds incest secret if relation with target is incest in my or liege's faith
+#give_witch_secret_or_trait_effect 		- trait if accepted, secret if not
+#give_deviant_secret_or_trait_effect	- trait if accepted, secret if not
+#give_cannibal_secret_or_trait_effect 	- trait if accepted, secret if not
+#give_homosexual_secret_or_nothing_effect - nothing if accepted, secret if not
+#give_homosexual_secret_or_nothing_with_target_effect - nothing if accepted, secret if relation with target is sodomy
+#add_adulterer_trait_or_nothing_effect  - adds trait is married and adultery is shunned/criminal, otherwise nothing
+#add_fornicator_trait_or_nothing_effect - adds trait if unmarried and adultery is shunned/criminal, otherwise nothing
+#add_adulterer_fornicator_trait_or_nothing_effect - add fornicator/adulterer trait if shunned/criminal, otherwise nothing
+#add_kinslayer_trait_or_nothing_effect	- adds kinslayer_1/2/3 trait or nothing (if kinslaying is accepted)
+
+#SECRET DISCOVERY
+#reveal_to_without_events_effect - this effect should
+
+#SECRET EXPOSURE
+#secret_exposed_notification_effect 	- sends events and feed messages
+#remove_piety_level_for_shunned_or_criminal_trait_effect	- removes a piety level if the trait is shunned/criminal
+#secret_exposed_owner_effects_effect	- applies traits etc. when a secret is revaled
+#secret_exposed_notification_effects_effect	- shows a tooltip for adding traits etc. when a secret is revealed
+#secret_exposed_effects_effect			- applies the correct effect for
+
+# LOVER SECRETS: INFIDELITY CONFRONTATION
+# start_infidelity_confrontation_story_discovery_effect - Creates a story about confrontations/choices after discovered infidelity (lover secret discovery)
+# start_infidelity_confrontation_story_exposure_effect 	- Creates a story about confrontations/choices after discovered infidelity (lover secret exposure)
+# infidelity_confrontation_story_add_to_list_effect 	- Support effect for building lists in "start_infidelity_confrontation_story_exposure_effect"
+# infidelity_confrontation_story_creation_effect 		- Support for "start_infidelity_confrontation_story_exposure/discovery_effect" for creating the story
+
+# MISC
+#give_random_secret_effect 				- for testing
+#give_random_likely_secret_effect
+
+
+
+
+######################################################################
+# EFFECTS
+######################################################################
+
+
+####BLACKMAIL####
+
+#adds a blackmail strong or weak blackmail hook for current scope against TARGET based on SECRET type
+#Always use with is_blackmailable_secret_trigger
+blackmail_target_with_secret_effect = {
+	if = {
+		limit = {
+			$SECRET$ = { is_criminal_for = $TARGET$ }
+			can_add_hook = {
+				target = $TARGET$
+				type = strong_blackmail_hook
+			}
+		}
+		add_hook = {
+			target = $TARGET$
+			type = strong_blackmail_hook
+			secret = $SECRET$
+		}
+	}
+	else_if = {
+		limit = {
+			$SECRET$ = { is_shunned_for = $TARGET$ }
+			can_add_hook = {
+				target = $TARGET$
+				type = weak_blackmail_hook
+			}
+		}
+		add_hook = {
+			target = $TARGET$
+			type = weak_blackmail_hook
+			secret = $SECRET$
+		}
+	}
+}
+
+
+###SECRET HANDLING###
+
+
+give_incest_secret_or_nothing_effect = {
+	save_temporary_scope_as = incest_character
+	if = {
+		limit = {
+			NOR = {
+				has_trait = incestuous
+				any_secret = { type = secret_incest }
+			}
+			is_adult = yes
+			trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:incestuous GENDER_CHARACTER = scope:incest_character }
+		}
+		add_secret = {
+			type = secret_incest
+		}
+	}
+}
+
+give_incest_secret_or_nothing_with_target_effect = { #Should only add secret to one character!
+	if = {
+		limit = { relation_with_character_is_incestuous_in_my_or_lieges_faith_trigger = { CHARACTER = $CHARACTER$ } }
+		give_incest_secret_or_nothing_effect = yes  #Checks my and liege's faith
+	}
+}
+
+
+give_witch_secret_or_trait_effect = {
+	save_temporary_scope_as = witch_character
+	if = {
+		limit = { #Not already a witch
+			NOR = {
+				has_trait = witch
+				any_secret = { type = secret_witch }
+			}
+		}
+		if = {
+			limit = {
+				trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:witch GENDER_CHARACTER = scope:witch_character }
+			}
+			add_secret = {
+				type = secret_witch
+			}
+			random_secret = {
+				type = secret_witch
+				save_scope_as = witch_secret
+			}
+			# If you have a legend maybe we change it?
+			if = {
+				limit = {
+					has_legend_chapter_trigger = { CHAPTER = opening }
+				}
+				random = {
+					chance = 10
+					send_interface_toast = {
+						title = legend_chapter_change_toast
+						left_icon = root
+						promoted_legend = {
+							set_legend_chapter = {
+								name = opening
+								localization_key = legend_chapter_opening_witch
+							}
+						}
+					}
+				}
+			}
+		}
+		else = {
+			add_trait = witch
+			# If you have a legend maybe we change it?
+			if = {
+				limit = {
+					has_legend_chapter_trigger = { CHAPTER = opening }
+				}
+				random = {
+					chance = 10
+					send_interface_toast = {
+						title = legend_chapter_change_toast
+						left_icon = root
+						promoted_legend = {
+							set_legend_chapter = {
+								name = opening
+								localization_key = legend_chapter_opening_witch
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+remove_witch_secret_or_trait_effect = {
+	save_temporary_scope_as = witch_character
+	if = {
+		limit = { #Is already a witch
+			OR = {
+				has_trait = witch
+				any_secret = { type = secret_witch }
+			}	
+		}
+		if = {
+			limit = {
+				has_trait = witch
+			}
+			remove_trait = witch
+		}
+		else = {
+			random_secret = {
+				type = secret_witch
+				remove_secret = yes
+			}
+		}
+	}	
+}
+
+give_deviant_secret_or_trait_effect = {
+	save_temporary_scope_as = deviant_character
+	if = {
+		limit = { #Not already a deviant
+			is_adult = yes
+			NOR = {
+				has_trait = deviant
+				any_secret = { type = secret_deviant }
+			}
+		}
+		if = {
+			limit = {
+				trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:deviant GENDER_CHARACTER = scope:deviant_character }
+			}
+			add_secret = {
+				type = secret_deviant
+			}
+		}
+		else_if = {
+			limit = {
+				is_adult = yes
+			}
+			add_trait = deviant
+		}
+	}
+}
+
+give_cannibal_secret_or_trait_effect = {
+	save_temporary_scope_as = cannibal_character
+	if = {
+		limit = { #Not already a cannibal
+			NOR = {
+				has_trait = cannibal
+				any_secret = { type = secret_cannibal }
+			}
+		}
+		if = {
+			limit = {
+				trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:cannibal GENDER_CHARACTER = scope:cannibal_character }
+			}
+			add_secret = {
+				type = secret_cannibal
+			}
+		}
+		else = {
+			add_trait = cannibal
+		}
+	}
+}
+
+remove_cannibal_secret_or_trait_effect = {
+	save_temporary_scope_as = cannibal_character
+	if = {
+		limit = { #Is already a cannibal
+			OR = {
+				has_trait = cannibal
+				any_secret = { type = secret_cannibal }
+			}	
+		}
+		if = {
+			limit = {
+				has_trait = cannibal
+			}
+			remove_trait = cannibal
+		}
+		else = {
+			random_secret = {
+				type = secret_cannibal
+				remove_secret = yes
+			}
+		}
+	}
+}
+
+give_homosexual_secret_or_nothing_effect = {
+	save_temporary_scope_as = homosexual_character
+	if = {
+		limit = { #Not already a known/secret sodomite and can become one
+			is_adult = yes
+			NOR = {
+				has_trait = sodomite
+				any_secret = { type = secret_homosexual }
+			}
+			is_male = yes
+			trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:sodomite GENDER_CHARACTER = scope:homosexual_character }
+		}
+		add_secret = {
+			type = secret_homosexual
+		}
+	}
+}
+
+give_homosexual_secret_or_nothing_with_target_effect = { #Should only add secret to one character!
+	if = {
+		limit = {
+			is_adult = yes
+			is_male = yes
+			$CHARACTER$ = {
+				is_adult = yes
+				is_male = yes
+			}
+		}
+		give_homosexual_secret_or_nothing_effect = yes  #Checks my and liege's faith
+	}
+}
+
+give_non_believer_secret_effect = {
+	add_secret = {
+		type = secret_non_believer
+	}
+}
+
+add_adulterer_trait_or_nothing_effect = {
+	save_scope_as = adulterer_check
+	if = {
+		limit = {
+			is_married = yes
+			trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:adulterer GENDER_CHARACTER = scope:adulterer_check }
+		}
+		add_trait_force_tooltip = adulterer
+	}
+}
+
+add_fornicator_trait_or_nothing_effect = {
+	save_scope_as = fornicator_check
+	if = {
+		limit = {
+			is_adult = yes
+			is_married = no
+			trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:fornicator GENDER_CHARACTER = scope:fornicator_check }
+		}
+		add_trait_force_tooltip = fornicator
+	}
+}
+
+add_adulterer_fornicator_trait_or_nothing_effect = {
+	if =  {
+		limit = { is_married = yes }
+		add_adulterer_trait_or_nothing_effect = yes
+	}
+	else_if = {
+		limit = {
+			is_adult = yes
+		}
+		add_fornicator_trait_or_nothing_effect = yes
+	}
+}
+
+add_kinslayer_trait_or_nothing_effect = {
+	save_scope_as = slayer
+	if = {
+		limit = {
+			murdering_character_is_kinslaying_in_my_or_same_dynasty_lieges_faith_trigger = { CHARACTER = $VICTIM$ }
+		}
+		if = {
+			limit = {
+				is_close_family_of = $VICTIM$
+			}
+			if = {
+				limit = { this = scope:slayer }
+				set_trait_rank = {
+					trait = kinslayer
+					rank = 3
+				}
+				remove_piety_level_for_shunned_or_criminal_trait_effect = { TRAIT = trait:kinslayer_3 }
+			}
+			else = {
+				add_trait_force_tooltip = kinslayer_3 #This is to make sure trait appears in notification messages for other characters
+			}
+		}
+		else_if = {
+			limit = {
+				is_extended_family_of = $VICTIM$
+			}
+			if = {
+				limit = { this = scope:slayer }
+				set_trait_rank = {
+					trait = kinslayer
+					rank = 2
+				}
+				remove_piety_level_for_shunned_or_criminal_trait_effect = { TRAIT = trait:kinslayer_2 }
+			}
+			else = {
+				add_trait_force_tooltip = kinslayer_2 #This is to make sure trait appears in notification messages for other characters
+			}
+		}
+		else_if = {
+			limit = {
+				dynasty ?= $VICTIM$.dynasty
+			}
+			if = {
+				limit = { this = scope:slayer }
+				set_trait_rank = {
+					trait = kinslayer
+					rank = 1
+				}
+				remove_piety_level_for_shunned_or_criminal_trait_effect = { TRAIT = trait:kinslayer_1 }
+			}
+			else = {
+				add_trait_force_tooltip = kinslayer_1 #This is to make sure trait appears in notification messages for other characters
+			}
+		}
+	}
+}
+
+give_or_update_embezzler_secret_effect = {
+	# Either try to add a new embezzler secret.
+	if = {
+		limit = {
+			NOT = {
+				any_secret = {
+					type = secret_embezzler
+					secret_target = $TARGET$
+				}
+			}
+		}
+		add_secret = {
+			type = secret_embezzler
+			target = $TARGET$
+		}
+		random_secret = {
+			type = secret_embezzler
+			limit = {
+				secret_target = $TARGET$
+			}
+			set_variable = {
+				name = embezzlement_stake
+				value = $STAKE$
+			}
+			set_variable = {
+				name = embezzlement_stake_half
+				value = {
+					value = $STAKE$
+					multiply = 0.5
+				}
+			}
+		}
+	}
+	# Or else increment the existing one.
+	else = {
+		random_secret = {
+			type = secret_embezzler
+			limit = {
+				secret_target = $TARGET$
+				has_variable = embezzlement_stake
+			}
+			change_variable = {
+				name = embezzlement_stake
+				add = $STAKE$
+			}
+			change_variable = {
+				name = embezzlement_stake_half
+				add = {
+					value = $STAKE$
+					multiply = 0.5
+				}
+			}
+		}
+	}
+}
+
+forgive_exposed_embezzler_effect = {
+	# Let 'em know they're off the hook.
+	scope:embezzler = {
+		# Very kind of you, old chap.
+		add_opinion = {
+			target = root
+			modifier = grateful_opinion
+			opinion = $OPINION$
+		}
+		send_interface_toast = {
+			title = secrets.0122.c.tt
+			left_icon = root
+			root = {
+				if = {
+					limit = {
+						scope:secret = {
+							secret_type = secret_embezzler
+						}
+					}
+					remove_opinion = {
+						target = scope:embezzler
+						modifier = embezzled_opinion
+					}
+				}
+				else = {
+					remove_opinion = {
+						target = scope:embezzler
+						modifier = siphoned_treasury_crime
+					}
+				}
+			}
+		}
+	}
+}
+
+give_coup_plotter_secret_effect = {
+	if = {
+		limit = {
+			NOT = {
+				any_secret = {
+					type = secret_coup_plotter
+					secret_target = $TARGET$
+				}
+			}
+		}
+		add_secret = {
+			type = secret_coup_plotter
+			target = $TARGET$
+		}
+		random_secret = {
+			type = secret_coup_plotter
+			limit = {
+				secret_target = $TARGET$
+			}
+		}
+	}
+}
+
+
+###SECRET DISCOVERY###
+
+reveal_to_without_events_effect = {
+	if = {
+		limit = { secret_type = secret_disputed_heritage }
+		$CHARACTER$ = {
+			add_character_flag = {
+				flag = block_secret_disputed_heritage_discovery_event
+				days = 20
+			}
+		}
+	}
+	else_if = {
+		limit = { secret_type = secret_unmarried_illegitimate_child }
+		$CHARACTER$ = {
+			add_character_flag = {
+				flag = block_secret_unmarried_illegitimate_child_discovery_event
+				days = 20
+			}
+		}
+	}
+	else_if = {
+		limit = { secret_type = secret_murder_attempt }
+		$CHARACTER$ = {
+			add_character_flag = {
+				flag = block_secret_murder_attempt_discovery_event
+				days = 20
+			}
+		}
+	}
+	else_if = {
+		limit = { secret_type = secret_murder }
+		$CHARACTER$ = {
+			add_character_flag = {
+				flag = block_secret_murder_discovery_event
+				days = 20
+			}
+		}
+	}
+	else_if = {
+		limit = { secret_type = secret_lover }
+		#Cannot block because the event is mechanical.
+		#You can reveal a lover secret and add a variable to it to get special texts. Check out the story_cycle_infidelty_confronter
+	}
+	reveal_to = $CHARACTER$
+}
+
+###SECRET EXPOSURE EFFECTS###
+
+#Support effect for secret_exposed_notification_effect
+save_list_targets_for_secret_exposure_events_effect = {
+	every_spouse = {
+		limit = {
+			show_me_exposed_secret_event_trigger = { SECRET = $SECRET$ CHARACTER = $CHARACTER$ }
+		}
+		add_to_list = send_exposed_secret_event_list
+	}
+	every_close_family_member = {
+		limit = {
+			show_me_exposed_secret_event_trigger = { SECRET = $SECRET$ CHARACTER = $CHARACTER$ }
+			NOT = {
+				any_in_list = { #These checks should remain here and not be in the scripted triggers
+					list = send_exposed_secret_event_list
+					this = prev
+				}
+			}
+		}
+		add_to_list = send_exposed_secret_event_list
+	}
+	every_relation = {
+		type = friend
+		limit = {
+			show_me_exposed_secret_event_trigger = { SECRET = $SECRET$ CHARACTER = $CHARACTER$ }
+			NOT = {
+				any_in_list = { #These checks should remain here and not be in the scripted triggers
+					list = send_exposed_secret_event_list
+					this = prev
+				}
+			}
+		}
+		add_to_list = send_exposed_secret_event_list
+	}
+	every_relation = {
+		type = lover
+		limit = {
+			show_me_exposed_secret_event_trigger = { SECRET = $SECRET$ CHARACTER = $CHARACTER$ }
+			NOT = {
+				any_in_list = { #These checks should remain here and not be in the scripted triggers
+					list = send_exposed_secret_event_list
+					this = prev
+				}
+			}
+		}
+		add_to_list = send_exposed_secret_event_list
+	}
+	every_relation = {
+		type = rival
+		limit = {
+			show_me_exposed_secret_event_trigger = { SECRET = $SECRET$ CHARACTER = $CHARACTER$ }
+			NOT = {
+				any_in_list = { #These checks should remain here and not be in the scripted triggers
+					list = send_exposed_secret_event_list
+					this = prev
+				}
+			}
+		}
+		add_to_list = send_exposed_secret_event_list
+	}
+	every_relation = {
+		type = blood_brother
+		limit = {
+			show_me_exposed_secret_event_trigger = { SECRET = $SECRET$ CHARACTER = $CHARACTER$ }
+			NOT = {
+				any_in_list = { #These checks should remain here and not be in the scripted triggers
+					list = send_exposed_secret_event_list
+					this = prev
+				}
+			}
+		}
+		add_to_list = send_exposed_secret_event_list
+	}
+}
+
+save_extra_lover_list_targets_for_secret_exposure_events_effect = {
+	scope:target = {
+		if = {
+			limit = {
+				any_secret = {
+					type = secret_lover
+					secret_target = scope:owner
+				}
+			}
+			save_temporary_scope_as = secret_character
+			#Save spouses, close family members, liege and anyone they are primary heir of
+			random_secret = {
+				type = secret_lover
+				limit = {
+					secret_target = scope:owner
+				}
+				save_scope_as = targets_secret
+			}
+			save_list_targets_for_secret_exposure_events_effect = { SECRET = scope:targets_secret CHARACTER = scope:secret_character }
+		}
+	}
+}
+
+save_extra_bastard_list_targets_for_secret_exposure_events_effect = {
+	#Those who care about child
+	if = {
+		limit = {
+			exists = scope:child
+			scope:owner != scope:child #Child hasn't inherited the secret
+		}
+		scope:target = {
+			save_temporary_scope_as = secret_character
+			save_list_targets_for_secret_exposure_events_effect = { SECRET = scope:secret CHARACTER = scope:secret_character }
+		}
+	}
+	#Those who care about real father
+	if = {
+		limit = {
+			exists = scope:real_father
+			scope:owner != scope:real_father #Real_father hasn't inherited the secret
+		}
+		scope:real_father = {
+			save_temporary_scope_as = secret_character
+			save_list_targets_for_secret_exposure_events_effect = { SECRET = scope:secret CHARACTER = scope:secret_character }
+		}
+	}
+	#Those who care about mother
+	if = {
+		limit = {
+			exists = scope:mother
+			scope:owner != scope:mother #Mother doesn't have secret anymore (dead)
+		}
+		scope:mother = {
+			save_temporary_scope_as = secret_character
+			save_list_targets_for_secret_exposure_events_effect = { SECRET = scope:secret CHARACTER = scope:secret_character }
+		}
+	}
+	#Make sure father is in there
+	if = {
+		limit = {
+			exists = scope:father
+			scope:father = { show_me_exposed_secret_event_trigger = { SECRET = scope:secret CHARACTER = scope:secret_character } }
+		}
+		scope:father = { add_to_list = send_exposed_secret_event_list }
+	}
+}
+
+#Support effect for secret_exposed_notification_effect
+save_list_targets_for_secret_exposure_feed_messages_effect = {
+	$SECRET$ = {
+		every_secret_knower = {
+			limit = {
+				show_me_exposed_secret_feed_message_trigger = { SECRET = $SECRET$ CHARACTER = $CHARACTER$ }
+				NOR = {
+					any_in_list = { #These checks should remain here and not be in the scripted triggers
+						list = send_exposed_secret_event_list
+						this = prev
+					}
+					any_in_list = {
+						list = send_exposed_secret_feed_message_list
+						this = prev
+					}
+				}
+			}
+			add_to_list = send_exposed_secret_feed_message_list
+		}
+	}
+}
+
+#Support effect for secret_exposed_notification_effect
+save_additional_lover_secret_list_targets_for_feed_messages_effect = {
+	#If it's a sodomy lover relation, also tell people who know of my sodomy secret
+	if = {
+		limit = { relation_with_character_is_sodomy_in_my_or_lieges_faith_trigger = { CHARACTER = scope:other_lover } }
+		random_secret = {
+			type = secret_homosexual
+			every_secret_knower = {
+				limit = {
+					show_me_exposed_secret_feed_message_trigger = { SECRET = scope:secret CHARACTER = scope:owner }
+					NOR = {
+						any_in_list = { #These checks should remain here and not be in the scripted triggers
+							list = send_exposed_secret_event_list
+							this = prev
+						}
+						any_in_list = {
+							list = send_exposed_secret_feed_message_list
+							this = prev
+						}
+					}
+				}
+				add_to_list = send_exposed_secret_feed_message_list
+			}
+		}
+	}
+	#If it's a incest lover relation, also tell people who know of my incest secret
+	if = {
+		limit = { relation_with_character_is_incestuous_in_my_or_lieges_faith_trigger = { CHARACTER = scope:other_lover } }
+		random_secret = {
+			type = secret_incest
+			every_secret_knower = {
+				limit = {
+					show_me_exposed_secret_feed_message_trigger = { SECRET = scope:secret CHARACTER = scope:owner }
+					NOR = {
+						any_in_list = { #These checks should remain here and not be in the scripted triggers
+							list = send_exposed_secret_event_list
+							this = prev
+						}
+						any_in_list = {
+							list = send_exposed_secret_feed_message_list
+							this = prev
+						}
+					}
+				}
+				add_to_list = send_exposed_secret_feed_message_list
+			}
+		}
+	}
+}
+
+#Used to notify everyone who cares about secret owner/target (and additional characters of interest) about secret + effects
+secret_exposed_notification_effect = {
+	save_scope_as = secret
+	secret_owner = {
+		save_scope_as = owner
+	}
+	if = {
+		limit = { exists = secret_target }
+		secret_target = { save_scope_as = target }
+	}
+
+
+	#### Visible events for those who care and knower of landed people's secrets ###
+
+	#Save spouses, close family members, liege and anyone whom I am primary heir of
+	scope:owner = {
+		save_list_targets_for_secret_exposure_events_effect = { SECRET = scope:secret CHARACTER = scope:owner }
+	}
+
+	#If it's a lover secret, tell people who cares about the target as well
+	if = {
+		limit = { scope:secret = { secret_type = secret_lover } }
+		save_extra_lover_list_targets_for_secret_exposure_events_effect = yes
+	}
+
+	#If it's a bastard secret, tell people who cares about child/real_father as well
+	else_if = {
+		limit  = {
+			scope:secret = {
+				OR = {
+					secret_type = secret_disputed_heritage
+					secret_type = secret_unmarried_illegitimate_child
+				}
+			}
+		}
+		save_extra_bastard_list_targets_for_secret_exposure_events_effect = yes
+	}
+
+	#If it's a murder/murder attempt secret, also inform those who care about victim
+	else_if = {
+		limit = {
+			scope:secret = {
+				OR = {
+					secret_type = secret_murder_attempt
+					secret_type = secret_murder
+				}
+			}
+		}
+
+		scope:victim = { save_list_targets_for_secret_exposure_events_effect = { SECRET = scope:secret CHARACTER = scope:victim } }
+	}
+
+	#If it's a secret faith, save the faith
+	else_if = {
+		limit = {
+			scope:secret = { secret_type = secret_crypto_religionist }
+		}
+		scope:owner.secret_faith = { save_scope_as = crypto_faith }
+	}
+
+	#Send the notification event
+	every_in_list = {
+		list = send_exposed_secret_event_list
+
+		if = {
+			limit = {
+				scope:secret = { secret_type = secret_incest }
+			}
+			trigger_event = secrets.0106
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_witch }
+			}
+			trigger_event = secrets.0107
+		}
+		else_if = {
+			limit = {
+				scope:secret = {
+					OR = {
+						secret_type = secret_embezzler
+						secret_type = secret_siphoned_treasury					
+					}
+				}
+			}
+			trigger_event = secrets.0122
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_cannibal }
+			}
+			trigger_event = secrets.0104
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_non_believer }
+			}
+			trigger_event = secrets.0105
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_homosexual }
+			}
+			trigger_event = secrets.0103
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_lover }
+			}
+			trigger_event = secrets.0108
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_deviant }
+			}
+			trigger_event = secrets.0101
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_disputed_heritage }
+			}
+			trigger_event = secrets.0110
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_unmarried_illegitimate_child }
+			}
+			trigger_event = secrets.0112
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_murder_attempt }
+			}
+			trigger_event = secrets.0116
+		}
+		else_if = {
+			limit = {
+				scope:secret = { secret_type = secret_murder }
+			}
+			if = {
+				limit = {
+					scope:secret = { has_variable = known_murder }
+				}
+				add_death_event_blocker_effect = { DEAD = scope:victim }
+			}
+			trigger_event = secrets.0118
+		}
+		else = {
+			add_to_list = send_exposed_secret_feed_message_list
+		}
+	}
+
+	### Sending feed messages to other characters who care ###
+	scope:owner = {
+		#Save secret knowers and extended family members for feed messages
+		save_list_targets_for_secret_exposure_feed_messages_effect = { SECRET = scope:secret CHARACTER = scope:owner }
+	}
+
+	#Extra stuff for lover secrets
+	if = {
+		limit = { scope:secret = { secret_type = secret_lover } }
+		secret_owner = {
+			#Also send feed messages who know about my sodomy/incest secret if relation is homosexual/incestuous
+			scope:target = { save_temporary_scope_as = other_lover }
+			save_additional_lover_secret_list_targets_for_feed_messages_effect = yes
+		}
+
+		#Feed messages for my lover secret target
+		scope:target = {
+			if = {
+				limit = {
+					exists = scope:targets_secret
+				}
+				#Save secret knowers and extended family members for feed messages
+				save_list_targets_for_secret_exposure_feed_messages_effect = { SECRET = scope:targets_secret CHARACTER = scope:target }
+			}
+
+			#Also send feed messages who know about target's sodomy/incest secret if relation is homosexual/incestuous
+			scope:target = { save_temporary_scope_as = other_lover }
+			save_additional_lover_secret_list_targets_for_feed_messages_effect = yes
+		}
+	}
+
+	every_in_list = {
+		list = send_exposed_secret_feed_message_list
+		save_scope_as = secret_expose_feed_message_scope
+
+		send_interface_message = {
+			type = secret_exposed_message
+			left_icon = scope:owner
+			right_icon = scope:target
+			title = secret_exposed_notification_effect_message
+			desc = {
+				first_valid = {
+					triggered_desc = {
+						trigger = { scope:secret = { secret_type = secret_incest } }
+						desc = secret_exposed_notification_effect_message_incest
+					}
+					triggered_desc = {
+						trigger = { scope:secret = { secret_type = secret_witch } }
+						desc = secret_exposed_notification_effect_message_witch
+					}
+					triggered_desc = {
+						trigger = { scope:secret = { secret_type = secret_cannibal } }
+						desc = secret_exposed_notification_effect_message_cannibal
+					}
+					triggered_desc = {
+						trigger = { scope:secret = { secret_type = secret_non_believer } }
+						desc = secret_exposed_notification_effect_message_non_believer
+					}
+					triggered_desc = {
+						trigger = { scope:secret = { secret_type = secret_homosexual } }
+						desc = secret_exposed_notification_effect_message_homosexual
+					}
+					triggered_desc = {
+						trigger = { #Incest lover
+							scope:secret = { secret_type = secret_lover }
+							scope:owner = { relation_with_character_is_incestuous_in_faith_trigger = { CHARACTER = scope:target FAITH = scope:secret_expose_feed_message_scope.faith } }
+						}
+						desc = secret_exposed_notification_effect_message_lover_incest
+					}
+					triggered_desc = {
+						trigger = { #Sodomy lover
+							scope:secret = { secret_type = secret_lover }
+							scope:owner = { relation_with_character_is_sodomy_in_faith_trigger = { CHARACTER = scope:target FAITH = scope:secret_expose_feed_message_scope.faith } }
+						}
+						desc = secret_exposed_notification_effect_message_lover_sodomy
+					}
+					triggered_desc = {
+						trigger = { scope:secret = { secret_type = secret_lover } }
+						desc = secret_exposed_notification_effect_message_lover
+					}
+					triggered_desc = {
+						trigger = { scope:secret = { secret_type = secret_deviant } }
+						desc = secret_exposed_notification_effect_message_deviant
+					}
+					triggered_desc = { #Illegitimate child
+						trigger = {
+							scope:secret = {
+								OR = {
+									secret_type = secret_disputed_heritage
+									secret_type = secret_unmarried_illegitimate_child
+								}
+							}
+						}
+						desc = secret_exposed_notification_effect_message_illegitimate_child
+					}
+					triggered_desc = {
+						trigger = { scope:secret = { secret_type = secret_murder_attempt } }
+						desc = secret_exposed_notification_effect_message_murder_attempt
+					}
+					triggered_desc = {
+						trigger = {
+							scope:secret = { secret_type = secret_murder }
+							scope:owner != scope:secret_exposer
+						}
+						desc = secret_exposed_notification_effect_message_murder
+					}
+					triggered_desc = {
+						trigger = {
+							scope:secret = { secret_type = secret_murder }
+							scope:owner = scope:secret_exposer
+						}
+						desc = secret_exposed_notification_effect_message_known_murder
+					}
+					triggered_desc = {
+						trigger = {
+							scope:secret = { secret_type = secret_crypto_religionist }
+						}
+						desc = secret_exposed_notification_effect_message_faith
+					}
+				}
+			}
+
+			if = {
+				limit = { has_hook_from_secret = scope:secret }
+				if = {
+					limit = {
+						has_hook_of_type = {
+							target = scope:owner
+							type = weak_blackmail_hook
+						}
+					}
+					remove_hook = {
+						target = scope:owner
+						type = weak_blackmail_hook
+					}
+				}
+				else_if = {
+					limit = {
+						has_hook_of_type = {
+							target = scope:owner
+							type = strong_blackmail_hook
+						}
+					}
+					remove_hook = {
+						target = scope:owner
+						type = strong_blackmail_hook
+					}
+				}
+			}
+		}
+	}
+
+	### Send toast to exposer ###
+	if = {
+		limit = {
+			trigger_if = {
+				limit = { exists = scope:target }
+				NOR = {
+					scope:secret_exposer = scope:target
+					scope:secret_exposer = scope:owner
+				}
+			}
+			trigger_else = {
+				scope:secret_exposer != scope:owner
+			}
+		}
+		scope:secret_exposer = {
+			save_scope_as = secret_expose_feed_message_scope
+			send_interface_toast = {
+				left_icon = scope:owner
+				right_icon = scope:target
+				title = secret_exposed_notification_effect_message
+
+				if = {
+					limit = { scope:secret = { secret_type = secret_incest } }
+					custom_tooltip = secret_exposed_notification_effect_message_incest.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_witch } }
+					custom_tooltip = secret_exposed_notification_effect_message_witch.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_cannibal } }
+					custom_tooltip = secret_exposed_notification_effect_message_cannibal.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_non_believer } }
+					custom_tooltip = secret_exposed_notification_effect_message_non_believer.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_homosexual } }
+					custom_tooltip = secret_exposed_notification_effect_message_homosexual.i_exposed
+				}
+				else_if = {
+					limit = { #Incest lover
+						scope:secret = { secret_type = secret_lover }
+						scope:owner = { relation_with_character_is_incestuous_in_faith_trigger = { CHARACTER = scope:target FAITH = scope:secret_expose_feed_message_scope.faith } }
+					}
+					custom_tooltip = secret_exposed_notification_effect_message_lover_incest.i_exposed
+				}
+				else_if = {
+					limit = { #Sodomy lover
+						scope:secret = { secret_type = secret_lover }
+						scope:owner = { relation_with_character_is_sodomy_in_faith_trigger = { CHARACTER = scope:target FAITH = scope:secret_expose_feed_message_scope.faith } }
+					}
+					custom_tooltip = secret_exposed_notification_effect_message_lover_sodomy.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_lover } }
+					custom_tooltip = secret_exposed_notification_effect_message_lover.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_deviant } }
+					custom_tooltip = secret_exposed_notification_effect_message_deviant.i_exposed
+				}
+				else_if = {
+					limit = {
+						scope:secret = {
+							OR = {
+								secret_type = secret_disputed_heritage
+								secret_type = secret_unmarried_illegitimate_child
+							}
+						}
+					}
+					custom_tooltip = secret_exposed_notification_effect_message_illegitimate_child.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_murder_attempt } }
+					custom_tooltip = secret_exposed_notification_effect_message_murder_attempt.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_murder } }
+					custom_tooltip = secret_exposed_notification_effect_message_murder.i_exposed
+				}
+				else_if = {
+					limit = { scope:secret = { secret_type = secret_crypto_religionist } }
+					custom_tooltip = secret_exposed_notification_effect_message_faith.i_exposed
+				}
+
+				if = {
+					limit = { has_hook_from_secret = scope:secret }
+					remove_hook = {
+						target = scope:owner
+						type = weak_blackmail_hook
+					}
+				}
+				
+				if = {
+					limit = {
+						has_government = landless_adventurer_government
+						has_perk = court_of_shadows_perk
+					}
+					add_prestige = {
+						value = 100
+						multiply = {
+							value = scope:owner.highest_held_title_tier
+							add = 1
+						}
+						min = 50
+					}
+				}
+				
+				stress_impact = {
+					honest = medium_stress_impact_loss
+					just = medium_stress_impact_loss
+				}
+				
+				scope:owner = {
+					stress_impact = {
+						honest = medium_stress_impact_loss
+						just = medium_stress_impact_loss
+					}
+				}
+				
+				# If we're a clan this interaction affects unity
+				add_clan_unity_interaction_effect = {
+					CHARACTER = scope:secret_expose_feed_message_scope
+					TARGET = scope:owner
+					VALUE = major_unity_loss
+					DESC = clan_unity_secret_exposure.desc
+					REVERSE_NON_HOUSE_TARGET = no
+				}
+			}
+		}
+	}
+}
+
+remove_piety_level_for_shunned_or_criminal_trait_effect = {
+	save_temporary_scope_as = piety_character
+	if = {
+		limit = {
+			OR = {
+				trait_is_shunned_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = scope:piety_character.faith GENDER_CHARACTER = scope:piety_character }
+				trait_is_criminal_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = scope:piety_character.faith GENDER_CHARACTER = scope:piety_character }
+			}
+		}
+		add_piety_level = -1
+
+		# LEGITIMACY LOSS FROM CRIME EXPOSURE
+		if = {
+			limit = {
+				is_valid_for_legitimacy_change = yes
+				NOT = { exists = scope:suppress_legitimacy_from_crime }
+			}
+			if = {
+				limit = {
+					trait_is_shunned_in_faith_trigger = { TRAIT = $TRAIT$ FAITH = scope:piety_character.faith GENDER_CHARACTER = scope:piety_character }
+				}
+				add_legitimacy = minor_legitimacy_loss
+			}
+			else = { add_legitimacy = medium_legitimacy_loss }
+			# Flag that we might not always want to apply future legitimacy losses down the line.
+			save_scope_value_as = {
+				name = suppress_legitimacy_from_crime
+				value = yes
+			}
+		}
+	}
+}
+
+#Purpose: to make sure trait always appears in tooltip for other characters informed about you gaining trait
+add_trait_only_force_tooltip_if_not_pov_effect = {
+	if = {
+		limit = { this = $POV$ }
+		add_trait = $TRAIT$
+	}
+	else = {
+		add_trait_force_tooltip = $TRAIT$
+	}
+}
+
+remove_trait_only_force_tooltip_if_not_root_effect = {
+	if = {
+		limit = { this = root }
+		remove_trait = $TRAIT$
+	}
+	else = {
+		remove_trait_force_tooltip = $TRAIT$
+	}
+}
+
+#applies traits etc. when a secret is revealed
+#SECRET = secret in question, POV = point of view i.e. who get this event
+secret_exposed_owner_effects_effect = {
+
+	$SECRET$ = {
+		if = {
+			limit = { #Checks to make sure the right target gets saved. Confusion might arise from the secret's "on_expose" effect since it sends the same event (secrets.0008) for both target and owner.
+				exists = secret_target
+				exists = scope:target
+				scope:target = secret_owner
+				NOT = { secret_owner = $POV$ } #To not mess up tooltips (in e.g. secrets.0108)
+			}
+			secret_owner = { save_scope_as = exposed_secret_target }
+		}
+		else_if = {
+			limit = {
+				exists = secret_target
+			}
+			secret_target = { save_scope_as = exposed_secret_target }
+		}
+
+		secret_owner = { save_scope_as = local_secret_owner }
+	}
+
+	###DEVIANT###
+	if = {
+		limit = { $SECRET$ = { secret_type = secret_deviant } }
+		add_trait_only_force_tooltip_if_not_pov_effect = { TRAIT = trait:deviant POV = $POV$ }
+		remove_piety_level_for_shunned_or_criminal_trait_effect = { TRAIT = trait:deviant }
+	}
+	###SODOMITE###
+	else_if = {
+		limit = {
+			$SECRET$ = { secret_type = secret_homosexual }
+			relation_with_character_is_sodomy_in_my_or_lieges_faith_trigger = { CHARACTER = this } #To check your own gender
+		}
+		add_trait_only_force_tooltip_if_not_pov_effect = { TRAIT = trait:sodomite POV = $POV$ }
+		remove_piety_level_for_shunned_or_criminal_trait_effect = { TRAIT = trait:sodomite }
+	}
+	###CANNIBAL###
+	else_if = {
+		limit = { $SECRET$ = { secret_type = secret_cannibal } }
+		add_trait_only_force_tooltip_if_not_pov_effect = { TRAIT = cannibal POV = $POV$ }
+		remove_piety_level_for_shunned_or_criminal_trait_effect = { TRAIT = trait:cannibal }
+	}
+	###NON-BELIEVER###
+	else_if = {
+		limit = { $SECRET$ = { secret_type = secret_non_believer } }
+		add_character_modifier = {
+			modifier = known_non_believer
+			days = 3650
+		}
+		if = {
+			limit = {
+				OR = {
+					has_trait = zealous
+					has_character_flag = non_believer_lost_zealous
+				}
+			}
+			remove_trait_only_force_tooltip_if_not_root_effect = { TRAIT = zealous }
+			add_character_flag = {
+				flag = non_believer_lost_zealous
+				days = 5
+			}
+		}
+		if = {
+			limit = {
+				OR = {
+					number_of_personality_traits < personality_trait_limit
+					has_character_flag =  non_believer_gained_cynical
+				}
+			}
+			add_trait_only_force_tooltip_if_not_pov_effect = { TRAIT = cynical POV = $POV$ }
+			add_character_flag = {
+				flag = non_believer_gained_cynical
+				days = 5
+			}
+		}
+		add_piety_level = -1
+	}
+	###EMBEZZLER###
+	else_if = {
+		limit = {
+			$SECRET$ = { secret_type = secret_embezzler }
+			scope:secret_target = { is_alive = yes }
+		}
+		scope:secret_target = {
+			# Apply appropriate criminal opinion.
+			add_opinion = {
+				target = scope:secret_owner
+				modifier = embezzled_opinion
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			$SECRET$ = { secret_type = secret_siphoned_treasury }
+			scope:secret_target = { is_alive = yes }
+		}
+		scope:secret_target = {
+			add_opinion = {
+				target = scope:secret_owner
+				modifier = siphoned_treasury_crime
+			}
+		}
+	}
+	###INCEST###
+	else_if = {
+		limit = { $SECRET$ = { secret_type = secret_incest } }
+		add_trait_only_force_tooltip_if_not_pov_effect = { TRAIT = incestuous POV = $POV$ }
+		remove_piety_level_for_shunned_or_criminal_trait_effect = { TRAIT = trait:incestuous }
+	}
+	###WITCH###
+	else_if = {
+		limit = { $SECRET$ = { secret_type = secret_witch } }
+		add_trait_only_force_tooltip_if_not_pov_effect = { TRAIT = trait:witch POV = $POV$ }
+		remove_piety_level_for_shunned_or_criminal_trait_effect = { TRAIT = trait:witch }
+	}
+	###LOVER###
+	else_if = {
+		limit = { 
+			$SECRET$ = { secret_type = secret_lover }
+			NOT = {
+				scope:exposed_secret_target = {
+					government_has_flag = government_is_mandala
+					house ?= { has_house_aspiration_parameter = aspect_of_creation }
+				}
+			}
+		}
+
+		#Adds traits (adulterer, fornicator, sodomite, incestuous), removes devotion, sets opinions & rivalry
+		extramarital_sex_exposure_consequences_with_target_effect = { TARGET = scope:exposed_secret_target SPOUSE_EVENT = no }
+	}
+	###DISPUTED HERITAGE###
+	else_if = {
+		limit = {
+			$SECRET$ = {
+				secret_type = secret_disputed_heritage
+			}
+		}
+
+		# Child gains the Disputed Heritage trait
+		scope:child = { add_trait = disputed_heritage }
+
+		# Biological parents, if alive, suffer penalties from adultery.
+		if = {
+			limit = { scope:mother = { is_alive = yes } }
+			scope:mother = {
+				# Comprehensive effect which adds adulter/fornicator/incestuous traits, unfaithfulness & slept with wife opinions, and characters losing the appropriate number of piety level(s).
+				expose_lover_secret_or_run_consequence_effect = {
+					TARGET = scope:real_father
+					EXPOSER = $POV$
+				}
+			}
+		}
+		else_if = { limit = { scope:real_father = { is_alive = yes } }
+			# If the mother is dead, run this on the real_father instead (so it gets run somewhere). If the mother is alive, the real_father will have already suffered the penalties.
+			scope:real_father = {
+				expose_lover_secret_or_run_consequence_effect = {
+					TARGET = scope:mother
+					EXPOSER = $POV$
+				}
+			}
+		}
+
+		# Additional father opinion modifiers
+ 		hidden_effect = {
+ 			# Real father gains opinion of child
+			if = {
+				limit = {
+					scope:real_father = { is_alive = yes }
+				}
+				scope:real_father = {
+					add_opinion = {
+						target = scope:child
+						modifier = truly_of_my_blood_opinion
+					}
+				}
+			}
+
+		 	#Non-real father loses opinion of child
+			if = {
+				limit = {
+					exists = scope:father
+					scope:father = {
+						is_alive = yes
+					}
+				}
+				scope:father = {
+					add_opinion = {
+						target = scope:child
+						modifier = uncertain_lineage_opinion
+					}
+				}
+			}
+		}
+	}
+	###UNKNOWN FATHER###
+	else_if = {
+		limit = {
+			$SECRET$ = {
+				secret_type = secret_unmarried_illegitimate_child
+			}
+		}
+		# Set the correct Father for the child
+		scope:child = {
+			set_father = scope:real_father
+			set_parent_house_effect = yes
+			remove_inherited_descendent_traits_effect = yes
+		}
+
+		#Father becomes adulterer/fornicator (mother already suffered these penalties when she was discovered pregnant out of wedlock)
+		scope:real_father = {
+			if = {
+				limit = { is_alive = yes }
+
+				#Adds adulter/fornicator/incestuous traits, unfaithfulness & slept with wife opinions, removes piety levels
+				expose_lover_secret_or_run_consequence_effect = {
+					TARGET = scope:mother
+					EXPOSER = $POV$
+				}
+			}
+		}
+	}
+
+	###ATTEMPTED MURDERER###
+	else_if = {
+		limit = { $SECRET$ = { secret_type = secret_murder_attempt } }
+
+		#Hide this for everyone else
+		if = {
+			limit = { root = scope:murderer }
+			add_dread = 10
+			hostile_scheme_exposure_legitimacy_effect = yes
+			attempted_murder_opinion_effect = { VICTIM = scope:victim MURDERER = scope:murderer }
+		}
+	}
+	###MURDERER###
+	else_if = {
+		limit = { $SECRET$ = { secret_type = secret_murder } }
+
+ 		#Traits, (crime) opinions, dread
+		murder_consequences_known_or_exposed_effect = {
+			MURDERER = scope:murderer
+			VICTIM = scope:victim
+			POV = $POV$
+		}
+	}
+	else_if = {
+		limit = {
+			$SECRET$ = { secret_type = secret_coup_plotter }
+			scope:secret_target = { is_alive = yes }
+		}
+
+		scope:secret_target = {
+			# Apply appropriate criminal opinion.
+			add_opinion = {
+				target = scope:secret_owner
+				modifier = coup_plotter_opinion
+			}
+		}
+	}
+	###INCURSION###
+	else_if = {
+		limit = {
+			$SECRET$ = { secret_type = secret_request_incursion }
+		}
+		if = {
+			limit = {
+				scope:secret_target = { is_alive = yes }
+			}
+			scope:secret_target = {
+				# Apply appropriate criminal opinion.
+				add_opinion = {
+					target = scope:secret_owner
+					modifier = requested_incursion_opinion
+				}
+			}
+		}
+		if = {
+			limit = {
+				scope:secret_target != scope:secret_owner.top_liege
+				scope:secret_owner.top_liege != scope:secret_owner
+			}
+			scope:secret_owner.top_liege = {
+				add_opinion = {
+					target = scope:secret_owner
+					modifier = requested_incursion_opinion
+				}
+			}
+		}
+		scope:secret_owner = {
+			if = {
+				limit = {
+					exists = top_participant_group:dynastic_cycle
+					title:h_china.holder ?= {
+						this != scope:secret_owner
+						this = scope:secret_target.top_liege
+					}
+				}
+				tgp_activate_catalyst_against_hegemon_effect = {
+					HEGEMON = scope:secret_owner.top_liege
+					CATALYST = catalyst_requested_incursion
+				}
+			}
+		}
+	}
+
+
+	## Struggle Catalysts
+	if = {
+		limit = {
+			scope:local_secret_owner = {
+				is_semi_important_ruler_struggle_character = yes
+				any_character_struggle	 = {
+					involvement = involved
+					phase_has_catalyst = catalyst_reveal_secret_important
+				}
+			}
+		}
+		scope:local_secret_owner = {
+			every_character_struggle = {
+				involvement = involved
+				activate_struggle_catalyst = {
+					catalyst = catalyst_reveal_secret_important
+					character = scope:local_secret_owner
+				}
+			}
+		}
+	}
+	if = {
+		limit = {
+			scope:local_secret_owner = {
+				has_trait = fp3_struggle_supporter
+				any_character_struggle	 = {
+					involvement = involved
+					phase_has_catalyst = catalyst_reveal_secret_supporter
+				}
+			}
+		}
+		scope:local_secret_owner = {
+			every_character_struggle = {
+				involvement = involved
+				activate_struggle_catalyst = {
+					catalyst = catalyst_reveal_secret_supporter
+					character = scope:local_secret_owner
+				}
+				log_debug_variable_for_persian_struggle_effect = { VAR = unrest_catalyst_reveal_secret_supporter }
+			}
+		}
+	}
+	if = {
+		limit = {
+			scope:local_secret_owner = {
+				has_trait = fp3_struggle_detractor
+				any_character_struggle	 = {
+					involvement = involved
+					phase_has_catalyst = catalyst_reveal_secret_detractor
+				}
+			}
+		}
+		scope:local_secret_owner = {
+			every_character_struggle = {
+				involvement = involved
+				activate_struggle_catalyst = {
+					catalyst = catalyst_reveal_secret_detractor
+					character = scope:local_secret_owner
+				}
+				log_debug_variable_for_persian_struggle_effect = { VAR = stabil_catalyst_reveal_secret_detractor }
+			}
+		}
+	}
+}
+
+secret_exposed_owner_opinion_effects_effect = {
+	if = {
+		limit = {
+			exists = scope:secret_exposer
+			this != scope:secret_exposer
+			scope:secret_exposer = { is_alive = yes }
+		}
+		add_opinion = {
+			target = scope:secret_exposer
+			modifier = exposed_my_secret_opinion
+		}
+	}
+}
+
+secret_exposed_notification_effects_effect = {
+	save_temporary_scope_as = notification_receiver
+	if = {
+		limit = { has_hook_from_secret = $SECRET$ }
+		remove_hook = {
+			target = $CHARACTER$
+		}
+	}
+	show_as_tooltip = {
+		$CHARACTER$ = { #Shows traits etc. applied to owner (and other involved characters)
+			secret_exposed_owner_effects_effect = { SECRET = $SECRET$ POV = scope:notification_receiver }
+			secret_exposed_owner_opinion_effects_effect = yes
+		}
+	}
+}
+
+
+
+
+
+
+
+
+
+
+###########################################
+# LOVER SECRETS: INFIDELITY CONFRONTATION #
+###########################################
+
+# Support effect for building lists in "start_infidelity_confrontation_story_exposure_effect"
+infidelity_confrontation_story_add_to_list_effect = {
+	save_temporary_scope_as = checked_confronting_partner
+	if = {
+		limit = {
+			NOR = {
+				this = $LOVER_1$
+				this = $LOVER_2$
+				scope:infidelity_story = {
+					is_target_in_variable_list = {
+						name = confronting_partners
+						target = scope:checked_confronting_partner
+					}
+				}
+			}
+			#Exempt polyamorous spouses.
+			accepts_adultery_without_penalty_trigger = no
+		}
+		scope:infidelity_story = {
+			add_to_variable_list = {
+				name = confronting_partners
+				target = scope:checked_confronting_partner
+			}
+		}
+	}
+}
+
+# Support for "start_infidelity_confrontation_story_exposure/discovery_effect" effects to creating the story
+infidelity_confrontation_story_creation_effect = {
+	$LOVER_1$ = {
+		create_story = {
+			type = story_cycle_infidelty_confronter
+			save_scope_as = infidelity_story
+		}
+		scope:infidelity_story = {
+			set_variable = {
+				name = lover_1
+				value = $LOVER_1$
+			}
+			set_variable = {
+				name = lover_2
+				value = $LOVER_2$
+			}
+			add_to_variable_list = {
+				name = infidelity_lovers
+				target = $LOVER_1$
+			}
+			add_to_variable_list = {
+				name = infidelity_lovers
+				target = $LOVER_2$
+			}
+		}
+	}
+}
+
+# Creates a story about confrontations/choices after discovered infidelity (lover secret discovery)
+start_infidelity_confrontation_story_discovery_effect = {
+	if = {
+		limit = {
+			NOR = {
+				$DISCOVERER$ = $LOVER_2$
+				$DISCOVERER$ = $LOVER_1$
+			}
+			$DISCOVERER$ = {
+				OR = {
+					has_relation_lover = $LOVER_1$
+					is_spouse_of = $LOVER_1$
+					has_relation_lover = $LOVER_2$
+					is_spouse_of = $LOVER_2$
+				}
+			}
+			NOR = {
+				$LOVER_1$ = {
+					any_owned_story = {
+						type = story_cycle_infidelty_confronter
+						var:lover_2 = $LOVER_2$ #var:lover_2 is the secret target i.e. the other person
+					}
+				}
+				$LOVER_2$ = {
+					any_owned_story = {
+						type = story_cycle_infidelty_confronter
+						var:lover_2 = $LOVER_1$ #var:lover_2 is the secret target i.e. the other person
+					}
+				}
+			}
+			#Exempt marriages to polyamorous spouses.
+			NOR = {
+				$LOVER_1$ = {
+					OR = {
+						any_spouse = {
+							count = all
+							accepts_adultery_without_penalty_trigger = yes
+						}
+						has_character_flag = block_infidelity_flag
+					}
+				}
+				$LOVER_2$ = {
+					OR = {
+						any_spouse = {
+							count = all
+							accepts_adultery_without_penalty_trigger = yes
+						}
+						has_character_flag = block_infidelity_flag
+					}
+				}
+			}
+		}
+		infidelity_confrontation_story_creation_effect = { LOVER_1 = $LOVER_1$ LOVER_2 = $LOVER_2$ }
+		scope:infidelity_story = {
+			add_to_variable_list = {
+				name = confronting_partners
+				target = $DISCOVERER$
+			}
+		}
+		#Certain changes to desc in event if the secret was revealed through investigation
+		if = {
+			limit = { $DISCOVERER$ = { is_ai = no } } #Text changes are only relevant to players
+
+			#Save the secrets so we can check them
+			$LOVER_1$ = {
+				random_secret = {
+					type = secret_lover
+					limit = {
+						secret_target = $LOVER_2$
+					}
+					add_to_temporary_list = secrets_for_desc
+				}
+			}
+			$LOVER_2$ = {
+				random_secret = {
+					type = secret_lover
+					limit = {
+						secret_target = $LOVER_1$
+					}
+					add_to_temporary_list = secrets_for_desc
+				}
+			}
+
+			#infidelity_confrontation_1000_investigation_desc
+			if = {
+				limit = {
+					any_in_list = {
+						list = secrets_for_desc
+						exists = var:revealed_through_investigation_by_desc
+						var:revealed_through_investigation_by_desc = $DISCOVERER$
+					}
+				}
+				scope:infidelity_story = {
+					set_variable = {
+						name = infidelity_confrontation_1000_investigation_desc
+						value = yes
+					}
+				}
+			}
+
+			#revealed_through_confession_to_desc
+			if = {
+				limit = {
+					any_in_list = {
+						list = secrets_for_desc
+						exists = var:revealed_through_confession_to_desc
+						var:revealed_through_confession_to_desc = $DISCOVERER$
+					}
+				}
+				scope:infidelity_story = {
+					set_variable = {
+						name = infidelity_confrontation_1000_confession_desc
+						value = yes
+					}
+				}
+			}
+		}
+	}
+}
+
+# Creates a story about confrontations/choices after discovered infidelity (lover secret exposure)
+start_infidelity_confrontation_story_exposure_effect = {
+	if = {
+		limit = {
+			NOR = {
+				$EXPOSER$ = $LOVER_2$
+				$EXPOSER$ = $LOVER_1$
+			}
+			OR = {
+				$LOVER_1$ = {
+					OR = {
+						any_spouse = { NOT = { this = $LOVER_2$ } }
+						any_relation = {
+							type = lover
+							NOT = { this = $LOVER_2$ }
+						}
+					}
+				}
+				$LOVER_2$ = {
+					OR = {
+						any_spouse = { NOT = { this = $LOVER_1$ } }
+						any_relation = {
+							type = lover
+							NOT = { this = $LOVER_1$ }
+						}
+					}
+				}
+			}
+		}
+		#Set up story
+		infidelity_confrontation_story_creation_effect = { LOVER_1 = $LOVER_1$ LOVER_2 = $LOVER_2$ }
+		scope:infidelity_story = {
+			set_variable = {
+				name = exposer
+				value = $EXPOSER$
+			}
+		}
+
+		#Add all confronting partners
+		$LOVER_1$ = {
+			every_spouse = {
+				infidelity_confrontation_story_add_to_list_effect = { LOVER_1 = $LOVER_1$ LOVER_2 = $LOVER_2$ }
+			}
+			every_relation = {
+				type = lover
+				infidelity_confrontation_story_add_to_list_effect = { LOVER_1 = $LOVER_1$ LOVER_2 = $LOVER_2$ }
+			}
+		}
+		$LOVER_2$ = {
+			every_spouse = {
+				infidelity_confrontation_story_add_to_list_effect = { LOVER_1 = $LOVER_1$ LOVER_2 = $LOVER_2$ }
+			}
+			every_relation = {
+				type = lover
+				infidelity_confrontation_story_add_to_list_effect = { LOVER_1 = $LOVER_1$ LOVER_2 = $LOVER_2$ }
+			}
+		}
+
+		#Save a list of the confronting partners who already knew
+		scope:infidelity_story = {
+			every_in_list = {
+				variable = confronting_partners
+				limit = {
+					save_temporary_scope_as = confronting_partner_knowledge_check
+					OR = {
+						$LOVER_1$ = {
+							any_secret = {
+								type = secret_lover
+								secret_target = $LOVER_2$
+								any_secret_knower = { this = scope:confronting_partner_knowledge_check }
+							}
+						}
+						$LOVER_2$ = {
+							any_secret = {
+								type = secret_lover
+								secret_target = $LOVER_1$
+								any_secret_knower = { this = scope:confronting_partner_knowledge_check }
+							}
+						}
+					}
+				}
+				save_temporary_scope_as = knowing_confronting_partner
+				scope:infidelity_story = {
+					add_to_variable_list = {
+						name = knowing_confronting_partners
+						target = scope:knowing_confronting_partner
+					}
+				}
+			}
+		}
+	}
+}
+
+
+
+
+#################
+# MISC
+##############
+
+
+# Used to give people a random secret (small chance of multiples)
+give_random_secret_effect = {
+	random_list = {
+		20 = {
+			modifier = {
+				factor = 0
+				OR = {
+					has_trait = deviant
+					any_secret = {
+						type = secret_deviant
+					}
+				}
+			}
+			give_deviant_secret_or_trait_effect = yes
+		}
+		20 = {
+			modifier = {
+				factor = 0
+				OR = {
+					has_sexuality = homosexual
+					any_secret = {
+						type = secret_homosexual
+					}
+				}
+			}
+			give_homosexual_secret_or_nothing_effect = yes
+		}
+		10 = {
+			modifier = {
+				factor = 0
+				OR = {
+					has_trait = deviant
+					any_secret = {
+						type = secret_deviant
+					}
+					has_sexuality = homosexual
+					any_secret = {
+						type = secret_homosexual
+					}
+				}
+			}
+			add_secret = {
+				type = secret_deviant
+			}
+			give_homosexual_secret_or_nothing_effect = yes
+		}
+		5 = { # Get ALL the secrets!
+			if = {
+				limit = {
+					NOR = {
+						has_sexuality = homosexual
+						any_secret = {
+							type = secret_homosexual
+						}
+					}
+				}
+				give_homosexual_secret_or_nothing_effect = yes
+			}
+			if = {
+				limit = {
+					NOR = {
+						has_trait = deviant
+						any_secret = {
+							type = secret_deviant
+						}
+					}
+				}
+				give_deviant_secret_or_trait_effect = yes
+			}
+		}
+	}
+}
+
+
+give_random_likely_secret_effect = {
+	save_temporary_scope_as = secret_getter
+	random_list = {
+		100 = { #DEVIANT
+			trigger = {
+				is_adult = yes
+				secret_deviant_is_valid_trigger = { OWNER = this }
+				NOR = {
+					has_trait = chaste
+					has_trait = celibate
+				}
+				NOT = { any_secret = { type = secret_deviant } }
+				trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:deviant GENDER_CHARACTER = scope:secret_getter }
+
+			}
+			modifier = {
+				has_trait = lustful
+				add = 200
+			}
+			ai_value_modifier = {
+				ai_boldness = tiny_chance_impact_positive_ai_value #+50 for high positive boldness
+				ai_honor = tiny_chance_impact_negative_ai_value #+50 for high negative honor
+				ai_zeal = medium_chance_impact_negative_ai_value #-200 for high positive zeal
+			}
+			give_deviant_secret_or_trait_effect = yes
+		}
+		200 = { #HOMOSEXUAL
+			trigger = {
+				is_adult = yes
+				trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:sodomite GENDER_CHARACTER = scope:secret_getter }
+				OR = {
+					has_sexuality = homosexual
+					has_sexuality = bisexual
+				}
+				NOT = { any_secret = { type = secret_homosexual } }
+			}
+			modifier = {
+				any_relation = { type = lover sex_opposite_of = prev }
+				factor = 0.1
+			}
+			give_homosexual_secret_or_nothing_effect = yes
+		}
+		150 = { #MURDER ATTEMPT
+			trigger = {
+				is_adult = yes
+				save_temporary_scope_as = murderer
+				OR = {
+					any_relation = {
+						type = rival
+						give_random_likely_secret_murder_attempt_victim_trigger = yes
+					}
+					any_close_or_extended_family_member = {
+						reverse_opinion = {
+							target = prev
+							value <= -10
+						}
+						give_random_likely_secret_murder_attempt_victim_trigger = yes
+					}
+				}
+			}
+			ai_value_modifier = {
+				ai_boldness = tiny_chance_impact_positive_ai_value #+50 for high positive boldness
+				ai_greed = tiny_chance_impact_positive_ai_value #+50 for high positive greed
+				ai_compassion = low_chance_impact_negative_ai_value #-100 for high positive compassion
+			}
+
+			save_temporary_scope_as = murderer
+
+			every_relation = {
+				type = rival
+				limit = {
+					give_random_likely_secret_murder_attempt_victim_trigger = yes
+				}
+				add_to_list = victim_options
+			}
+			every_close_or_extended_family_member = {
+				limit = {
+					reverse_opinion = {
+						target = prev
+						value <= -10
+					}
+					give_random_likely_secret_murder_attempt_victim_trigger = yes
+				}
+				add_to_list = victim_options
+			}
+
+			random_in_list = {
+				list = victim_options
+				save_temporary_scope_as = victim
+			}
+
+			add_secret = {
+				type = secret_murder_attempt
+				target = scope:victim
+			}
+		}
+		100 = { #CANNIBAL
+			trigger = {
+				secret_cannibal_is_valid_trigger = { OWNER = this }
+				NOT = { any_secret = { type = secret_cannibal } }
+				trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:cannibal GENDER_CHARACTER = scope:secret_getter }
+			}
+			ai_value_modifier = {
+				ai_boldness = tiny_chance_impact_positive_ai_value #+50 for high positive boldness
+				ai_greed = tiny_chance_impact_positive_ai_value #+50 for high positive greed
+				ai_zeal = low_chance_impact_negative_ai_value #-100 for high positive zeal
+				ai_compassion = medium_chance_impact_negative_ai_value #-200 for high positive compassion
+			}
+			modifier = {
+				is_adult = no
+				add = -80
+			}
+
+			give_cannibal_secret_or_trait_effect = yes
+		}
+		200 = { #HERETIC
+			trigger = {
+				NOT = { any_secret = { type = secret_non_believer } }
+			}
+			modifier = {
+				add = {
+					value = ai_zeal
+					multiply = -2
+				}
+			}
+
+			give_non_believer_secret_effect = yes
+		}
+		400 = { #LOVER
+			trigger = {
+				is_adult = yes
+				NOT = { has_trait = celibate }
+				save_temporary_scope_as = lover_1
+				OR = {
+					any_courtier_or_guest = {
+						give_random_likely_secret_lover_trigger = yes
+					}
+					any_vassal = {
+						any_courtier_or_guest = {
+							give_random_likely_secret_lover_trigger = yes
+						}
+					}
+				}
+			}
+			modifier = {
+				OR = {
+					has_trait = lustful
+					has_trait = seducer
+				}
+				add = 400
+			}
+			modifier = {
+				has_trait = chaste
+				add = -300
+			}
+			ai_value_modifier = {
+				ai_compassion = medium_chance_impact_positive_ai_value #+200 for high positive compassion
+			}
+
+			save_temporary_scope_as = lover_1
+			random_courtier_or_guest = {
+				limit = { give_random_likely_secret_lover_trigger = yes }
+				weight = {
+					base = 1
+					modifier = {
+						has_trait = lustful
+						factor = 3
+					}
+				}
+				save_temporary_scope_as = lover
+			}
+ 			if = {
+ 				limit = { NOT = { exists = scope:lover } }
+ 				random_vassal = {
+ 					limit = { any_courtier_or_guest = { give_random_likely_secret_lover_trigger = yes } }
+ 					random_courtier_or_guest = {
+ 						limit = { give_random_likely_secret_lover_trigger = yes }
+ 						weight = {
+ 							base = 1
+	 						modifier = {
+								has_trait = lustful
+								factor = 3
+							}
+ 						}
+						save_temporary_scope_as = lover
+ 					}
+ 				}
+ 			}
+
+			set_random_lover_reason = { TARGET = scope:lover }
+		}
+		100 = { #INCESTOUS LOVER
+			trigger = {
+				is_adult = yes
+				NOT = { has_trait = celibate }
+				save_temporary_scope_as = lover_2
+				any_close_family_member = {
+					give_random_likely_secret_incestous_lover_trigger = yes
+				}
+			}
+			modifier = {
+				has_trait = deviant
+				add = 100
+			}
+
+			random_close_family_member = {
+				limit = { give_random_likely_secret_incestous_lover_trigger = yes }
+				set_random_lover_reason = { TARGET = prev }
+			}
+		}
+		100 = { #WITCH
+			trigger = {
+				NOT = { any_secret = { type = secret_witch } }
+				trait_is_shunned_or_criminal_in_my_or_lieges_faith_trigger = { TRAIT = trait:witch GENDER_CHARACTER = scope:secret_getter }
+			}
+			ai_value_modifier = {
+				ai_greed = tiny_chance_impact_positive_ai_value #+50 for high positive greed
+				ai_zeal = medium_chance_impact_negative_ai_value #+200 for high negative zeal
+				ai_compassion = tiny_chance_impact_negative_ai_value #+50 for high negative compassion
+			}
+			modifier = {
+				has_trait = lifestyle_mystic
+				add = 100
+			}
+			modifier = {
+				has_trait = lifestyle_physician
+				add = 40
+			}
+
+			add_secret = {
+				type = secret_witch
+			}
+		}
+	}
+}
+
+
+
+#Give secret and save as scope:secret
+give_secret_and_save_as_secret_effect = {
+	save_temporary_scope_value_as = {
+		name = give_secret_type
+		value = flag:$SECRET_TYPE$
+	}
+
+	if = {
+		limit = {
+			OR = {
+				scope:give_secret_type = flag:secret_deviant
+				scope:give_secret_type = flag:secret_cannibal
+				scope:give_secret_type = flag:secret_non_believer
+				scope:give_secret_type = flag:secret_witch
+			}
+		}
+		add_secret = {
+			type = $SECRET_TYPE$
+		}
+	}
+	else_if = {
+		limit = {
+			scope:give_secret_type = flag:secret_incest
+		}
+		give_incest_secret_or_nothing_effect = yes
+	}
+	else_if = {
+		limit = {
+			scope:give_secret_type = flag:secret_homosexual
+			is_male = yes
+		}
+		give_homosexual_secret_or_nothing_effect = yes
+	}
+
+	random_secret = {
+		limit = {
+			secret_type = $SECRET_TYPE$
+		}
+		save_scope_as = secret
+	}
+}
+
+save_my_known_father_effect = {
+	if = {
+		limit = {
+			exists = this.father
+			NOT = {
+				any_known_secret = {
+					secret_target = prev
+					OR = {
+						secret_type = secret_disputed_heritage
+						secret_type = secret_unmarried_illegitimate_child
+					}
+				}
+			}
+		}
+		scope:father = { save_scope_as = known_father }
+	}
+	else_if = {
+		limit = {
+			exists = this.real_father
+			any_known_secret = {
+				secret_target = prev
+				OR = {
+					secret_type = secret_disputed_heritage
+					secret_type = secret_unmarried_illegitimate_child
+				}
+			}
+		}
+		scope:real_father = { save_scope_as = known_father }
+	}
+}
+
+
+add_random_blackmailable_secret_effect = {
+	save_scope_as = target
+
+	random_list = {
+		3 = { #Secret Deviant
+			trigger = {
+				secret_type_is_blackmailable_simple_trigger = {
+					TYPE = secret_deviant
+					TARGET = scope:target
+					BLACKMAILER = $BLACKMAILER$
+				}
+			}
+			add_secret = {
+				type = secret_deviant
+			}
+			random_secret = {
+				type = secret_deviant
+				save_scope_as = new_secret
+			}
+		}
+		5 = { #Secret Homosexual
+			trigger = {
+				secret_type_is_blackmailable_simple_trigger = {
+					TYPE = secret_homosexual
+					TARGET = scope:target
+					BLACKMAILER = $BLACKMAILER$
+				}
+			}
+			add_secret = {
+				type = secret_homosexual
+			}
+			random_secret = {
+				type = secret_homosexual
+				save_scope_as = new_secret
+			}
+		}
+		1 = { #Secret Cannibal
+			trigger = {
+				secret_type_is_blackmailable_simple_trigger = {
+					TYPE = secret_cannibal
+					TARGET = scope:target
+					BLACKMAILER = $BLACKMAILER$
+				}
+			}
+			add_secret = {
+				type = secret_cannibal
+			}
+			random_secret = {
+				type = secret_cannibal
+				save_scope_as = new_secret
+			}
+		}
+		2 = { #Secret Non-believer
+			trigger = {
+				secret_type_is_blackmailable_simple_trigger = {
+					TYPE = secret_non_believer
+					TARGET = scope:target
+					BLACKMAILER = $BLACKMAILER$
+				}
+			}
+			add_secret = {
+				type = secret_non_believer
+			}
+			random_secret = {
+				type = secret_non_believer
+				save_scope_as = new_secret
+			}
+		}
+		1 = { #Secret Incest
+			trigger = {
+				secret_type_is_blackmailable_simple_trigger = {
+					TYPE = secret_incest
+					TARGET = scope:target
+					BLACKMAILER = $BLACKMAILER$
+				}
+			}
+			add_secret = {
+				type = secret_incest
+			}
+			random_secret = {
+				type = secret_incest
+				save_scope_as = new_secret
+			}
+		}
+		2 = { #Secret Witch
+			trigger = {
+				secret_type_is_blackmailable_simple_trigger = {
+					TYPE = secret_witch
+					TARGET = scope:target
+					BLACKMAILER = $BLACKMAILER$
+				}
+			}
+			add_secret = {
+				type = secret_witch
+			}
+			random_secret = {
+				type = secret_witch
+				save_scope_as = new_secret
+			}
+		}
+	}
+
+	assert_if = {
+		limit = {
+			NOT = { exists = scope:new_secret }
+		}
+		text = "No secret added by add_random_blackmailable_secret_effect - Always check the target with random_blackmailable_secret_can_be_added_simple_trigger first!"
+	}
+}

--- a/common/scripted_effects/00_secret_effects.txt
+++ b/common/scripted_effects/00_secret_effects.txt
@@ -2338,7 +2338,7 @@ save_my_known_father_effect = {
 				}
 			}
 		}
-		scope:father = { save_scope_as = known_father }
+		father = { save_scope_as = known_father } #Unop: Save this character's own father, not scope:father which may not be set
 	}
 	else_if = {
 		limit = {

--- a/common/scripted_effects/05_dlc_bp2_effects.txt
+++ b/common/scripted_effects/05_dlc_bp2_effects.txt
@@ -1104,6 +1104,7 @@ adopt_effect = {
 		adopt = $CHILD$
 		$CHILD$ = {
 			set_house = $ADOPTER$.house
+			add_character_flag = unop_was_adopted #Unop: Mark the child so bastard secret exposure does not undo the adoption
 			# Remove bastard traits
 			if = {
 				limit = {
@@ -1336,6 +1337,7 @@ adventurer_adopt_effect = {
 		$CHILD$ = {
 			hidden_effect = {
 				set_house = $ADOPTER$.house
+				add_character_flag = unop_was_adopted #Unop: Mark the child so bastard secret exposure does not undo the adoption
 				found_cadet_house_decision_effect = {
 					CHARACTER = scope:recipient
 					PRESTIGE = 0

--- a/common/secret_types/00_bastard_secrets.txt
+++ b/common/secret_types/00_bastard_secrets.txt
@@ -1,0 +1,456 @@
+﻿
+secret_disputed_heritage = {
+	category = adultery
+
+	is_valid = {
+		secret_disputed_heritage_is_valid_trigger = {
+			TARGET = scope:secret_target
+		}
+	}
+
+	is_shunned = {	
+		bastard_secret_is_shunned = {
+			TARGET = scope:secret_target
+			PARTICIPANT = scope:target
+		}
+	}
+
+	is_criminal = {
+		bastard_secret_is_criminal = {
+			TARGET = scope:secret_target
+			PARTICIPANT = scope:target
+		}
+	}
+
+	on_owner_death = {
+		save_scope_as = secret
+		scope:secret_target = {
+			save_scope_as = child
+		}
+
+		###SET NEW OWNERSHIP###
+		#Should we set new secret owner(s)?
+		if = {
+			limit = {
+				#Child knows about the secret
+				is_known_by = scope:child
+				scope:child = { is_alive = yes }
+			}
+			set_secret_owner = scope:child
+		}
+	}
+
+	on_discover = {
+		save_scope_as = secret
+		scope:secret_target = {
+			save_scope_as = child
+			real_father = {
+				save_scope_as = real_father
+			}
+			mother = {
+				save_scope_as = mother
+			}
+			if =  {
+				limit = {
+					exists = father
+				}
+				father = {
+					save_scope_as = father
+				}
+			}
+			else = {
+				debug_log = "secret_disputed_heritage was discovered for a child without a father!"
+				debug_log_scopes = yes
+			}
+		}
+
+		scope:child = { remove_inherited_descendent_traits_effect = yes }
+
+		###Sends events###
+		scope:discoverer = {
+			if = {
+				limit = { NOT = { has_character_flag = block_secret_disputed_heritage_discovery_event } } #Set by reveal_to_without_events_effect
+
+				if = {
+					limit = { is_ai = no } #Don't send any events to AI, they have no effect
+
+					#CHILD#
+					if = {
+						limit = { this = scope:child }
+						trigger_event = secrets.0501
+					}
+					#REAL FATHER#
+					else_if = {
+						limit = { this = scope:real_father }
+						trigger_event = secrets.0502
+					}
+					#FATHER#
+					else_if = {
+						limit = {
+							this = scope:father
+							scope:mother = {
+								NOT = { has_variable = borte_first_child_var }
+							}
+						}
+						trigger_event = secrets.0500	
+					}
+					#CONSORT/LOVER OF CHILD (if we're now siblings!)
+					else_if =  {
+						limit = {
+							any_sibling = {
+								is_consort_of = scope:child
+								has_relation_lover = scope:child
+							}
+						}
+						save_my_known_father_effect = yes #Saves known_father for this character
+						if = {
+							limit = {
+								scope:known_father = scope:real_father
+								any_sibling = {
+									father = scope:known_father
+									OR = {
+										is_consort_of = scope:child
+										has_relation_lover = scope:child
+									}
+								}
+							}
+
+							random_sibling = {
+								limit = {
+									father = scope:known_father
+									OR = {
+										is_consort_of = scope:child
+										has_relation_lover = scope:child
+									}
+								}
+								save_scope_as = sibling_partner
+							}
+							trigger_event = secrets.0503
+						}
+					}		
+				}
+			}
+			else = {
+				remove_character_flag = block_secret_disputed_heritage_discovery_event
+			}
+		}
+
+		#Set participants for this secret
+		if = {
+			limit = {
+				OR = {
+					scope:discoverer = { this = scope:real_father }
+					scope:discoverer = { this = scope:child }
+				}
+			}
+			add_secret_participant = scope:discoverer
+		}
+	}
+
+	on_expose = {
+		# Save scopes and set "knows"-flags for reference in events later on.
+		save_scope_as = secret
+		scope:secret_owner = { save_scope_as = owner }
+		scope:secret_target = {
+			#Child
+			save_scope_as = child
+			if = {
+				limit = {
+					scope:secret = {
+						is_known_by = scope:child
+					}
+				}
+				scope:child = {
+					add_character_flag = child_knows
+				}
+			}
+
+			#Mother
+			mother = {
+				save_scope_as = mother
+			}
+
+			#Real_father
+			scope:child.real_father = {
+				save_scope_as = real_father
+				if = {
+					limit = {
+						scope:secret = {
+							is_known_by = scope:real_father
+						}
+					}
+					add_character_flag = real_father_knows
+				}
+			}
+
+			#Father
+			if = {
+				limit = { exists = father }
+				father = { save_scope_as = father }
+				if = {
+					limit = {
+						scope:secret = {
+							is_known_by = scope:father
+						}
+					}
+					add_character_flag = father_knows
+				}
+			}
+		}
+
+		# Actual effects of exposing the secret
+		hidden_effect = {
+			secret_exposed_owner_effects_effect = { SECRET = scope:secret POV = scope:secret_exposer }
+		}
+
+		##############################
+		# EXPOSURE EVENTS		  	 						
+		#  These events exist for notification purposes — they only describe what has already happened, and do not trigger any actual gameplay effects
+		##############################
+
+		##Every secret knower & those who care about the child, mother and real_father (spouses/father are handled here)
+		secret_exposed_notification_effect = yes
+
+		#"Unique" targets
+		scope:child = {
+			remove_inherited_descendent_traits_effect = yes
+			trigger_event = secret_bastard.2003
+		}
+		scope:mother = {
+			trigger_event = {
+				id = secret_bastard.2000
+			}
+		}
+		scope:real_father = {
+			trigger_event = {
+				id = secret_bastard.2002
+			}
+		}
+
+		if = {
+			limit = {
+				exists = scope:father
+				scope:father = scope:secret_exposer
+			}
+			scope:father = {
+				trigger_event = secret_bastard.2001
+			}
+		}
+	}
+}
+
+
+secret_unmarried_illegitimate_child = {
+	category = adultery
+	
+	is_valid = {
+		secret_unmarried_illegitimate_child_is_valid_trigger = {
+			TARGET = scope:secret_target
+		}
+	}
+
+	is_shunned = {	
+		bastard_secret_is_shunned = {
+			TARGET = scope:secret_target
+			PARTICIPANT = scope:target
+		}
+	}
+
+	is_criminal = {
+		bastard_secret_is_criminal = {
+			TARGET = scope:secret_target
+			PARTICIPANT = scope:target
+		}
+	}
+
+	on_owner_death = {
+		save_scope_as = secret
+		scope:secret_target = {
+			save_scope_as = child
+		}
+
+		###SET NEW OWNERSHIP###
+		#Should we set new secret owner?
+		if = {
+			limit = {
+				#Child knows about the secret
+				scope:secret = { is_known_by = scope:child }
+				scope:child = { is_alive = yes }
+			}
+			set_secret_owner = scope:child
+		}
+	}
+
+	on_discover = {
+		save_scope_as = secret
+		scope:secret_target = {
+			save_scope_as = child
+			real_father = {
+				save_scope_as = real_father
+			}
+			mother = {
+				save_scope_as = mother
+			}
+		}
+
+		###Sends events###
+		scope:discoverer = {
+			if = {
+				limit = { NOT = { has_character_flag = block_secret_unmarried_illegitimate_child_discovery_event } } #Set by reveal_to_without_events_effect
+
+				if = {
+					limit = { is_ai = no } #Do not send any events to AI, they have no script effects (they exist for informational purposes only).
+
+					#CHILD#
+					if = {
+						limit = { this = scope:child }
+						trigger_event = secrets.0501
+					}
+					#REAL FATHER#
+					else_if = {
+						limit = { this = scope:real_father }
+						trigger_event = secrets.0502
+					}
+					#CONSORT/LOVER OF CHILD (if we're now siblings!)
+					else_if =  {
+						limit = {
+							any_sibling = {
+								is_consort_of = scope:child
+								has_relation_lover = scope:child
+							}
+						}
+						save_my_known_father_effect = yes #Saves known_father for this character
+						if = {
+							limit = {
+								scope:known_father = scope:real_father
+								any_sibling = {
+									father = scope:known_father
+									OR = {
+										is_consort_of = scope:child
+										has_relation_lover = scope:child
+									}
+								}
+							}
+
+							random_sibling = {
+								limit = {
+									father = scope:known_father
+									OR = {
+										is_consort_of = scope:child
+										has_relation_lover = scope:child
+									}
+								}
+								save_scope_as = sibling_partner
+							}
+							trigger_event = secrets.0503
+						}
+					}		
+				}
+			}
+			else = {
+				remove_character_flag = block_secret_unmarried_illegitimate_child_discovery_event
+			}
+		}
+
+		#Set participants for this secret
+		if = {
+			limit = {
+				OR = {
+					scope:discoverer = { this = scope:real_father }
+					scope:discoverer = { this = scope:child }
+				}
+			}
+			add_secret_participant = scope:discoverer
+		}
+	}
+
+	on_expose = {
+		#Save scopes and set "knows"-flags for reference in events later on.
+		save_scope_as = secret
+		scope:secret_owner = { save_scope_as = owner }
+		scope:secret_target = {
+			#Child
+			save_scope_as = child
+			if = {
+				limit = {
+					scope:secret = {
+						is_known_by = scope:child
+					}
+				}
+				scope:child = {
+					add_character_flag = child_knows
+				}
+			}
+
+			#Mother
+			mother = {
+				save_scope_as = mother
+			}
+
+			#Real_father
+			scope:child.real_father = {
+				save_scope_as = real_father
+				if = {
+					limit = {
+						scope:secret = {
+							is_known_by = scope:real_father
+						}
+					}
+					add_character_flag = real_father_knows
+				}
+			}
+		}
+
+
+		# Actual effects of exposing the secret
+		hidden_effect = {
+			secret_exposed_owner_effects_effect = { SECRET = scope:secret POV = scope:secret_exposer }
+		}
+		scope:child = {
+			set_father = scope:real_father
+			set_parent_house_effect = yes
+			remove_inherited_descendent_traits_effect = yes
+		}
+
+
+		##############################
+		# EXPOSURE EVENTS		  	 						
+		#  These events exist for notification purposes — they only describe what has already happened, and do not trigger any actual gameplay effects
+		##############################
+
+		#Every secret knower & those who care about child(ren), mother and real_father (spouses are handled here)
+		secret_exposed_notification_effect = yes
+
+		#"Unique" targets
+		scope:child = {
+			if = {
+				limit = {
+					is_hostage = yes
+					dynasty = warden.dynasty
+				}
+				save_scope_as = unhostaged_child
+				warden = { save_scope_as = warden }
+			}
+			trigger_event = secret_bastard.3001
+		}
+		scope:mother = {
+			trigger_event = secret_bastard.2000
+		}
+		scope:real_father = {
+			if = {
+				limit = {
+					is_alive = yes
+					NOT = { has_variable = do_not_notify_me_of_bastard_secret_reveal }
+				}
+				trigger_event = secret_bastard.3000
+			}
+		}
+		scope:child = {
+			if = {
+				limit = { exists = scope:unhostaged_child }
+				return_hostage = yes
+				scope:warden = { add_courtier = root }
+			}
+		}
+	}
+}

--- a/common/secret_types/00_bastard_secrets.txt
+++ b/common/secret_types/00_bastard_secrets.txt
@@ -200,7 +200,7 @@ secret_disputed_heritage = {
 
 		# Actual effects of exposing the secret
 		hidden_effect = {
-			secret_exposed_owner_effects_effect = { SECRET = scope:secret POV = scope:secret_exposer }
+			scope:secret_owner = { secret_exposed_owner_effects_effect = { SECRET = scope:secret POV = scope:secret_exposer } } #Unop: Wrap in scope:secret_owner so the effect runs in character scope, matching how 00_secret_types.txt calls this effect
 		}
 
 		##############################
@@ -404,7 +404,7 @@ secret_unmarried_illegitimate_child = {
 
 		# Actual effects of exposing the secret
 		hidden_effect = {
-			secret_exposed_owner_effects_effect = { SECRET = scope:secret POV = scope:secret_exposer }
+			scope:secret_owner = { secret_exposed_owner_effects_effect = { SECRET = scope:secret POV = scope:secret_exposer } } #Unop: Wrap in scope:secret_owner so the effect runs in character scope, matching how 00_secret_types.txt calls this effect
 		}
 		scope:child = {
 			set_father = scope:real_father
@@ -449,7 +449,7 @@ secret_unmarried_illegitimate_child = {
 			if = {
 				limit = { exists = scope:unhostaged_child }
 				return_hostage = yes
-				scope:warden = { add_courtier = root }
+				scope:warden = { add_courtier = prev } #Unop: root is the secret in on_expose, but add_courtier needs the child character
 			}
 		}
 	}

--- a/common/secret_types/00_bastard_secrets.txt
+++ b/common/secret_types/00_bastard_secrets.txt
@@ -406,10 +406,13 @@ secret_unmarried_illegitimate_child = {
 		hidden_effect = {
 			scope:secret_owner = { secret_exposed_owner_effects_effect = { SECRET = scope:secret POV = scope:secret_exposer } } #Unop: Wrap in scope:secret_owner so the effect runs in character scope, matching how 00_secret_types.txt calls this effect
 		}
-		scope:child = {
-			set_father = scope:real_father
-			set_parent_house_effect = yes
-			remove_inherited_descendent_traits_effect = yes
+		if = { #Unop: Skip if the child has been adopted; the adoption has rebound them to a new family
+			limit = { scope:child = { NOT = { has_character_flag = unop_was_adopted } } }
+			scope:child = {
+				set_father = scope:real_father
+				set_parent_house_effect = yes
+				remove_inherited_descendent_traits_effect = yes
+			}
 		}
 
 

--- a/common/secret_types/00_bastard_secrets.txt
+++ b/common/secret_types/00_bastard_secrets.txt
@@ -452,7 +452,7 @@ secret_unmarried_illegitimate_child = {
 			if = {
 				limit = { exists = scope:unhostaged_child }
 				return_hostage = yes
-				scope:warden = { add_courtier = prev } #Unop: root is the secret in on_expose, but add_courtier needs the child character
+				scope:warden = { add_courtier = scope:unhostaged_child } #Unop: root is the secret in on_expose, but add_courtier needs the child character
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #213

When a bastard child is adopted, the secret about their true heritage (`secret_unmarried_illegitimate_child` or `secret_disputed_heritage`) remains attached to the bio parents. When that secret is later exposed, vanilla re-binds the child to the bio father (changing house/dynasty) or adds the `disputed_heritage` trait — silently undoing the adoption.

This adds a persistent `unop_was_adopted` character flag in `adopt_effect` and `adventurer_adopt_effect`, then skips the child-side consequences in both `secret_exposed_owner_effects_effect` and `secret_unmarried_illegitimate_child.on_expose` (vanilla has duplicate logic in both places) when the flag is present. Parent-side consequences (adultery traits, opinions) still fire, so secret owners keep their leverage.

Also fixes four pre-existing vanilla scope bugs surfaced by ck3-tiger once the affected files were brought into the mod tree:
- `00_bastard_secrets.txt`: two `secret_exposed_owner_effects_effect` calls in `on_expose` ran in secret scope; wrapped in `scope:secret_owner` to match the convention in `00_secret_types.txt`.
- `00_bastard_secrets.txt`: `add_courtier = root` in the hostage-return path used the secret as the courtier; corrected to `prev` (the child).
- `00_secret_effects.txt`: `save_my_known_father_effect` referenced `scope:father` which is unset at one of its two call sites; corrected to `father` (the implicit relation of the discoverer).

Note: characters adopted before this fix will not have the flag and remain vulnerable on exposure. There is no clean way to retroactively flag them.