### PR TITLE
Fix Random Harm game rule not affecting yearly trigger chance

### DIFF
--- a/events/harm_events.txt
+++ b/events/harm_events.txt
@@ -9681,6 +9681,12 @@ harm.9501 = {
 		is_incapable = no
 	}
 
+	#Unop Make the yearly chance to trigger a harm event respect the Random Harm game rule
+	weight_multiplier = {
+		base = 0
+		modifier = { add = harm_game_rule_likelihood_value }
+	}
+
 	immediate = {
 		trigger_event = { on_action = harm_events_pulse }
 	}


### PR DESCRIPTION
Fixes #476

`harm.9501` is the event that decides whether any random harm event fires in a given year (called at weight 15 from `yearly_health_pulse`). It had no `weight_multiplier`, so its yearly probability was independent of the `Random Harm` game rule — the rule only ever affected *which* harm event was selected once `harm.9501` had already fired, not the overall yearly chance.

Add a `weight_multiplier` to `harm.9501` that gates on `harm_game_rule_likelihood_value`, the same script value used by the individual harm events. This makes the yearly chance respect the game rule:

- `Illusion of Safety` → 0.25× the default chance
- `Dangerous` / `Spiteful` → default
- `Tragic` / `Tragically Spiteful` → 1.5× the default chance