### PR TITLE
Fix greek fire firing repeatedly and targeting the open Black Sea

### DIFF
--- a/events/dlc/ep3/ep3_emperor_yearly_3.txt
+++ b/events/dlc/ep3/ep3_emperor_yearly_3.txt
@@ -1,0 +1,1947 @@
+﻿namespace = ep3_emperor_yearly
+
+############################
+# EP3 Admin Emperor Events #
+# by Jason Cantalini   	   #
+# 3000 - 3500              #
+############################
+
+# Byzantine-only: your Varangians loot the palace after succession
+
+ep3_emperor_yearly.3000 = {
+	type = character_event
+	title = ep3_emperor_yearly.3000.t
+	desc = {
+		desc = ep3_emperor_yearly.3000.desc
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:varangian_leader = {
+						is_courtier_of = root
+					}
+				}
+				desc = ep3_emperor_yearly.3000.desc_leader
+			}
+			desc = ep3_emperor_yearly.3000.desc_no_leader
+		}
+	}
+	theme = emperor
+	override_background = { reference = throne_room }
+	left_portrait = {
+		character = root
+		animation = disapproval
+	}
+	right_portrait = {
+		character = scope:varangian_leader
+		animation = celebrate_axe
+		camera = camera_event_very_left
+	}
+	lower_right_portrait = {
+		character = scope:varangian_2
+	}
+	lower_left_portrait = {
+		character = scope:varangian_3
+	}
+	lower_center_portrait = {
+		character = scope:dead_emperor
+	}
+
+	trigger = {
+		has_ep3_dlc_trigger = yes
+		primary_title = { has_variable = founded_varangian_guard }
+	}
+
+	immediate = {
+		save_scope_as = root_scope
+		#Choose which malus to use
+		random_list = {
+			#Artifact is damaged
+			10 = {
+				trigger = {
+					any_character_artifact = {
+						artifact_durability > 45
+					}
+				}
+				add_character_flag = malus_broken_artifact
+				random_character_artifact = {
+					limit = {
+						artifact_durability > 45
+					}
+					save_scope_as = broken_artifact
+				}
+				save_scope_value_as = {
+					name = varangian_gold
+					value = {
+						value = 0
+						add = {
+							value = var:varangian_regiments
+							multiply = 30
+						}
+					}
+				}
+			}
+			#Artifact is stolen
+			10 = {
+				trigger = {
+					any_character_artifact = {
+						artifact_wealth_quality_average_value < 20
+					}
+				}
+				random_character_artifact = {
+					limit = {
+						artifact_wealth_quality_average_value < 20
+					}
+					save_scope_as = stolen_artifact
+				}
+				add_character_flag = malus_stolen_artifact
+				save_scope_value_as = {
+					name = varangian_gold
+					value = {
+						value = 0
+						add = {
+							value = var:varangian_regiments
+							multiply = 30
+						}
+					}
+				}
+			}
+			##Court grandeur lost
+			10 = {
+				trigger = {
+					has_royal_court = yes
+					has_dlc_feature = royal_court
+				}
+				add_character_flag = malus_court_grandeur
+				save_scope_value_as = {
+					name = varangian_gold
+					value = {
+						value = 0
+						add = {
+							value = var:varangian_regiments
+							multiply = 30
+						}
+					}
+				}
+			}
+			##Gold is lost
+			10 = {
+				save_scope_value_as = {
+					name = varangian_gold
+					value = {
+						value = 0
+						add = {
+							value = var:varangian_regiments
+							multiply = 50
+						}
+					}
+				}
+			}
+		}
+
+		#Choose which bonus to give a refuser
+		random_list = {
+			5 = {
+				trigger = {
+					is_adult = yes
+				}
+				add_character_flag = refuse_bonus_dread
+			}
+			10 = {
+				add_character_flag = refuse_bonus_prestige
+			}
+			5 = {
+				add_character_flag = refuse_bonus_opinion
+			}
+		}
+
+		#Choose which bonus to give an accepter
+		random_list = {
+			10 = {
+				trigger = {
+					max_number_maa_soldiers_of_base_type = {
+						type = heavy_infantry
+						value >= 300
+					}
+				}
+				add_character_flag = accept_bonus_heavy_infantry
+			}
+			10 = {
+				add_character_flag = accept_bonus_scheme_resist
+			}
+			10 = {
+				add_character_flag = accept_bonus_army
+			}
+			10 = {
+				add_character_flag = accept_bonus_legitimacy
+			}
+		}
+
+		#Save a first Varangian to be the boss
+		if = {
+			limit = {
+				any_court_position_holder = {
+					type = akolouthos_court_position
+					ep3_varangian_trigger = yes
+					is_available = yes
+				}
+			}
+			random_court_position_holder = {
+				type = akolouthos_court_position
+				save_scope_as = varangian_leader
+			}
+		}
+		else_if = {
+			limit = {
+				any_court_position_holder = {
+					type = bodyguard_court_position
+					ep3_varangian_trigger = yes
+					is_available = yes
+				}
+			}
+			random_court_position_holder = {
+				type = bodyguard_court_position
+				limit = {
+					ep3_varangian_trigger = yes
+					is_available = yes
+				}
+				save_scope_as = varangian_leader
+			}
+		}
+		else_if = {
+			limit = {
+				any_courtier = {
+					ep3_varangian_trigger = yes
+					is_available_adult = yes
+				}
+			}
+			random_courtier = {
+				limit = {
+					ep3_varangian_trigger = yes
+					is_available_adult = yes
+				}
+				save_scope_as = varangian_leader
+			}
+		}
+		else_if = {
+			limit = {
+				current_date < 1066
+			}
+			#Norse
+			create_character = {
+				template = varangian_template
+				location = root.location
+				culture = culture:norse
+				faith = root.faith
+				dynasty = none
+				save_scope_as = varangian_leader
+			}
+			scope:varangian_leader = {
+				add_character_flag = need_military_outfit
+			}
+			hidden_effect = { add_visiting_courtier = scope:varangian_leader }
+		}
+		else = {
+			#Anglo-Saxon
+			create_character = {
+				template = varangian_template
+				location = root.location
+				culture = culture:anglo_saxon
+				faith = root.faith
+				dynasty = none
+				save_scope_as = varangian_leader
+			}
+			scope:varangian_leader = {
+				add_character_flag = need_military_outfit
+			}
+			hidden_effect = { add_visiting_courtier = scope:varangian_leader }
+		}
+		#Save another Varangian
+		if = {
+			limit = {
+				exists = scope:varangian_leader
+				any_court_position_holder = {
+					type = bodyguard_court_position
+					ep3_varangian_trigger = yes
+					is_available = yes
+					this != scope:varangian_leader
+				}
+			}
+			random_court_position_holder = {
+				type = bodyguard_court_position
+				limit = {
+					ep3_varangian_trigger = yes
+					is_available = yes
+					this != scope:varangian_leader
+				}
+				save_scope_as = varangian_2
+			}
+		}
+		else_if = {
+			limit = {
+				exists = scope:varangian_leader
+				any_courtier = {
+					ep3_varangian_trigger = yes
+					is_available_adult = yes
+					this != scope:varangian_leader
+				}
+			}
+			random_courtier = {
+				limit = {
+					ep3_varangian_trigger = yes
+					is_available_adult = yes
+					this != scope:varangian_leader
+				}
+				save_scope_as = varangian_2
+			}
+		}
+		#Save a third
+		if = {
+			limit = {
+				exists = scope:varangian_leader
+				exists = scope:varangian_2
+				any_court_position_holder = {
+					type = bodyguard_court_position
+					ep3_varangian_trigger = yes
+					is_available = yes
+					NOR = {
+						this = scope:varangian_leader
+						this = scope:varangian_2
+					}
+				}
+			}
+			random_court_position_holder = {
+				type = bodyguard_court_position
+				limit = {
+					ep3_varangian_trigger = yes
+					is_available = yes
+					NOR = {
+						this = scope:varangian_leader
+						this = scope:varangian_2
+					}
+				}
+				save_scope_as = varangian_3
+			}
+		}
+		else_if = {
+			limit = {
+				exists = scope:varangian_leader
+				exists = scope:varangian_2
+				any_courtier = {
+					ep3_varangian_trigger = yes
+					is_available_adult = yes
+					NOR = {
+						this = scope:varangian_leader
+						this = scope:varangian_2
+					}
+				}
+			}
+			random_courtier = {
+				limit = {
+					ep3_varangian_trigger = yes
+					is_available_adult = yes
+					NOR = {
+						this = scope:varangian_leader
+						this = scope:varangian_2
+					}
+				}
+				save_scope_as = varangian_3
+			}
+		}
+	}
+
+	#Have the Akolouthos seize some of the spoils
+	option = {
+		name = ep3_emperor_yearly.3000.a
+		flavor = ep3_emperor_yearly.3000.a.flavor
+		trigger = {
+			employs_court_position = akolouthos_court_position
+			any_court_position_holder = {
+				type = akolouthos_court_position
+				aptitude = {
+					court_position = akolouthos_court_position
+					value >= 3
+				}
+			}
+		}
+		add_internal_flag = special
+		custom_tooltip = akolouthos_aptitude_option_unlock
+		
+		#Random refuse bonus effect
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_prestige
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				add_prestige = massive_prestige_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 4
+				}
+				add_prestige = major_prestige_gain
+			}
+			else = {
+				add_prestige = medium_prestige_gain
+			}
+		}
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_dread
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				add_dread = major_dread_gain
+				add_prestige = major_prestige_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 4
+				}
+				add_dread = medium_dread_gain
+				add_prestige = medium_prestige_gain
+			}
+			else = {
+				add_dread = minor_dread_gain
+				add_prestige = minor_prestige_gain
+			}
+		}
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_opinion
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				every_vassal = {
+					custom = every_parochial_vassal
+					add_opinion = {
+						modifier = respect_opinion
+						opinion = 30
+						target = root
+					}
+				}
+				add_prestige = major_prestige_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 4
+				}
+				every_vassal = {
+					custom = every_parochial_vassal
+					add_opinion = {
+						modifier = respect_opinion
+						opinion = 20
+						target = root
+					}
+				}
+				add_prestige = medium_prestige_gain
+			}
+			else = {
+				every_vassal = {
+					custom = every_parochial_vassal
+					add_opinion = {
+						modifier = respect_opinion
+						opinion = 10
+						target = root
+					}
+				}
+				add_prestige = minor_prestige_gain
+			}
+		}
+		change_influence = medium_influence_gain
+			
+		remove_treasury_or_gold = {
+			value = {
+				value = 0
+				add = {
+					value = scope:varangian_gold
+					multiply = 0.4
+				}
+			}
+		}
+		#Negative heavy inf and scheme resistance modifier
+		add_character_modifier = {
+			modifier = disrespected_varangians_modifier
+			years = 10
+		}
+		if = {
+			limit = {
+				scope:varangian_leader = {
+					is_courtier_of = root
+				}
+			}
+			if = {
+				limit = {
+					scope:varangian_leader = { has_trait = loyal }
+				}
+				scope:varangian_leader = { remove_trait = loyal }
+				reverse_add_opinion = {
+					target = scope:varangian_leader
+					modifier = angry_opinion
+					opinion = -20
+				}
+			}
+			else = {
+				reverse_add_opinion = {
+					target = scope:varangian_leader
+					modifier = hate_opinion
+					opinion = -40
+				}
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:varangian_2
+			}
+			if = {
+				limit = {
+					scope:varangian_2 = { has_trait = loyal }
+				}
+				scope:varangian_2 = { remove_trait = loyal }
+				reverse_add_opinion = {
+					target = scope:varangian_2
+					modifier = angry_opinion
+					opinion = -20
+				}
+			}
+			else = {
+				reverse_add_opinion = {
+					target = scope:varangian_2
+					modifier = hate_opinion
+					opinion = -40
+				}
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:varangian_3
+			}
+			if = {
+				limit = {
+					scope:varangian_3 = { has_trait = loyal }
+				}
+				scope:varangian_3 = { remove_trait = loyal }
+				reverse_add_opinion = {
+					target = scope:varangian_3
+					modifier = angry_opinion
+					opinion = -20
+				}
+			}
+			else = {
+				reverse_add_opinion = {
+					target = scope:varangian_3
+					modifier = hate_opinion
+					opinion = -40
+				}
+			}
+		}
+		#Apply randomized_malus
+		if = {
+			limit = {
+				has_character_flag = malus_court_grandeur
+				var:varangian_regiments >= 7
+			}
+			change_current_court_grandeur = minor_court_grandeur_loss
+		}
+		if = {
+			limit = {
+				has_character_flag = malus_broken_artifact
+				var:varangian_regiments >= 7
+			}
+			scope:broken_artifact = {
+				add_durability = -20
+			}
+		}
+		if = {
+			limit = {
+				NOT = {
+					scope:varangian_leader = {
+						is_courtier_of = root
+					}
+				}
+			}
+			hidden_effect = {
+				scope:varangian_leader = { move_to_pool = yes }
+			}
+		}
+		
+		stress_impact = {
+			craven = medium_stress_impact_gain
+			paranoid = medium_stress_impact_gain
+			generous = medium_stress_impact_gain
+			content = minor_stress_impact_gain
+			just = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 50
+			ai_value_modifier = {
+				ai_greed = 1
+				ai_boldness = 1
+			}
+			modifier = {
+				factor = 0
+				OR = {
+					has_trait = craven
+					has_trait = paranoid
+					has_trait = generous
+					has_trait = content
+					has_trait = just
+				}
+			}
+			modifier = {
+				factor = 3
+				short_term_gold <= 300
+			}
+			modifier = {
+				factor = 0.5
+				OR = {
+					has_trait = content
+					has_trait = just
+				}
+			}
+		}
+	}
+	#Chastise the Varangians
+	option = {
+		trigger = {
+			age >= 12
+		}
+		name = ep3_emperor_yearly.3000.b
+		flavor = ep3_emperor_yearly.3000.b.flavor
+		#Random refuse bonus effect
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_prestige
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				add_prestige = massive_prestige_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 4
+				}
+				add_prestige = major_prestige_gain
+			}
+			else = {
+				add_prestige = medium_prestige_gain
+			}
+		}
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_dread
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				add_dread = major_dread_gain
+				add_prestige = major_prestige_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 4
+				}
+				add_dread = medium_dread_gain
+				add_prestige = medium_prestige_gain
+			}
+			else = {
+				add_dread = minor_dread_gain
+				add_prestige = minor_prestige_gain
+			}
+		}
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_opinion
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				every_vassal = {
+					custom = every_parochial_vassal
+					add_opinion = {
+						modifier = respect_opinion
+						opinion = 30
+						target = root
+					}
+				}
+				add_prestige = major_prestige_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 4
+				}
+				every_vassal = {
+					custom = every_parochial_vassal
+					add_opinion = {
+						modifier = respect_opinion
+						opinion = 20
+						target = root
+					}
+				}
+				add_prestige = medium_prestige_gain
+			}
+			else = {
+				every_vassal = {
+					custom = every_parochial_vassal
+					add_opinion = {
+						modifier = respect_opinion
+						opinion = 10
+						target = root
+					}
+				}
+				add_prestige = minor_prestige_gain
+			}
+		}
+
+		if = {
+			limit = {
+				var:varangian_regiments > 0
+			}
+			remove_long_term_gold = {
+				value = scope:varangian_gold
+			}
+		}
+
+		#show custom payout tooltip
+		if = {
+			limit = {
+				exists = scope:varangian_3
+			}
+			custom_tooltip = major_gold_to_varangians_tooltip
+		}
+		else_if = {
+			limit = {
+				exists = scope:varangian_2
+			}
+			custom_tooltip = medium_gold_to_varangians_tooltip
+		}
+		else_if = {
+			limit = {
+				scope:varangian_leader = {
+					is_courtier_of = root
+				}
+			}
+			custom_tooltip = minor_gold_to_varangians_tooltip
+		}
+		
+		if = {
+			limit = {
+				scope:varangian_leader = {
+					is_courtier_of = root
+				}
+			}
+			if = {
+				limit = {
+					scope:varangian_leader = { has_trait = loyal }
+				}
+				scope:varangian_leader = { remove_trait = loyal }
+			}
+			else = {
+				reverse_add_opinion = {
+					target = scope:varangian_leader
+					modifier = angry_opinion
+					opinion = -20
+				}
+			}
+			hidden_effect = {
+				pay_long_term_gold = {
+					target = scope:varangian_leader
+					gold = 25
+				}
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:varangian_2
+			}
+			if = {
+				limit = {
+					scope:varangian_2 = { has_trait = loyal }
+				}
+				scope:varangian_2 = { remove_trait = loyal }
+			}
+			else = {
+				reverse_add_opinion = {
+					target = scope:varangian_2
+					modifier = angry_opinion
+					opinion = -20
+				}
+			}
+			hidden_effect = {
+				pay_long_term_gold = {
+					target = scope:varangian_2
+					gold = 25
+				}
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:varangian_3
+			}
+			if = {
+				limit = {
+					scope:varangian_3 = { has_trait = loyal }
+				}
+				scope:varangian_3 = { remove_trait = loyal }
+			}
+			else = {
+				reverse_add_opinion = {
+					target = scope:varangian_3
+					modifier = angry_opinion
+					opinion = -20
+				}
+			}
+			hidden_effect = {
+				pay_long_term_gold = {
+					target = scope:varangian_3
+					gold = 25
+				}
+			}
+		}
+		#Negative heavy inf and scheme resistance modifier
+		add_character_modifier = {
+			modifier = disrespected_varangians_modifier
+			years = 10
+		}
+		#Apply randomized_malus
+		ep3_palace_looting_random_malus_effect = yes
+		
+		if = {
+			limit = {
+				NOT = {
+					scope:varangian_leader = {
+						is_courtier_of = root
+					}
+				}
+			}
+			hidden_effect = {
+				scope:varangian_leader = { move_to_pool = yes }
+			}
+		}
+
+		stress_impact = {
+			craven = medium_stress_impact_gain
+			paranoid = medium_stress_impact_gain
+			generous = minor_stress_impact_gain
+			content = minor_stress_impact_gain
+			just = miniscule_stress_impact_gain
+		}
+		ai_chance = {
+			base = 50
+			ai_value_modifier = {
+				ai_vengefulness = 1
+			}
+			modifier = {
+				factor = 0
+				OR = {
+					has_trait = craven
+					has_trait = paranoid
+					has_trait = generous
+					has_trait = content
+				}
+			}
+			modifier = {
+				factor = 0.5
+				OR = {
+					has_trait = generous
+					has_trait = content
+					has_trait = just
+				}
+			}
+		}
+	}
+	#It's just tradition
+	option = {
+		name = ep3_emperor_yearly.3000.c
+		flavor = ep3_emperor_yearly.3000.c.flavor
+		if = {
+			limit = {
+				has_character_flag = accept_bonus_legitimacy
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				add_legitimacy = major_legitimacy_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 3
+				}
+				add_legitimacy = medium_legitimacy_gain
+			}
+			else = {
+				add_legitimacy = minor_legitimacy_gain
+			}
+		}
+		if = {
+			limit = {
+				has_character_flag = accept_bonus_heavy_infantry
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				add_character_modifier = {
+					modifier = loyal_varangians_modifier
+					years = 10
+				}
+				add_legitimacy = medium_legitimacy_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 3
+				}
+				add_character_modifier = {
+					modifier = loyal_varangians_modifier
+					years = 10
+				}
+				add_legitimacy = miniscule_legitimacy_gain
+			}
+			else = {
+				add_character_modifier = {
+					modifier = loyal_varangians_modifier
+					years = 10
+				}
+			}
+		}
+		if = {
+			limit = {
+				has_character_flag = accept_bonus_scheme_resist
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				add_character_modifier = {
+					modifier = attentive_varangians_modifier
+					years = 10
+				}
+				add_legitimacy = medium_legitimacy_gain
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 3
+				}
+				add_character_modifier = {
+					modifier = attentive_varangians_modifier
+					years = 10
+				}
+				add_legitimacy = miniscule_legitimacy_gain
+			}
+			else = {
+				add_character_modifier = {
+					modifier = attentive_varangians_modifier
+					years = 10
+				}
+			}
+		}
+		if = {
+			limit = {
+				has_character_flag = accept_bonus_army
+			}
+			if = {
+				limit = {
+					var:varangian_regiments >= 7
+				}
+				spawn_army = {
+					name = eager_varangian_army
+					levies = 600
+					men_at_arms = {
+						type = varangian_guards
+						stacks = 4
+					}
+					location = root.capital_province
+					uses_supply = yes
+					inheritable = no
+				}
+			}
+			else_if = {
+				limit = {
+					var:varangian_regiments >= 3
+				}
+				spawn_army = {
+					name = eager_varangian_army
+					levies = 300
+					men_at_arms = {
+						type = varangian_guards
+						stacks = 2
+					}
+					location = root.capital_province
+					uses_supply = yes
+					inheritable = no
+				}
+			}
+			else = {
+				spawn_army = {
+					name = eager_varangian_army
+					levies = 100
+					men_at_arms = {
+						type = varangian_guards
+						stacks = 1
+					}
+					location = root.capital_province
+					uses_supply = yes
+					inheritable = no
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				var:varangian_regiments > 0
+			}
+			remove_long_term_gold = {
+				value = scope:varangian_gold
+			}
+		}
+
+
+		#show custom payout tooltip
+		if = {
+			limit = {
+				exists = scope:varangian_3
+			}
+			custom_tooltip = major_gold_to_varangians_tooltip
+		}
+		else_if = {
+			limit = {
+				exists = scope:varangian_2
+			}
+			custom_tooltip = medium_gold_to_varangians_tooltip
+		}
+		else_if = {
+			limit = {
+				scope:varangian_leader = {
+					is_courtier_of = root
+				}
+			}
+			custom_tooltip = minor_gold_to_varangians_tooltip
+		}
+
+		if = {
+			limit = {
+				scope:varangian_leader = {
+					is_courtier_of = root
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:varangian_leader
+				modifier = loyalty_opinion
+				opinion = 60
+			}
+			hidden_effect = {
+				pay_long_term_gold = {
+					target = scope:varangian_leader
+					gold = 25
+				}
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:varangian_2
+			}
+			reverse_add_opinion = {
+				target = scope:varangian_2
+				modifier = loyalty_opinion
+				opinion = 60
+			}
+			hidden_effect = {
+				pay_long_term_gold = {
+					target = scope:varangian_2
+					gold = 25
+				}
+			}
+		}
+		if = {
+			limit = {
+				exists = scope:varangian_3
+			}
+			reverse_add_opinion = {
+				target = scope:varangian_3
+				modifier = loyalty_opinion
+				opinion = 60
+			}
+			hidden_effect = {
+				pay_long_term_gold = {
+					target = scope:varangian_3
+					gold = 25
+				}
+			}
+		}
+
+		#Apply randomized_malus
+		ep3_palace_looting_random_malus_effect = yes
+
+		stress_impact = {
+			generous = miniscule_stress_impact_loss
+			paranoid = minor_stress_impact_loss
+			greedy = medium_stress_impact_gain
+			vengeful = medium_stress_impact_gain
+			arrogant = minor_stress_impact_gain
+			arbitrary = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 200
+			ai_value_modifier = {
+				ai_greed = -0.5
+				ai_boldness = -0.5
+				ai_vengefulness = -1
+			}
+			modifier = {
+				factor = 0
+				OR = {
+					has_trait = greedy
+					has_trait = vengeful
+					has_trait = arrogant
+					has_trait = arbitrary
+				}
+			}
+			modifier = {
+				factor = 0.5
+				OR = {
+					has_trait = arrogant
+					has_trait = arbitrary
+				}
+			}
+		}
+	}
+	after = {
+		if = {
+			limit = {
+				scope:varangian_leader = {
+					has_character_flag = need_military_outfit
+				}
+			}
+			scope:varangian_leader = {
+				remove_character_flag = need_military_outfit
+			}
+		}
+		if = {
+			limit = {
+				has_character_flag = malus_broken_artifact
+			}
+			remove_character_flag = malus_broken_artifact
+		}
+		if = {
+			limit = {
+				has_character_flag = malus_stolen_artifact
+			}
+			remove_character_flag = malus_stolen_artifact
+		}
+		if = {
+			limit = {
+				has_character_flag = malus_court_grandeur
+			}
+			remove_character_flag = malus_court_grandeur
+		}
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_dread
+			}
+			remove_character_flag = refuse_bonus_dread
+		}
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_opinion
+			}
+			remove_character_flag = refuse_bonus_opinion
+		}
+		if = {
+			limit = {
+				has_character_flag = refuse_bonus_prestige
+			}
+			remove_character_flag = refuse_bonus_prestige
+		}
+		if = {
+			limit = {
+				has_character_flag = accept_bonus_heavy_infantry
+			}
+			remove_character_flag = accept_bonus_heavy_infantry
+		}
+		if = {
+			limit = {
+				has_character_flag = accept_bonus_scheme_resist
+			}
+			remove_character_flag = accept_bonus_scheme_resist
+		}
+		if = {
+			limit = {
+				has_character_flag = accept_bonus_army
+			}
+			remove_character_flag = accept_bonus_army
+		}
+		if = {
+			limit = {
+				has_character_flag = accept_bonus_legitimacy
+			}
+			remove_character_flag = accept_bonus_legitimacy
+		}
+	}
+}
+
+#Byzantine emperor sends fireships to defend the strait of Marmara
+ep3_emperor_yearly.3010 = {
+	hidden = yes
+
+	trigger = {
+		#province is strait of Marmara
+		scope:army.location = {
+			OR = {
+				this = province:947
+				this = province:950
+				this = province:948
+				this = province:8667
+				this = province:8668
+				this = province:8665
+			}
+		}
+		#A lot of jank would be introduced by multiplayer and armies continuing to move, unpaused
+		has_multiple_players = no
+		title:c_byzantion = { has_county_modifier = defensive_fire_dromons_modifier }
+		NOT = { has_character_flag = used_fire_dromons }
+		#this event is really going to f up the enemy army in a way no player will appreciate
+		is_ai = yes
+		
+		#Is it at war with powerful ruler whose capital is Constantinople
+		any_war_enemy = {
+			is_landed = yes
+			capital_county = title:c_byzantion
+			capital_province = { is_occupied = no }
+			culture = {
+				OR = {
+					this = culture:greek
+					any_parent_culture_or_above = { this = culture:greek }
+				}
+			}
+		}
+	}
+
+	immediate = {
+		save_scope_as = invader
+		scope:army.army_commander ?= { save_scope_as = invading_commander }
+		random_war_enemy = {
+			limit = {
+				is_landed = yes
+				capital_county = title:c_byzantion
+				capital_province = { is_occupied = no }
+				culture = {
+					OR = {
+						this = culture:greek
+						any_parent_culture_or_above = { this = culture:greek }
+					}
+				}
+			}
+			save_scope_as = marmara_defender
+		}
+		scope:marmara_defender = {
+			trigger_event = ep3_emperor_yearly.3011
+		}
+	}
+}
+
+ep3_emperor_yearly.3011 = {
+	type = character_event
+	title = ep3_emperor_yearly.3011.t
+	desc = {
+		desc = ep3_emperor_yearly.3011.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:invader = {
+						this = scope:invading_commander
+					}
+				}
+				desc = ep3_emperor_yearly.3011.liege_attacking
+			}
+			desc = ep3_emperor_yearly.3011.commander_attacking
+		}
+		desc = ep3_emperor_yearly.3011.desc
+		triggered_desc = {
+			trigger = {
+				knows_language = language_greek
+				religion = religion:christianity_religion
+			}
+			desc = ep3_emperor_yearly.3011.kyrie_eleison
+		}
+	}
+	theme = war
+	override_background = { reference = ep3_constantinople }
+	left_portrait = {
+		character = scope:city_defender
+		animation = survey
+		camera = camera_event_left_away
+	}
+	lower_right_portrait = {
+		character = scope:invading_commander
+	}
+
+	immediate = {
+		#perspective character for event window
+		if = {
+			limit = {
+				is_available = yes
+			}
+			save_scope_as = city_defender
+		}
+		else_if = {
+			limit = {
+				cp:councillor_marshal ?= {
+					is_available = yes
+				}
+			}
+			cp:councillor_marshal = {
+				save_scope_as = city_defender
+			}
+		}
+		else_if = {
+			limit = {
+				OR = {
+					has_diarchy_type = temporary_regency
+					has_diarchy_type = regency
+				}
+				diarch = {
+					is_available = yes
+				}
+			}
+			diarch = { save_scope_as = city_defender }
+		}
+		else = {
+			save_scope_as = city_defender
+		}
+		scope:city_defender = {
+			add_character_flag = need_military_outfit
+		}
+		scope:invader = {
+			if = {
+				limit = {
+					any_knight = {
+						is_in_army = yes
+						this != scope:invading_commander
+					}
+				}
+				random_knight = {
+					limit = {
+						is_in_army = yes
+						this != scope:invading_commander
+					}
+					save_scope_as = knight_1
+				}
+			}
+			if = {
+				limit = {
+					any_knight = {
+						is_in_army = yes
+						NOR = {
+							this = scope:knight_1
+							this = scope:invading_commander
+						}
+					}
+				}
+				random_knight = {
+					limit = {
+						is_in_army = yes
+						NOR = {
+							this = scope:knight_1
+							this = scope:invading_commander
+						}
+					}
+					save_scope_as = knight_2
+				}
+			}
+			if = {
+				limit = {
+					any_knight = {
+						is_in_army = yes
+						NOR = {
+							this = scope:knight_1
+							this = scope:knight_2
+							this = scope:invading_commander
+						}
+					}
+				}
+				random_knight = {
+					limit = {
+						is_in_army = yes
+						NOR = {
+							this = scope:knight_1
+							this = scope:knight_2
+							this = scope:invading_commander
+						}
+					}
+					save_scope_as = knight_3
+				}
+			}
+			if = {
+				limit = {
+					any_knight = {
+						is_in_army = yes
+						NOR = {
+							this = scope:knight_1
+							this = scope:knight_2
+							this = scope:knight_3
+							this = scope:invading_commander
+						}
+					}
+				}
+				random_knight = {
+					limit = {
+						is_in_army = yes
+						NOR = {
+							this = scope:knight_1
+							this = scope:knight_2
+							this = scope:knight_3
+							this = scope:invading_commander
+						}
+					}
+					save_scope_as = knight_4
+				}
+			}
+			if = {
+				limit = {
+					any_knight = {
+						is_in_army = yes
+						NOR = {
+							this = scope:knight_1
+							this = scope:knight_2
+							this = scope:knight_3
+							this = scope:knight_4
+							this = scope:invading_commander
+						}
+					}
+				}
+				random_knight = {
+					limit = {
+						is_in_army = yes
+						NOR = {
+							this = scope:knight_1
+							this = scope:knight_2
+							this = scope:knight_3
+							this = scope:knight_4
+							this = scope:invading_commander
+						}
+					}
+					save_scope_as = knight_5
+				}
+			}
+		}
+	}
+	#Use the greek fire ships
+	option = {
+		name = ep3_emperor_yearly.3011.a
+		add_character_flag = {
+			flag = used_fire_dromons
+			days = 30
+		}
+		custom_tooltip = unable_to_use_fire_ships_tooltip
+		scope:city_defender = {
+			duel = {
+				skill = martial
+				target = scope:invading_commander
+				35 = { #Your fleet ruins the enemy
+					desc = ep3_emperor_yearly.3011.a.success
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = 3.5
+						min = -34
+					}
+					modifier = {
+						has_trait = forder
+						add = 20
+					}
+					modifier = {
+						highest_held_title_tier >= tier_empire
+						
+						add = 10
+					}
+					modifier = {
+						scope:army = {
+							army_size <= 1000
+						}
+						add = 10
+					}
+					modifier = {
+						scope:army = {
+							#Big enough army to actually siege the city
+							army_size < 2500
+						}
+						add = 10
+					}
+					modifier = {
+						scope:invading_commander = {
+							has_trait = reckless
+						}
+						add = 10
+					}
+					modifier = {
+						has_trait = reckless
+						add = 10
+					}
+					modifier = {
+						has_trait = aggressive_attacker
+						add = 10
+					}
+					modifier = {
+						has_trait = military_engineer
+						add = 10
+					}
+					modifier = {
+						scope:invading_commander = {
+							has_trait = aggressive_attacker
+						}
+						add = 10
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = curtain_walls_01
+						}
+						add = 5
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = curtain_walls_03
+						}
+						add = 5
+					}
+					modifier = {
+						province:496  = {
+							has_building_or_higher = curtain_walls_05
+						}
+						add = 5
+					}
+					modifier = {
+						province:496  = {
+							has_building_or_higher = curtain_walls_07
+						}
+						add = 5
+					}
+					modifier = {
+						province:496  = {
+							has_building_or_higher = common_tradeport_01
+						}
+						add = 5
+					}
+					modifier = {
+						province:496  = {
+							has_building_or_higher = common_tradeport_03
+						}
+						add = 5
+					}
+					modifier = {
+						province:496  = {
+							has_building_or_higher = common_tradeport_05
+						}
+						add = 5
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = common_tradeport_07
+						}
+						add = 5
+					}
+					show_as_tooltip = { ep3_greek_fire_success_effect = yes }
+					root = { add_character_flag = successful_greek_fire_attack }
+				}
+				50 = { #Your fleet does some damage
+					desc = ep3_emperor_yearly.3011.a.fail
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = -3.5
+						min = -49
+					}
+					modifier = {
+						has_trait = forder
+						add = 40
+					}
+					modifier = {
+						scope:army = {
+							#Big enough army to actually siege the city
+							army_size < 2500
+						}
+						add = 20
+					}
+					modifier = {
+						scope:army = {
+							army_size <= 1000
+						}
+						add = 20
+					}
+					modifier = {
+						scope:invading_commander = {
+							has_trait = reckless
+						}
+						add = 20
+					}
+					modifier = {
+						scope:invading_commander = {
+							has_trait = aggressive_attacker
+						}
+						add = 10
+					}
+					modifier = {
+						has_trait = aggressive_attacker
+						add = 20
+					}
+					modifier = {
+						has_trait = military_engineer
+						add = 20
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = curtain_walls_01
+						}
+						add = 10
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = curtain_walls_03
+						}
+						add = 10
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = curtain_walls_05
+						}
+						add = 10
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = curtain_walls_07
+						}
+						add = 10
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = common_tradeport_01
+						}
+						add = 10
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = common_tradeport_03
+						}
+						add = 10
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = common_tradeport_05
+						}
+						add = 10
+					}
+					modifier = {
+						province:496 = {
+							has_building_or_higher = common_tradeport_07
+						}
+						add = 10
+					}
+					show_as_tooltip = { ep3_greek_fire_fail_effect = yes }
+					root = { add_character_flag = failed_greek_fire_attack }
+				}
+				15 = { #Your fleet does a little damage and... ruins themselves
+					desc = ep3_emperor_yearly.3011.a.critical_fail
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = -3.5
+						min = -14
+					}
+					modifier = {
+						scope:invading_commander = {
+							has_trait = forder
+						}
+						add = 40
+					}
+					modifier = {
+						scope:invading_commander = {
+							has_trait = organizer
+						}
+						add = 20
+					}
+					modifier = {
+						scope:invading_commander = {
+							has_trait = cautious_leader
+						}
+						add = 20
+					}
+					modifier = {
+						has_trait = cautious_leader
+						add = 20
+					}
+					
+					modifier = {
+						scope:army = {
+							army_size >= 5000
+						}
+						add = 20
+					}
+					modifier = {
+						scope:army = {
+							army_size >= 10000
+						}
+						add = 20
+					}
+					show_as_tooltip = { ep3_greek_fire_crit_fail_effect = yes }
+					root = { add_character_flag = crit_failed_greek_fire_attack }
+				}
+			}
+		}
+		trigger_event = ep3_emperor_yearly.3012
+		stress_impact = {
+			compassionate = medium_stress_impact_gain
+			cautious_leader = medium_stress_impact_gain
+			patient = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_vengefulness = 1
+				ai_boldness = 1
+			}
+			modifier = {
+				add = 20
+				scope:city_defender = {
+					martial >= high_skill_rating
+				}
+			}
+			modifier = {
+				add = 20
+				scope:invading_commander = {
+					martial <= high_skill_rating
+				}
+			}
+			modifier = {
+				factor = 0.5
+				OR = {
+					has_trait = compassionate
+					has_trait = cautious_leader
+				}
+			}
+			modifier = {
+				factor = 2
+				scope:army = {
+					army_size >= 4000
+				}
+			}
+			modifier = {
+				factor = 2
+				scope:army = {
+					army_size >= 7000
+				}
+			}
+		}
+	}
+	#Don't attack
+	option = {
+		name = ep3_emperor_yearly.3011.b
+		if = {
+			limit = {
+				scope:army = {
+					#Big enough army to actually siege the city
+					army_size >= 4000
+				}
+			}
+			add_prestige = medium_prestige_loss
+		}
+		else_if = {
+			limit = {
+				scope:army = {
+					army_size >= 3000
+				}
+			}
+			add_prestige = minor_prestige_loss
+		}
+		else = {
+			add_prestige = miniscule_prestige_loss
+		}
+		stress_impact = {
+			vengeful = medium_stress_impact_gain
+			wrathful = medium_stress_impact_gain
+			sadistic = miniscule_stress_impact_gain
+			reckless = minor_stress_impact_gain
+			brave = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			ai_value_modifier = {
+				ai_energy = -1
+				ai_boldness = -1
+			}
+			modifier = {
+				add = 20
+				scope:city_defender = {
+					martial < decent_skill_rating
+				}
+			}
+			modifier = {
+				add = 20
+				scope:invading_commander = {
+					martial > very_high_skill_rating
+				}
+			}
+			modifier = {
+				factor = 0.5
+				OR = {
+					has_trait = wrathful
+					has_trait = vengeful
+					has_trait = reckless
+					has_trait = brave
+				}
+			}
+			modifier = {
+				factor = 2
+				scope:army = {
+					army_size <= 2000
+				}
+			}
+			modifier = {
+				factor = 2
+				scope:army = {
+					army_size < 1000
+				}
+			}
+		}
+	}
+	after = {
+		scope:city_defender = { remove_character_flag = need_military_outfit }
+	}
+}
+
+ep3_emperor_yearly.3012 = {
+	type = character_event
+	title = ep3_emperor_yearly.3012.t
+	desc = {
+		desc = ep3_emperor_yearly.3012.intro
+		#Triggered desc based on success
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_character_flag = successful_greek_fire_attack
+				}
+				desc = ep3_emperor_yearly.3012.attack_success
+			}
+			triggered_desc = {
+				trigger = {
+					has_character_flag = failed_greek_fire_attack
+				}
+				desc = ep3_emperor_yearly.3012.attack_fail
+			}
+			triggered_desc = {
+				trigger = {
+					has_character_flag = crit_failed_greek_fire_attack
+				}
+				desc = ep3_emperor_yearly.3012.attack_crit_fail
+			}
+		}
+	}
+	theme = war
+	override_background = { reference = ocean }
+	widget = {
+		gui = "event_window_widget_vfx_heavy_smoke"
+		container = "foreground_shader_vfx_container"
+	}
+	right_portrait = {
+		character = scope:invading_commander
+		triggered_animation = {
+			trigger = {
+				root = { has_character_flag = successful_greek_fire_attack }
+			}
+			animation = sword_yield_start
+		}
+		triggered_animation = {
+			trigger = {
+				root = { has_character_flag = failed_greek_fire_attack }
+			}
+			animation = fear
+		}
+		triggered_animation = {
+			trigger = {
+				root = { has_character_flag = crit_failed_greek_fire_attack }
+			}
+			animation = sword_coup_degrace
+		}
+	}
+
+	immediate = {
+		play_music_cue = "mx_cue_war_declared"
+		#show effect as tooltip here
+		create_character_memory = {
+			type = endured_greek_fire_memory
+			participants = {
+				attacker = root
+			}
+		}
+	}
+
+	option = {
+		name = {
+			trigger = { has_character_flag = successful_greek_fire_attack }
+			text = ep3_emperor_yearly.3012.a_success
+		}
+		name = {
+			trigger = { has_character_flag = failed_greek_fire_attack }
+			text = ep3_emperor_yearly.3012.a_fail
+		}
+		name = {
+			trigger = { has_character_flag = crit_failed_greek_fire_attack }
+			text = ep3_emperor_yearly.3012.a_crit_fail
+		}
+
+		if = {
+			limit = { has_character_flag = successful_greek_fire_attack
+			}
+			ep3_greek_fire_success_effect = yes
+		}
+		if = {
+			limit = {
+				has_character_flag = failed_greek_fire_attack
+			}
+			ep3_greek_fire_fail_effect = yes
+		}
+		if = {
+			limit = {
+				has_character_flag = crit_failed_greek_fire_attack
+			}
+			ep3_greek_fire_crit_fail_effect = yes
+		}
+		#Apply memory to invading commander?
+		if = {
+			limit = {
+				has_character_flag = successful_greek_fire_attack
+			}
+			stress_impact = {
+				sadistic = medium_stress_impact_loss
+				paranoid = minor_stress_impact_loss
+				vengeful = medium_stress_impact_loss
+				callous = minor_stress_impact_loss
+			}
+		}
+	}
+	after = {
+		if = {
+			limit = { has_character_flag = successful_greek_fire_attack
+			}
+			remove_character_flag = successful_greek_fire_attack
+		}
+		if = {
+			limit = {
+				has_character_flag = failed_greek_fire_attack
+			}
+			remove_character_flag = failed_greek_fire_attack
+		}
+		if = {
+			limit = {
+				has_character_flag = crit_failed_greek_fire_attack
+			}
+			remove_character_flag = crit_failed_greek_fire_attack
+		}
+	}
+}

--- a/events/dlc/ep3/ep3_emperor_yearly_3.txt
+++ b/events/dlc/ep3/ep3_emperor_yearly_3.txt
@@ -1199,9 +1199,10 @@ ep3_emperor_yearly.3010 = {
 		scope:army.location = {
 			OR = {
 				this = province:947
-				this = province:950
+				#Unop Don't fire in the open Black Sea, only in the strait
+				#this = province:950
 				this = province:948
-				this = province:8667
+				#this = province:8667
 				this = province:8668
 				this = province:8665
 			}
@@ -1209,7 +1210,8 @@ ep3_emperor_yearly.3010 = {
 		#A lot of jank would be introduced by multiplayer and armies continuing to move, unpaused
 		has_multiple_players = no
 		title:c_byzantion = { has_county_modifier = defensive_fire_dromons_modifier }
-		NOT = { has_character_flag = used_fire_dromons }
+		#Unop Check the cooldown on the defender, where .3011 sets it, not the invader
+		NOT = { title:c_byzantion.holder = { has_character_flag = used_fire_dromons } }
 		#this event is really going to f up the enemy army in a way no player will appreciate
 		is_ai = yes
 		


### PR DESCRIPTION
Fixes #459

`ep3_emperor_yearly.3010` fires greek fire from `on_army_enter_province` (every province entry). Two vanilla bugs:

- **Fires every province entry, not once per 30 days.** The `used_fire_dromons` cooldown is checked in `.3010` on the invader (root), but set in `.3011` on the Byzantine defender (`scope:marmara_defender`) — so the check never matched and never blocked re-firing. Greek fire is one shared Byzantine fleet ("I cannot risk the fleet"; tooltip "Your Greek Fire ships will be unavailable for 30 days"), so the cooldown is per-defender. Now checked on `title:c_byzantion.holder`; the vanilla `.3011` set is left untouched. Declining (option B) intentionally sets no flag — the fleet wasn't spent.
- **Targets nonsense positions (Crimea / open Black Sea).** The `#strait of Marmara` location list included `province:950` and `province:8667` (`sea_black`, reaching Crimea). Removed; the actual strait approach (`947 sea_marmara`, `948 sea_gulf_varna`, `8665 sea_dardanelles`, `8668 sea_bosporus`) is kept.