### PR TITLE
Document mandala court positions crash compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The current version is compatible with **CK3 1.19**. Older CK3 versions are supp
 
 With the above load order, Unop is compatible with practically every other mod. If another mod replaces a file Unop also edits, you lose Unop's fixes for that file, but you avoid breaking the other mod's content.
 
+One exception: if another mod overrides `common/court_positions/types/00_mandala_court_positions.txt` without the Unop fix of the `khlon_glan_court_position` aptitude, the game will crash. In that case, please ask the other mod's author to incorporate the fix.
+
 The mod works with all DLCs and is save-game compatible.
 
 ## Localization

--- a/description.bbc
+++ b/description.bbc
@@ -66,6 +66,8 @@ The current version is compatible with [b]CK3 1.19[/b]. Older CK3 versions are s
 
 With the above load order, Unop is compatible with practically every other mod. If another mod replaces a file Unop also edits, you lose Unop's fixes for that file, but you avoid breaking the other mod's content.
 
+One exception: if another mod overrides [u]common/court_positions/types/00_mandala_court_positions.txt[/u] without the Unop fix of the [u]khlon_glan_court_position[/u] aptitude, the game will crash. In that case, please ask the other mod's author to incorporate the fix.
+
 The mod works with all DLCs and is save-game compatible.
 
 [h2]Localization[/h2]


### PR DESCRIPTION
Add a short note to the Compatibility section of `README.md` and `description.bbc` flagging that if another mod overrides `common/court_positions/types/00_mandala_court_positions.txt` without the Unop fix of the `khlon_glan_court_position` aptitude, the game will crash, and advising users to ask the other mod's author to incorporate the fix.