### PR TITLE
Fix Swift Execution perk applying oversized murder scheme phase reduction

### DIFF
--- a/common/lifestyle_perks/00_intrigue_1_skulduggery_tree_perks.txt
+++ b/common/lifestyle_perks/00_intrigue_1_skulduggery_tree_perks.txt
@@ -1,0 +1,263 @@
+﻿truth_is_relative_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 2 0 }
+	icon = node_intrigue
+
+	auto_selection_weight = {
+		value = 11
+		if = {
+			limit = {
+				has_education_intrigue_trigger = yes
+			}
+			add = 1989
+		}
+		if = {
+			limit = {
+				has_focus = intrigue_skulduggery_focus
+			}
+			multiply = 5
+		}
+		if = {
+			limit = {
+				can_start_new_lifestyle_tree_trigger = no
+			}
+			multiply = 0
+		}
+		if = { # Conquerors go for the best stuff for war!
+			limit = {
+				has_variable = conqueror
+			}
+			add = 10000
+		}
+	}
+
+	can_be_picked = {
+		always = yes
+	}
+
+	effect = {
+		custom_description_no_bullet = {
+			text = truth_is_relative_scheme_effect
+		}
+		if = {
+			limit = {
+				NOT = { government_has_flag = government_is_landless_adventurer }
+			}
+			custom_description_no_bullet = {
+				text = truth_is_relative_perk_effect
+			}
+		}
+	}
+}
+
+digging_for_dirt_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 0 1.25 }
+	icon = node_intrigue
+
+	parent = truth_is_relative_perk
+
+	can_be_picked = {
+		always = yes
+	}
+
+	effect = {
+		if = {
+			limit = {
+				NOT = { government_has_flag = government_is_landless_adventurer }
+			}
+			custom_description_no_bullet = {
+				text = digging_for_dirt_perk_effect
+			}
+		}
+		if = {
+			limit = {
+				government_has_flag = government_is_landless_adventurer
+			}	
+			custom_tooltip = {
+				text = adventurer_digging_for_dirt_perk_effect
+			}
+		}
+	}
+}
+
+kidnapper_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 0 2.5 }
+	icon = node_intrigue
+
+	parent = digging_for_dirt_perk
+
+	can_be_picked = {
+		always = yes
+	}
+
+	effect = {
+		custom_description_no_bullet = {
+			text = kidnapper_perk_effect
+		}
+		if = {
+			limit = { government_has_flag = government_is_nomadic }
+			custom_description_no_bullet = {
+				text = kidnapper_perk_nomadic_effect
+			}
+		}
+	}
+}
+
+court_of_shadows_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 2 1.25 }
+	icon = node_intrigue
+
+	parent = truth_is_relative_perk
+	
+	name = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { has_government = landless_adventurer_government }
+				desc = court_of_shadows_perk_adventurer_name
+			}
+			desc = court_of_shadows_perk_name
+		}
+	}
+
+	can_be_picked = {
+		always = yes
+	}
+	
+	government_character_modifier = {
+		flag = government_is_administrative
+		owned_political_scheme_success_chance_max_add = 10
+	}
+
+	effect = {
+		if = {
+			limit = {
+				NOT = { government_has_flag = government_is_landless_adventurer }
+			}
+			custom_description_no_bullet = {
+				text = court_of_shadows_perk_effect
+			}
+			custom_description_no_bullet = { text = court_of_shadows_perk_effect.increased_grace }
+		}
+		if = {
+			limit = {
+				government_has_flag = government_is_landless_adventurer
+			}	
+			custom_tooltip = {
+				text = adventurer_court_of_shadows_perk_effect
+			}
+			custom_tooltip = court_of_shadows_perk_effect.increased_grace
+		}
+	}
+}
+
+prepared_for_anything_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 2 2.5 }
+	icon = node_intrigue
+
+	parent = court_of_shadows_perk
+
+	can_be_picked = {
+		always = yes
+	}
+
+	character_modifier = {
+		enemy_hostile_scheme_success_chance_add = -25
+	}
+
+	effect = {
+		custom_description_no_bullet = {
+			text = prepared_for_anything_perk_bonus_effect
+		}
+	}
+}
+
+swift_execution_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 4 1.25 }
+	icon = node_intrigue
+
+	parent = truth_is_relative_perk
+
+	can_be_picked = {
+		always = yes
+	}
+	
+	government_character_modifier = {
+		flag = government_is_landless_adventurer
+		murder_scheme_phase_duration_add = monumental_scheme_phase_duration_bonus_value
+	}
+
+	character_modifier = {
+		murder_scheme_phase_duration_add = medium_scheme_phase_duration_bonus_value
+	}
+}
+
+a_job_done_right_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 4 2.5 }
+	icon = node_intrigue
+
+	parent = swift_execution_perk
+
+	can_be_picked = {
+		always = yes
+	}
+
+	character_modifier = {
+		owned_hostile_scheme_success_chance_add = 25
+		owned_hostile_scheme_success_chance_max_add = 5
+	}
+}
+
+twice_schemed_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 2 3.75 }
+	icon = node_intrigue
+
+	parent = kidnapper_perk
+	parent = prepared_for_anything_perk
+	parent = a_job_done_right_perk
+
+	can_be_picked = {
+		always = yes
+	}
+
+	character_modifier = {
+		max_hostile_schemes_add = 1
+	}
+	
+	government_character_modifier = {
+		flag = government_is_administrative
+		max_political_schemes_add = 1
+	}
+}
+
+schemer_perk = {
+	lifestyle = intrigue_lifestyle
+	tree = skulduggery
+	position = { 2 5 }
+	icon = trait_schemer
+
+	parent = twice_schemed_perk
+
+	can_be_picked = {
+		always = yes
+	}
+
+	trait = schemer
+	effect = {
+		add_trait_force_tooltip = schemer
+	}
+}

--- a/common/lifestyle_perks/00_intrigue_1_skulduggery_tree_perks.txt
+++ b/common/lifestyle_perks/00_intrigue_1_skulduggery_tree_perks.txt
@@ -194,11 +194,11 @@ swift_execution_perk = {
 	
 	government_character_modifier = {
 		flag = government_is_landless_adventurer
-		murder_scheme_phase_duration_add = monumental_scheme_phase_duration_bonus_value
+		murder_scheme_phase_duration_add = major_scheme_phase_duration_bonus_value #Unop scale to murder's shorter multi-phase structure
 	}
 
 	character_modifier = {
-		murder_scheme_phase_duration_add = medium_scheme_phase_duration_bonus_value
+		murder_scheme_phase_duration_add = minor_scheme_phase_duration_bonus_value #Unop scale to murder's shorter multi-phase structure
 	}
 }
 


### PR DESCRIPTION
Fixes #504

The `swift_execution_perk` used `monumental` (-100 days) for LAAMPs and `medium` (-20 days) for regular rulers — the same values used by friendly scheme perks (befriend, seduce, courting, elope) against their single 365-day phase.

Fix: replace with values that give a proportionally equivalent reduction on murder's 120-day base:
- Regular ruler: `medium` (-20) → `minor` (-10, ~8%)
- LAAMP: `monumental` (-100) → `major` (-40, ~33%)