### PR TITLE
Add French Localization Add-on link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,6 @@ You can reach us either by opening an issue on [GitHub](https://github.com/ProZe
 * [Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=2871648329)
 * [GitHub Repository](https://github.com/ProZeratul/CrusaderKings3UnofficialPatch)
 * [German Localization Add-on](https://steamcommunity.com/sharedfiles/filedetails/?id=3355568022)
+* [French Localization Add-on](https://steamcommunity.com/sharedfiles/filedetails/?id=3728831113)
 
 If you'd like to support the lead maintainer's work: [ko-fi.com/kazarion](https://ko-fi.com/kazarion).

--- a/description.bbc
+++ b/description.bbc
@@ -106,6 +106,7 @@ You can reach us either by opening an issue on [url=https://github.com/ProZeratu
 [list]
 [*] [url=https://github.com/ProZeratul/CrusaderKings3UnofficialPatch]GitHub Repository[/url]
 [*] [url=https://steamcommunity.com/sharedfiles/filedetails/?id=3355568022]German Localization Add-on[/url]
+[*] [url=https://steamcommunity.com/sharedfiles/filedetails/?id=3728831113]French Localization Add-on[/url]
 [/list]
 
 If you'd like to support the lead maintainer's work: [url=https://ko-fi.com/kazarion]ko-fi.com/kazarion[/url].


### PR DESCRIPTION
A French translation of Unop is now available on the Steam Workshop. Add it alongside the German one in `README.md` and `description.bbc`.

- French Localization Add-on: https://steamcommunity.com/sharedfiles/filedetails/?id=3728831113