### PR TITLE
Fix Grand Wedding leaving promised_grand_wedding_by stuck on a spouse

### DIFF
--- a/common/scripted_effects/00_fixpack_effects.txt
+++ b/common/scripted_effects/00_fixpack_effects.txt
@@ -666,6 +666,24 @@ create_grand_wedding_matrilineal_betrothal = {
 	}
 }
 
+# Unop: Post-marry variant of clean_grand_wedding_betrothal_variables — clears the variable from
+# spouses (via every_spouse) rather than from betrothed, which is empty once they're married.
+unop_clean_grand_wedding_betrothal_variables = {
+	save_temporary_scope_as = unop_gw_host
+	var:promised_grand_wedding_marriage_countdown = {
+		remove_variable = promised_grand_wedding_by
+		every_spouse = {
+			limit = {
+				has_variable = promised_grand_wedding_by
+				var:promised_grand_wedding_by = scope:unop_gw_host
+			}
+			remove_variable = promised_grand_wedding_by
+		}
+	}
+	remove_variable = promised_grand_wedding_marriage_countdown
+	remove_variable = promised_grand_wedding_to
+}
+
 unop_add_renown_effect = {
 	if = {
 		limit = { exists = dynasty }

--- a/events/dlc/ep2/wedding_events/ep2_wedding_events.txt
+++ b/events/dlc/ep2/wedding_events/ep2_wedding_events.txt
@@ -781,7 +781,9 @@ ep2_wedding.0151 = {
 			}
 		}
 		scope:host = {
-			clean_grand_wedding_betrothal_variables = yes
+			#Unop Use the post-marry variant (spouses are married, not betrothed, by this point)
+			#clean_grand_wedding_betrothal_variables = yes
+			unop_clean_grand_wedding_betrothal_variables = yes
 		}
 		# The marriage should not be consummated before the Wedding Night!
 		hidden_effect = {


### PR DESCRIPTION
Fixes #445

`clean_grand_wedding_betrothal_variables` is called after the `marry` effect in `ep2_wedding.0151.a`, when the spouses are already married and `spouse_1.betrothed` is empty. The cleanup leaves `promised_grand_wedding_by` stuck on spouse_2, which later blocks all marriage proposals via `has_been_promised_grand_wedding`.

Adds a post-marry variant `unop_clean_grand_wedding_betrothal_variables` that clears the variable via `every_spouse` instead, and swaps the single post-marry callsite to use it.