### PR TITLE
Fix is_landless_adventurer

### DIFF
--- a/common/scripted_triggers/00_available_for_events_triggers.txt
+++ b/common/scripted_triggers/00_available_for_events_triggers.txt
@@ -869,6 +869,7 @@ is_landless_nomad = {
 # This trigger checks if a character is a landless adventurer
 is_landless_adventurer = {
 	government_has_flag = government_is_landless_adventurer
+	has_domicile = yes #Unop Exclude landless adventurer followers
 }
 
 # This trigger checks if a character is a governor in an admin realm (implying they are landed)


### PR DESCRIPTION
Fix `is_landless_adventurer` to check if the character has a domicile. Right now, it only checks the government, but this returns true also for landless adventurer **followers** (government checks return true on courtiers for their liege's government).

The main issue is that this trigger is being used in `is_playable_character`, which implies that the character is a ruler (rulers are non-playable). Other triggers included in `is_playable_character` already exclude non-rulers in some way - by checking `has_domicile` and `is_house_head`. Only the first one is appropriate with landless adventurers.

The negative effect is hard to estimate but it's likely big. There are > 700 occurrences of `is_playable_character` in the codebase and landless adventurer followers are currently passing the filter. This trigger is also heavily used by mods. I came across the issue when trying to complete RICE activities as a LAAMP where guests were filtered by `is_playable_character = no` - suddently I couldn't invite anyone and therefore even start any of these activities. This worked before (e.g. in 1.17), I contributed the RICE changes to make it work personally.

I checked quickly other usages of `is_landless_adventurer` (52 in vanilla) for **intended** use on courtiers but couldn't find any, so I think it's safe to merge the fix as proposed.