### PR TITLE
Fix pilgrimage.2004 and pilgrimage.6001 poaching another ruler's spouse/heir/courtiers

### DIFF
--- a/common/scripted_triggers/00_courtier_guest_management_triggers.txt
+++ b/common/scripted_triggers/00_courtier_guest_management_triggers.txt
@@ -396,38 +396,40 @@ can_recruit_character_to_court_trigger = {
 			}
 			trigger_if = {
 				limit = { exists = host }
-				#Are they employed?
-				is_councillor_of = scope:recruitee.host
-				is_knight_of = scope:recruitee.host
-				any_relation = {
-					type = ward
-					OR = {
-						this = scope:recruitee.host
-						is_close_family_of = scope:recruitee.host
+				OR = { #Unop: Block recruiting an employed character (vanilla missing OR made this an unsatisfiable AND)
+					#Are they employed?
+					is_councillor_of = scope:recruitee.host
+					is_knight_of = scope:recruitee.host
+					any_relation = {
+						type = ward
+						OR = {
+							this = scope:recruitee.host
+							is_close_family_of = scope:recruitee.host
+						}
 					}
-				}
-				any_relation = {
-					type = guardian
-					OR = {
-						this = scope:recruitee.host
-						is_close_family_of = scope:recruitee.host
+					any_relation = {
+						type = guardian
+						OR = {
+							this = scope:recruitee.host
+							is_close_family_of = scope:recruitee.host
+						}
 					}
-				}
-				any_relation = {
-					type = mentor
-					OR = {
-						this = scope:recruitee.host
-						is_close_family_of = scope:recruitee.host
+					any_relation = {
+						type = mentor
+						OR = {
+							this = scope:recruitee.host
+							is_close_family_of = scope:recruitee.host
+						}
 					}
-				}
-				any_relation = {
-					type = student
-					OR = {
-						this = scope:recruitee.host
-						is_close_family_of = scope:recruitee.host
+					any_relation = {
+						type = student
+						OR = {
+							this = scope:recruitee.host
+							is_close_family_of = scope:recruitee.host
+						}
 					}
+					any_court_position_employer = { this = scope:recruitee.host }
 				}
-				any_court_position_employer = { this = scope:recruitee.host }
 			}
 			trigger_if = {
 				limit = {

--- a/events/activities/pilgrimage_activity/pilgrimage_events.txt
+++ b/events/activities/pilgrimage_activity/pilgrimage_events.txt
@@ -2810,7 +2810,6 @@ scripted_trigger pilgrimage_2004_potential_friend_trigger = {
 	faith = root.faith
 	NOT = { is_courtier_of = root }
 	location = root.location
-	is_ruler = no #Unop To fix [ Trying to put character in court despite being a ruler ] (because of this char being taken in piligrimage travel)
 }
 
 #Run into a potential friend
@@ -2857,9 +2856,18 @@ pilgrimage.2004 = {
 			target = scope:potential_friend
 			modifier = divine_blessing_friendship_opinion
 		}
-		add_to_entourage_court_and_activity_effect = { 
-			CHAR_TO_ADD = scope:potential_friend 
-			NEW_COURT_OWNER = root 
+		if = { #Unop Don't poach a spouse, heir, or employed courtier of another ruler
+			limit = {
+				scope:potential_friend = { is_ruler = no }
+				can_recruit_character_to_court_trigger = {
+					RECRUITER = root
+					RECRUITEE = scope:potential_friend
+				}
+			}
+			add_to_entourage_court_and_activity_effect = {
+				CHAR_TO_ADD = scope:potential_friend
+				NEW_COURT_OWNER = root
+			}
 		}
 		hidden_effect = {
 			add_opinion = {
@@ -7673,6 +7681,10 @@ pilgrimage.6001 = {
 		if = {
 			limit = {
 				scope:friend = { is_ruler = no }
+				can_recruit_character_to_court_trigger = { #Unop Don't poach a spouse, heir, or employed courtier of another ruler
+					RECRUITER = root
+					RECRUITEE = scope:friend
+				}
 			}
 			add_to_entourage_court_and_activity_effect = { 
 				CHAR_TO_ADD = scope:friend

--- a/events/activities/pilgrimage_activity/pilgrimage_events.txt
+++ b/events/activities/pilgrimage_activity/pilgrimage_events.txt
@@ -7622,10 +7622,11 @@ pilgrimage.3401 = {
 scripted_trigger pilgrimage_6001_friend_trigger = {
 	is_available_ai_adult = yes
 	faith = root.faith
-	trigger_if = {
-		limit = { faith.religion = religion:islam_religion }
-		has_trait = drunkard
-	}
+	drinks_alcohol_trigger = yes #Unop Also exclude other alcohol-forbidding faiths
+	#trigger_if = {
+	#	limit = { faith.religion = religion:islam_religion }
+	#	has_trait = drunkard
+	#}
 }
 #Sneaking off to a tavern with your pal
 # by Chad Uhl
@@ -7647,10 +7648,11 @@ pilgrimage.6001 = {
 		has_bp1_dlc_trigger = yes
 		is_location_valid_for_travel_event_on_land = yes
 		current_travel_plan = { next_destination_progress > 0.5 }
-		trigger_if = {
-			limit = { faith.religion = religion:islam_religion }
-			has_trait = drunkard
-		}
+		drinks_alcohol_trigger = yes #Unop Also exclude other alcohol-forbidding faiths
+		#trigger_if = {
+		#	limit = { faith.religion = religion:islam_religion }
+		#	has_trait = drunkard
+		#}
 		any_relation = {
 			type = friend
 			pilgrimage_6001_friend_trigger = yes


### PR DESCRIPTION
Fixes #450

`pilgrimage.2004` and `pilgrimage.6001` add the friend to the player's court via `add_to_entourage_court_and_activity_effect` (which calls `add_courtier`), guarded only by `is_ruler = no`. A non-ruler who is another ruler's spouse, child, councillor, knight, or court-position holder is still pulled out of their court.

The court-add is incidental in both event chains — nothing downstream depends on the friend being a courtier of `root`, so the friendship and opinion can still form without the poach.

**Fix 1:** Gate the court-add with the vanilla `can_recruit_character_to_court_trigger` (the canonical recruit gate, already used inside event options elsewhere, e.g. `travel_danger_events_arky.txt`, `feast_tsagaan_sar_events.txt`).

- `pilgrimage.6001`: add the trigger to the existing `if` limit around `add_to_entourage`.
- `pilgrimage.2004`: revert the prior `is_ruler = no` in the selection trigger `pilgrimage_2004_potential_friend_trigger` (it was added to silence the "Trying to put character in court despite being a ruler" script error) and instead wrap `add_to_entourage` in an `if` with `is_ruler = no` + the trigger, mirroring `pilgrimage.6001`. This keeps the friendship forming, avoids suppressing the event, and still avoids the original script error since `add_courtier` no longer runs on a ruler.

**Fix 2:** `can_recruit_character_to_court_trigger`, see the comment on the issue.

Wrapped the checks in `OR`, mirroring the two adjacent spouse-employment blocks (`OR = { #Is employed in some way }`), which is the intended structure. This is the canonical recruit trigger, so the fix also corrects **Invite to Court**, **Noble Family Adoption**, accolade recruitment, and several other events, where employed courtiers of other rulers could be recruited. See #450 for the full analysis.
