### PR TITLE
Fix laamp_as_mercenary_payout_trigger checking wrong side for defender employers

### DIFF
--- a/common/scripted_triggers/07_ep3_triggers.txt
+++ b/common/scripted_triggers/07_ep3_triggers.txt
@@ -1797,7 +1797,7 @@ laamp_as_mercenary_payout_trigger = {
 				scope:merc_temp = { is_attacker_in_war = scope:war_temp }
 			}
 			trigger_else = {
-				scope:merc_temp = { is_attacker_in_war = scope:war_temp }
+				scope:merc_temp = { is_defender_in_war = scope:war_temp } #Unop should check defender, not attacker, when employer is a defender
 			}
 		}
 		NOT = { is_leader_in_war = scope:war_temp }


### PR DESCRIPTION
Fixes #496

In `laamp_as_mercenary_payout_trigger`, the `trigger_else` branch (which runs when the employer is a **defender**) incorrectly checked `is_attacker_in_war` for the mercenary instead of `is_defender_in_war`. This is the same condition as the `trigger_if` case, applied backwards.

Fix: change `is_attacker_in_war` to `is_defender_in_war` in the `trigger_else` branch.