### PR TITLE
Keep relative harm event weights independent of Random Harm game rule

### DIFF
--- a/events/harm_events.txt
+++ b/events/harm_events.txt
@@ -913,10 +913,10 @@ harm.0501 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Weight up if you're _already_ inbred.
 		modifier = {
 			add = 0.5
@@ -1108,10 +1108,10 @@ harm.0502 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Weight up if you're _already_ inbred.
 		modifier = {
 			add = 0.5
@@ -1192,10 +1192,10 @@ harm.0511 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -1347,10 +1347,10 @@ harm.0512 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -1461,10 +1461,10 @@ harm.0521 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -1633,10 +1633,10 @@ harm.0522 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -1709,10 +1709,10 @@ harm.0531 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -1877,10 +1877,10 @@ harm.0532 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -2011,10 +2011,10 @@ harm.0541 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# If your body is poorly set up, then you're more accutely vulnerable.
 		modifier = {
 			add = 0.25
@@ -2180,10 +2180,10 @@ harm.0542 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# If your body is poorly set up, then you're more accutely vulnerable.
 		modifier = {
 			add = 0.25
@@ -2281,10 +2281,10 @@ harm.0551 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -2436,10 +2436,10 @@ harm.0552 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -2522,10 +2522,10 @@ harm.0561 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -2683,10 +2683,10 @@ harm.0562 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -2792,10 +2792,10 @@ harm.0571 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -2966,10 +2966,10 @@ harm.0572 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -3049,10 +3049,10 @@ harm.0581 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Some characters are more likely to take baths.
 		modifier = {
 			add = 0.25
@@ -3169,10 +3169,10 @@ harm.0582 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Some characters are more likely to take baths.
 		modifier = {
 			add = 0.25
@@ -3271,10 +3271,10 @@ harm.0591 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -3424,10 +3424,10 @@ harm.0592 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -3553,10 +3553,10 @@ harm.0601 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -3659,10 +3659,10 @@ harm.0602 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -3758,10 +3758,10 @@ harm.0611 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -3920,10 +3920,10 @@ harm.0612 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -4015,10 +4015,10 @@ harm.0621 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -4179,10 +4179,10 @@ harm.0622 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 	}
 
 	immediate = {
@@ -4419,10 +4419,10 @@ harm.0631 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -4602,10 +4602,10 @@ harm.0632 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -4707,10 +4707,10 @@ harm.0641 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -4878,10 +4878,10 @@ harm.0642 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -4965,10 +4965,10 @@ harm.1001 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -5115,10 +5115,10 @@ harm.1002 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -5190,10 +5190,10 @@ harm.1011 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -5360,10 +5360,10 @@ harm.1012 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -5448,10 +5448,10 @@ harm.1021 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -5626,10 +5626,10 @@ harm.1022 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -5705,10 +5705,10 @@ harm.1031 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = -0.75
@@ -5877,10 +5877,10 @@ harm.1032 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = -0.75
@@ -5964,10 +5964,10 @@ harm.1041 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -6081,10 +6081,10 @@ harm.1042 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -6165,10 +6165,10 @@ harm.1051 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -6274,10 +6274,10 @@ harm.1052 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -6361,10 +6361,10 @@ harm.1061 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -6517,10 +6517,10 @@ harm.1062 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -6631,10 +6631,10 @@ harm.1071 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -6891,10 +6891,10 @@ harm.1072 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -7006,10 +7006,10 @@ harm.1081 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -7165,10 +7165,10 @@ harm.1082 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -7239,10 +7239,10 @@ harm.1091 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -7426,10 +7426,10 @@ harm.1092 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -7504,10 +7504,10 @@ harm.1101 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -7667,10 +7667,10 @@ harm.1102 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -7777,10 +7777,10 @@ harm.1111 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25
@@ -7995,10 +7995,10 @@ harm.1112 = {
 	}
 
 	weight_multiplier = {
-		base = 0
+		base = 1 #Unop Keep relative harm event weights independent of the Random Harm game rule
 
 		# Add the weightings.
-		modifier = { add = harm_game_rule_likelihood_value }
+		#modifier = { add = harm_game_rule_likelihood_value }
 		# Plus some other factors apply.
 		modifier = {
 			add = 0.25


### PR DESCRIPTION
Fixes #476

Secondary fix for #476 (the primary yearly-trigger-chance fix landed in #484).

For the 54 `harm_events_pulse` events, flip `base = 0`to `base = 1` and comment out the `harm_game_rule_likelihood_value` modifier. Since that value is 1 at the default Dangerous setting, the baseline weight is unchanged, but the relative ratios between events are now constant across all game-rule settings.
