### PR TITLE
Add all missing zealot vassal stance check in coronation_events.6130

### DIFF
--- a/events/activities/coronation_activity/coronation_events_6.txt
+++ b/events/activities/coronation_activity/coronation_events_6.txt
@@ -12145,6 +12145,7 @@ coronation_events.6130 = {
 							faith.fervor >= 100
 						}
 						every_vassal = {
+							vassal_stance = zealot #Unop: Missing zealot vassal stance check
 							custom = custom.every_zealot_vassal
 							add_opinion = {
 								target = scope:host
@@ -12167,6 +12168,7 @@ coronation_events.6130 = {
 							faith.fervor >= 80
 						}
 						every_vassal = {
+							vassal_stance = zealot #Unop: Missing zealot vassal stance check
 							custom = custom.every_zealot_vassal
 							add_opinion = {
 								target = scope:host
@@ -12189,6 +12191,7 @@ coronation_events.6130 = {
 							faith.fervor >= 60
 						}
 						every_vassal = {
+							vassal_stance = zealot #Unop: Missing zealot vassal stance check
 							custom = custom.every_zealot_vassal
 							add_opinion = {
 								target = scope:host
@@ -12211,6 +12214,7 @@ coronation_events.6130 = {
 							faith.fervor >= 40
 						}
 						every_vassal = {
+							vassal_stance = zealot #Unop: Missing zealot vassal stance check
 							custom = custom.every_zealot_vassal
 							add_opinion = {
 								target = scope:host
@@ -12233,6 +12237,7 @@ coronation_events.6130 = {
 							faith.fervor >= 20
 						}
 						every_vassal = {
+							vassal_stance = zealot #Unop: Missing zealot vassal stance check
 							custom = custom.every_zealot_vassal
 							add_opinion = {
 								target = scope:host
@@ -12252,6 +12257,7 @@ coronation_events.6130 = {
 					}
 					else = {
 						every_vassal = {
+							vassal_stance = zealot #Unop: Missing zealot vassal stance check
 							custom = custom.every_zealot_vassal
 							add_opinion = {
 								target = scope:host


### PR DESCRIPTION
This will prevent ALL vassal to get the opinion duplicate (instead of just the zealous ones)

@pharaox I find this effect fishy, I've not changed it much except the obvious missing zealous check, but I still find it looking odd (as the whole thing looks duplicated) but I don't really know what would be the correct way to clean this. What do you think ?