### PR TITLE
Skip auto-spawning a coronation inspiration when one is already owned

### DIFF
--- a/events/court_maintenance_events.txt
+++ b/events/court_maintenance_events.txt
@@ -332,7 +332,11 @@ court_maintenance.0011 = {
 			}
 
 			# Artifact for Coronations setup
-			create_proper_coronation_artifact_setup = yes
+			#Unop Don't spawn an inspiration if a proper coronation artifact is already owned
+			if = {
+				limit = { coronation_has_proper_artifact_trigger = no }
+				create_proper_coronation_artifact_setup = yes
+			}
 		}
 		
 		if = {


### PR DESCRIPTION
Fixes #442

In `court_maintenance.0011` (gained a Royal Court), the call to `create_proper_coronation_artifact_setup` ran unconditionally on the first kingdom-tier promotion, even if the character already had a suitable crown or regalia artifact. `realm_maintenance.2001` and `ach_yearly_events.1005` already gate the same call on `coronation_has_proper_artifact_trigger = no`; mirror that here.