### PR TITLE
Fix befriend scheme Mandala Serenity Aspect modifier tooltip

### DIFF
--- a/common/schemes/scheme_types/befriend_scheme.txt
+++ b/common/schemes/scheme_types/befriend_scheme.txt
@@ -624,7 +624,7 @@
 				house ?= { has_house_head_parameter = improved_befriend_schemes }
 				is_house_head = yes
 			}
-			desc = aspect_of_serenity
+			desc = has_aspect_of_serenity #Unop Use the loc key, not the raw parameter token
 			add = 25
 		}
 


### PR DESCRIPTION
Fixes #478

The befriend scheme's +25 modifier for the Mandala "Aspect of Serenity" house aspiration used `desc = aspect_of_serenity`, but `aspect_of_serenity` has no loc entry — it's just the parameter token. Result: the scheme modifiers tooltip showed the raw key instead of a localized line.

Vanilla's parallel sway scheme handles the same bonus correctly with `desc = has_aspect_of_serenity`, which resolves via `tgp_mandala_modifiers_l_english.yml` to `"Aspect of Serenity: +25"`. Switch the befriend scheme to use the same loc key.