### PR TITLE
Fix AI never taking decisions with a non-zero influence cost

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -486,7 +486,15 @@ filter = {
 		NAND = { # scope:province_change_recipient absence is handled in change_province_metropolitan_effect
 			key = strict-scopes
 			text = "`display_movement_petition_recipient_acceptance_effect` expects scope:province_change_recipient to be set"
-			file = events/decisions_events/tgp_decision_events.txt
+			OR = {
+				file = events/decisions_events/tgp_decision_events.txt
+				file = common/decisions/dlc_decisions/tgp/tgp_dynastic_cycle_decisions.txt
+			}
+		}
+		NAND = { # tiger confused tracing petition_change_movement_power_effect from participant group scope; same as update_movement_power_effect rule
+			key = scopes
+			text = "`top_participant_group` is for character but scope seems to be situation participant group"
+			file = common/decisions/dlc_decisions/tgp/tgp_dynastic_cycle_decisions.txt
 		}
 		NAND = { # These dlc features are not unknown
 			key = missing-item

--- a/common/decisions/dlc_decisions/ep3_decisions.txt
+++ b/common/decisions/dlc_decisions/ep3_decisions.txt
@@ -676,6 +676,11 @@ ask_western_help_decision = {
 			NOT = { has_doctrine_parameter = great_holy_wars_active }
 		}
 		government_has_flag = government_is_administrative
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= unop_ask_western_help_influence_cost
+		}
 	}
 
 	is_valid = {
@@ -744,13 +749,18 @@ ask_western_help_decision = {
 		prestige = {
 			value = 300
 		}
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
 		influence = {
-			value = massive_influence_value
-			multiply = 2
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = unop_ask_western_help_influence_cost
+			}
 		}
 	}
 
 	effect = {
+		debug_log = "unop_475 ask_western_help_decision" #Unop debug log to confirm issue #475
 		custom_tooltip = ask_western_help_decision_effect_desc
 		hidden_effect = {
 			save_scope_as = caller
@@ -893,6 +903,11 @@ ask_western_help_decision = {
 					days = 3
 				}
 			}
+		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = { subtract = unop_ask_western_help_influence_cost }
 		}
 	}
 
@@ -2995,6 +3010,11 @@ foster_integration_decision = {
 			}
 			domicile.domicile_location.county.culture != root.top_liege.culture
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= unop_foster_integration_influence_cost
+		}
 	}
 
 	is_valid = {
@@ -3017,15 +3037,18 @@ foster_integration_decision = {
 	}
 
 	cost = {
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
 		influence = {
-			value = {
-				add = major_influence_value
-				multiply = 2
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = unop_foster_integration_influence_cost
 			}
 		}
 	}
 
 	effect = {
+		debug_log = "unop_475 foster_integration_decision" #Unop debug log to confirm issue #475
 		domicile.domicile_location.county = { save_scope_as = target_county }
 		add_character_modifier = {
 			modifier = ep3_integration_promoter_modifier
@@ -3106,6 +3129,11 @@ foster_integration_decision = {
 				}
 			}
 		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = { subtract = unop_foster_integration_influence_cost }
+		}
 	}
 
 	ai_check_interval_by_tier = {
@@ -3162,6 +3190,11 @@ gather_faction_support_decision = {
 		domicile ?= {
 			is_domicile_type = estate
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= unop_gather_faction_support_influence_cost
+		}
 	}
 
 	is_valid = {
@@ -3184,15 +3217,18 @@ gather_faction_support_decision = {
 	}
 
 	cost = {
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
 		influence = {
-			value = {
-				add = massive_influence_value
-				multiply = 2
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = unop_gather_faction_support_influence_cost
 			}
 		}
 	}
 
 	effect = {
+		debug_log = "unop_475 gather_faction_support_decision" #Unop debug log to confirm issue #475
 		joined_faction = { save_scope_as = the_faction }
 		add_joined_faction_discontent = 20
 		custom_tooltip = gathered_support_for_faction_get_army_tt
@@ -3200,6 +3236,11 @@ gather_faction_support_decision = {
 			name = gathered_support_for_faction
 			value = scope:the_faction
 			years = 5
+		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = { subtract = unop_gather_faction_support_influence_cost }
 		}
 	}
 

--- a/common/decisions/dlc_decisions/ep_3/06_ep3_admin_decisions.txt
+++ b/common/decisions/dlc_decisions/ep_3/06_ep3_admin_decisions.txt
@@ -608,6 +608,8 @@ admin_confirmation_decision = {
 			name = confirmation_liege_scope
 			value = liege
 		}
+		save_scope_as = confirmation_vassal #Unop Moved from below as these scopes are used by admin_confirmation_vassal_reward_guts_effect
+		liege ?= { save_scope_as = confirmation_liege }
 		custom_tooltip = admin_confirmation_decision_effects
 		show_as_tooltip = {
 			stress_impact = {
@@ -620,8 +622,8 @@ admin_confirmation_decision = {
 			}
 			admin_confirmation_vassal_reward_guts_effect = yes
 		}
-		save_scope_as = confirmation_vassal
-		liege ?= { save_scope_as = confirmation_liege }
+		#save_scope_as = confirmation_vassal #Unop Moved to above
+		#liege ?= { save_scope_as = confirmation_liege }
 		switch = {
 			trigger = has_trait
 			shy = { add_stress = medium_stress_impact_gain }

--- a/common/decisions/dlc_decisions/ep_3/06_ep3_admin_decisions.txt
+++ b/common/decisions/dlc_decisions/ep_3/06_ep3_admin_decisions.txt
@@ -28,6 +28,11 @@ estate_hire_agents_decisions = {
 		domicile ?= {
 			has_domicile_parameter = estate_unlock_hire_agents_decision
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= major_influence_value
+		}
 	}
 
 	is_valid = {
@@ -38,14 +43,27 @@ estate_hire_agents_decisions = {
 	}
 
 	effect = {
+		debug_log = "unop_475 estate_hire_agents_decisions" #Unop debug log to confirm issue #475
 		add_character_modifier = {
 			modifier = ep3_estate_hired_agents_modifier
 			years = 15
 		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = major_influence_loss
+		}
 	}
-	
+
 	cost = {
-		influence = major_influence_value
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
+		influence = {
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = major_influence_value
+			}
+		}
 	}
 
 	ai_potential = {
@@ -112,6 +130,11 @@ estate_bolster_security_decision = {
 		domicile ?= {
 			has_domicile_parameter = estate_unlock_bolster_security_decision
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= major_influence_value
+		}
 	}
 
 	is_valid = {
@@ -122,14 +145,27 @@ estate_bolster_security_decision = {
 	}
 
 	effect = {
+		debug_log = "unop_475 estate_bolster_security_decision" #Unop debug log to confirm issue #475
 		add_character_modifier = {
 			modifier = ep3_estate_bolster_security_modifier
 			years = 15
 		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = major_influence_loss
+		}
 	}
-	
+
 	cost = {
-		influence = major_influence_value
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
+		influence = {
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = major_influence_value
+			}
+		}
 	}
 
 	ai_potential = {
@@ -664,6 +700,11 @@ consolidate_rule_decision = {
 				this != root
 			}
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= medium_influence_value
+		}
 	}
 
 	is_valid = {
@@ -678,12 +719,25 @@ consolidate_rule_decision = {
 	}
 
 	effect = {
+		debug_log = "unop_475 consolidate_rule_decision" #Unop debug log to confirm issue #475
 		custom_tooltip = consolidate_rule_decision_effect_tt
 		trigger_event = ep3_decisions_event.4050
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = medium_influence_loss
+		}
 	}
 	
 	cost = {
-		influence = medium_influence_value
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
+		influence = {
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = medium_influence_value
+			}
+		}
 		piety = medium_piety_value
 	}
 
@@ -1655,6 +1709,11 @@ renounce_governorship_decision = {
 			is_governor_or_admin_count = yes
 			tgp_is_any_minister = yes
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= minor_influence_value
+		}
 	}
 
 	is_valid_showing_failures_only = {
@@ -1669,6 +1728,7 @@ renounce_governorship_decision = {
 	}
 
 	effect = {
+		debug_log = "unop_475 renounce_governorship_decision" #Unop debug log to confirm issue #475
 		if = {
 			limit = {
 				tgp_is_any_minister = yes
@@ -1724,10 +1784,22 @@ renounce_governorship_decision = {
 			view = decisions
 			player = root
 		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = minor_influence_loss
+		}
 	}
-	
+
 	cost = {
-		influence = minor_influence_value
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
+		influence = {
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = minor_influence_value
+			}
+		}
 	}
 
 	ai_potential = {

--- a/common/decisions/dlc_decisions/ep_3/06_ep3_admin_decisions.txt
+++ b/common/decisions/dlc_decisions/ep_3/06_ep3_admin_decisions.txt
@@ -1,0 +1,2032 @@
+﻿#############################################
+# Hire Agents								#
+# by Emil Tisander							#
+#############################################
+
+estate_hire_agents_decisions = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_misc.dds"
+	}
+	sort_order = 105
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 120
+		kingdom = 120
+		empire = 120
+		hegemony = 120
+	}
+
+	desc = estate_hire_agents_decisions_desc
+	selection_tooltip = estate_hire_agents_decisions_tooltip
+	decision_group_type = admin
+	
+	cooldown = { years = 15 }
+	
+	is_shown = {
+		has_ep3_dlc_trigger = yes
+		domicile ?= {
+			has_domicile_parameter = estate_unlock_hire_agents_decision
+		}
+	}
+
+	is_valid = {
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes # Skulduggery isn't for children
+	}
+
+	effect = {
+		add_character_modifier = {
+			modifier = ep3_estate_hired_agents_modifier
+			years = 15
+		}
+	}
+	
+	cost = {
+		influence = major_influence_value
+	}
+
+	ai_potential = {
+		is_governor = yes
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			add = 20
+			has_trait = deceitful
+		}
+		modifier = {
+			add = 20
+			has_trait = vengeful
+		}
+		modifier = {
+			add = 20
+			has_trait = paranoid
+		}
+		modifier = {
+			add = 10
+			has_trait = ambitious
+		}
+		modifier = {
+			add = -20
+			has_trait = content
+		}
+		modifier = {
+			add = -20
+			has_trait = compassionate
+		}
+	}
+}
+
+#############################################
+# Bolster Security							#
+# by Emil Tisander							#
+#############################################
+
+### Bolster Estate Security ###
+estate_bolster_security_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_invite_knights.dds"
+	}
+	sort_order = 105
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 120
+		kingdom = 120
+		empire = 120
+		hegemony = 120
+	}
+
+	desc = estate_bolster_security_decision_desc
+	selection_tooltip = estate_bolster_security_decision_tooltip
+	decision_group_type = admin
+	
+	cooldown = { years = 15 }
+	
+	is_shown = {
+		has_ep3_dlc_trigger = yes
+		domicile ?= {
+			has_domicile_parameter = estate_unlock_bolster_security_decision
+		}
+	}
+
+	is_valid = {
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+	}
+
+	effect = {
+		add_character_modifier = {
+			modifier = ep3_estate_bolster_security_modifier
+			years = 15
+		}
+	}
+	
+	cost = {
+		influence = major_influence_value
+	}
+
+	ai_potential = {
+		is_governor = yes
+		NOR = {
+			has_trait = trusting
+			has_trait = gregarious
+		}
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			add = 50
+			has_trait = paranoid
+		}
+		modifier = {
+			add = 10
+			has_trait = deceitful
+		}
+		modifier = {
+			add = 10
+			has_trait = craven
+		}
+		modifier = {
+			add = 10
+			dread >= 50
+		}
+	}
+}
+
+#############################################
+# Patrol Governorship						#
+# by Emil Tisander							#
+#############################################
+
+### Conduct Patrols in Governorship ###
+estate_governor_patrols_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/fp2_decision_struggle_opening.dds"
+	}
+	sort_order = 105
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 120
+		kingdom = 120
+		empire = 120
+		hegemony = 120
+	}
+
+	desc = estate_governor_patrols_decision_desc
+	selection_tooltip = estate_governor_patrols_decision_tooltip
+	decision_group_type = admin
+	
+	cooldown = { years = 15 }
+	
+	is_shown = {
+		has_ep3_dlc_trigger = yes
+		domicile ?= {
+			has_domicile_parameter = estate_unlock_patrol_decision
+		}
+	}
+
+	is_valid = {
+	}
+
+	is_valid_showing_failures_only = {
+		is_governor = yes
+	}
+
+	effect = {
+		every_held_title = {
+			title_tier = county
+			add_to_list = counties_in_governorship
+		}
+		every_vassal = {
+			limit = {
+				any_held_title = { title_tier = county }
+			}
+			every_held_title = {
+				title_tier = county
+				add_to_list = counties_in_governorship
+			}
+		}
+		every_in_list = {
+			list = counties_in_governorship
+			add_county_modifier = {
+				modifier = ep3_estate_governor_patrols_modifier
+				years = 15
+			}
+		}
+		increase_governance_effect = { VALUE = 6 }
+	}
+	
+	cost = {
+		gold = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = no
+				}
+				add = medium_gold_value
+			}
+		}
+		treasury = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = yes
+				}
+				add = medium_gold_value
+			}
+		}
+	}
+	
+	ai_potential = {
+		is_governor = yes
+	}
+	
+	ai_will_do = {
+		base = 20
+		modifier = {
+			add = 50
+			influence > monumental_influence_value
+		}
+		modifier = {
+			add = 10
+			has_trait = just
+		}
+		modifier = {
+			add = 10
+			has_trait = loyal
+		}
+		modifier = {
+			add = 10
+			has_trait = diligent
+		}
+		modifier = {
+			add = -25
+			has_trait = lazy
+		}
+		modifier = {
+			add = -20
+			opinion = {
+				target = liege
+				value < -20
+			}
+		}
+	}
+}
+
+#############################################
+# Manipulate Grain Market					#
+# by Emil Tisander							#
+#############################################
+
+### Manipulate Grain Market ###
+estate_granary_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_spend_money.dds"
+	}
+	sort_order = 105
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 120
+		kingdom = 120
+		empire = 120
+		hegemony = 120
+	}
+
+	desc = estate_granary_decision_desc
+	selection_tooltip = estate_granary_decision_tooltip
+	decision_group_type = admin
+	
+	cooldown = { years = 20 }
+	
+	is_shown = {
+		has_ep3_dlc_trigger = yes
+		domicile ?= {
+			has_domicile_parameter = estate_unlock_granary_decision
+		}
+	}
+
+	is_valid = {
+	}
+
+	is_valid_showing_failures_only = {
+	}
+
+	effect = {
+		add_character_modifier = {
+			modifier = ep3_estate_granary_modifier
+			years = 10
+		}
+		
+		# Descriptions - Make sure the triggers below matches the ones in the granary_modifier_scaling_value scripted value
+		save_scope_as = domicile_owner # We save it for the descriptions
+		custom_description_no_bullet = { text = estate_unlock_granary_decision_factors_tt }
+		if = {
+			limit = {
+				domicile ?= { has_domicile_building_or_higher = grain_field_01 }
+			}
+			custom_tooltip = estate_unlock_granary_decision_grain_building_tt
+		}
+		if = {
+			limit = {
+				domicile ?= { has_domicile_building_or_higher = east_asian_estate_rice_field_01 }
+			}
+			custom_tooltip = estate_unlock_granary_decision_rice_building_tt
+		}
+		if = {
+			limit = {
+				domicile ?= {
+					domicile_location = {
+						this = root.top_liege.capital_province
+					}
+				}
+			}
+			custom_tooltip = estate_unlock_granary_decision_capital_tt
+		}
+		if = {
+			limit = {
+				domicile ?= {
+					domicile_location = {
+						OR = {
+							terrain = farmlands
+							terrain = floodplains
+							terrain = terraced_hills
+						}
+					}
+				}
+			}
+			custom_tooltip = estate_unlock_granary_decision_terrain_tt
+		}
+		if = {
+			limit = {
+				domicile ?= {
+					domicile_location.county = {
+						county_control < 100
+					}
+				}
+			}
+			custom_tooltip = estate_unlock_granary_decision_control_tt
+		}
+		if = {
+			limit = {
+				domicile ?= {
+					domicile_location.county = {
+						development_level >= estate_granary_development_bonus_2_value
+					}
+				}
+			}
+			custom_tooltip = estate_unlock_granary_decision_development_2_tt
+		}
+		else_if = {
+			limit = {
+				domicile ?= {
+					domicile_location.county = {
+						development_level >= estate_granary_development_bonus_1_value
+					}
+				}
+			}
+			custom_tooltip = estate_unlock_granary_decision_development_1_tt
+		}
+		if = {
+			limit = {
+				domicile ?= {
+					domicile_location = {
+						any_province_epidemic = { }
+					}
+				}
+			}
+			custom_tooltip = estate_unlock_granary_decision_epidemic_tt
+		}
+		if = {
+			limit = {
+				granary_modifier_scaling_value <= 1
+			}
+			custom_tooltip = estate_unlock_granary_decision_no_factors_tt
+		}
+	}
+	
+	cost = {
+		prestige = major_prestige_value
+	}
+	
+	ai_potential = {
+		is_governor = yes
+	}
+	
+	ai_will_do = {
+		base = 20
+		modifier = {
+			add = 30
+			prestige > massive_prestige_value
+		}
+		modifier = {
+			add = 20
+			has_trait = greedy
+		}
+		modifier = {
+			add = 10
+			has_trait = deceitful
+		}
+		modifier = {
+			add = 10
+			has_trait = arbitrary
+		}
+		modifier = {
+			add = 10
+			has_trait = callous
+		}
+		modifier = {
+			add = 10
+			domicile ?= { has_domicile_building_or_higher = grain_field_01 }
+		}
+		modifier = {
+			add = -10
+			has_trait = generous
+		}
+		modifier = {
+			add = -20
+			has_trait = compassionate
+		}
+		modifier = {
+			add = -25
+			has_trait = just
+		}
+	}
+}
+
+#############################################
+# Governorship Confirmation					#
+# by Joe Parkin								#
+#############################################
+
+### Governorship Confirmation ###
+admin_confirmation_decision = {
+	picture = {
+		trigger = {
+			government_allows = merit
+		}
+		reference = "gfx/interface/illustrations/decisions/tgp_kowtow.dds"
+	}
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 45
+		duchy = 45
+		kingdom = 45
+		empire = 45
+		hegemony = 0
+	}
+	sort_order = 1000
+	picture = {
+		trigger = {
+			NOR = {
+				government_has_flag = government_is_tribal
+				government_has_flag = government_is_theocracy
+				top_liege ?= { government_has_flag = government_is_tribal }
+				top_liege ?= { government_has_flag = government_is_theocracy }
+			}
+			OR = {
+				culture = { has_cultural_pillar = heritage_byzantine }
+				top_liege ?= {
+					OR = {
+						culture = { has_cultural_pillar = heritage_byzantine }
+						capital_barony ?= title:b_constantinople
+						is_roman_emperor_primary_title_trigger = yes
+					}
+				}
+			}
+		}
+		reference = "gfx/interface/illustrations/decisions/ep3_cerimonial_decision.dds"
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_knight_kneeling.dds"
+	}
+	decision_group_type = admin
+
+	cost = {
+		prestige = standard_activity_base_cost
+	}
+
+	is_shown = {
+		has_ep3_dlc_trigger = yes
+		is_playable_character = yes
+		is_governor = yes
+		liege ?= top_liege
+		top_liege = { tgp_is_ceremonial_regent_trigger = no } # Not 'actual' ruler
+	}
+
+	is_valid = {
+		custom_tooltip = {
+			text = admin_confirmation_rank_tt
+			primary_title.tier >= main_administrative_tier # Governs a Province
+		}
+		custom_tooltip = {
+			text = admin_confirmation_liege_tt
+			top_liege != this
+			liege ?= top_liege
+		}
+		custom_tooltip = {
+			text = admin_confirmation_time_tt
+			primary_title ?= {
+				title_held_years >= 1
+			}
+		}
+		custom_tooltip = {
+			text = admin_confirmation_grace_valid_tt
+			NOR = {
+				has_variable = confirmation_grace
+				has_variable = confirmation_cooldown_vassal
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		liege ?= { is_available_adult = yes }
+		is_at_war_with_liege = no
+		trigger_if = {
+			limit = {
+				is_ai = no
+				has_royal_court = yes
+			}
+			has_spawned_court_events = no # should only be used for human players
+		}
+		trigger_if = {
+			limit = { is_ai = yes }
+			NOT = {
+				liege = { has_variable = confirmation_cooldown }
+			}
+		}
+	}
+
+	effect = {
+		set_variable = {
+			name = confirmation_liege_scope
+			value = liege
+		}
+		custom_tooltip = admin_confirmation_decision_effects
+		show_as_tooltip = {
+			stress_impact = {
+				shy = medium_stress_impact_gain
+				humble = medium_stress_impact_gain
+			}
+			custom_description_no_bullet = {
+				text = admin_confirmation_decision_tt_if_accepted
+				subject = root
+			}
+			admin_confirmation_vassal_reward_guts_effect = yes
+		}
+		save_scope_as = confirmation_vassal
+		liege ?= { save_scope_as = confirmation_liege }
+		switch = {
+			trigger = has_trait
+			shy = { add_stress = medium_stress_impact_gain }
+			humble = { add_stress = medium_stress_impact_gain }
+		}
+		start_travel_plan = {
+			destination = liege.capital_province
+			on_start_on_action = admin_confirmation_start
+			on_travel_planner_cancel_on_action = admin_confirmation_travel_planner_exit
+			on_arrival_event = ep3_decisions_event.2090
+			on_arrival_destinations = all_but_last
+		}
+	}
+	
+	ai_potential = {
+		is_at_war = no
+	}
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			add = 50
+			prestige > standard_activity_base_cost
+		}
+		modifier = {
+			add = -50
+			has_relation_rival = liege
+		}
+		modifier = {
+			add = -25
+			opinion = {
+				target = liege
+				value < 0
+			}
+		}
+		modifier = { # Kings should be more weighted
+			add = 25
+			primary_title.tier >= tier_kingdom
+		}
+	}
+}
+
+#############################################
+# Consolidate Rule							#
+#############################################
+
+### Consolidate Rule ###
+consolidate_rule_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_family_tree.dds"
+	}
+	sort_order = 105
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 0
+		empire = 120
+		hegemony = 120
+	}
+
+	desc = consolidate_rule_decision_desc
+	selection_tooltip = consolidate_rule_decision_tooltip
+	decision_group_type = admin
+	
+	cooldown = { years = 15 }
+	
+	is_shown = {
+		has_ep3_dlc_trigger = yes
+		highest_held_title_tier >= tier_empire # Only for Emperors
+		culture = { # Byzantium and others
+			has_cultural_tradition = tradition_religious_patronage
+		}
+		faith = { # You cannot consolidate yourself... kinda
+			religious_head ?= {
+				this != root
+			}
+		}
+	}
+
+	is_valid = {
+		government_allows = administrative
+	}
+
+	is_valid_showing_failures_only = {
+		culture = {
+			has_cultural_parameter = consolidate_rule_decision
+		}
+		any_held_title = { is_head_of_faith = no }
+	}
+
+	effect = {
+		custom_tooltip = consolidate_rule_decision_effect_tt
+		trigger_event = ep3_decisions_event.4050
+	}
+	
+	cost = {
+		influence = medium_influence_value
+		piety = medium_piety_value
+	}
+
+	ai_potential = {
+		highest_held_title_tier = tier_empire # Only for Emperors
+		culture = { # Byzantium and others
+			has_cultural_tradition = tradition_religious_patronage
+		}
+		faith = { # You cannot consolidate yourself... kinda
+			religious_head ?= {
+				this != root
+			}
+		}
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			add = 20
+			legitimacy_level <= 2
+		}
+		modifier = {
+			add = 20
+			legitimacy_level <= 1
+		}
+		modifier = {
+			add = 20
+			legitimacy_level = 0
+		}
+	}
+}
+
+###################################
+# Convert Realm to Administrative #
+###################################
+
+### Adopt Centralized Administration ###
+convert_to_administrative_decision = {
+	picture = {
+		trigger = {
+			culture_has_asian_heritage_pillar_trigger = yes
+		}
+		reference = "gfx/interface/illustrations/decisions/tgp_kowtow.dds"
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/ep3_cerimonial_decision.dds"
+	}
+	decision_group_type = major
+	title = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_tgp_dlc_trigger = yes
+				}
+				desc = convert_to_administrative_decision_title_multiple
+			}
+			desc = convert_to_administrative_decision
+		}
+	}
+	desc = convert_to_administrative_decision_desc
+	selection_tooltip = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_tgp_dlc_trigger = yes
+				}
+				desc = convert_to_administrative_decision_tooltip_multiple
+			}
+			desc = convert_to_administrative_decision_tooltip
+		}
+	}
+	confirm_text = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_tgp_dlc_trigger = yes
+				}
+				desc = convert_to_administrative_decision_confirm_multiple
+			}
+			desc = convert_to_administrative_decision_confirm
+		}
+	}
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 36
+		duchy = 36
+		kingdom = 36
+		empire = 36
+		hegemony = 0
+	}
+
+	is_shown = {
+		OR = {
+			has_ep3_dlc_trigger = yes
+			has_tgp_dlc_trigger = yes
+		}
+		OR = {
+			government_has_flag = government_is_feudal
+			government_has_flag = government_is_clan
+			government_has_flag = government_is_japan_feudal
+		}
+		trigger_if = {
+			limit = { top_liege != this }
+			liege = { government_allows = administrative }
+		}
+	}
+
+	is_valid = {
+		trigger_if = {
+			limit = { top_liege != this }
+			liege = { government_allows = administrative }
+		}
+		trigger_else = {
+			OR = {
+				custom_tooltip = {
+					text = HAS_SEAL_OF_INVESTITURE
+					any_character_artifact = {
+						OR = {
+							artifact_type = seal_of_investiture
+							artifact_type = seal_of_investiture_court
+						}
+					}
+				}
+				trigger_if = {
+					limit = {
+						culture = { has_cultural_parameter = can_adopt_administrative_government_as_kingdom_tier }
+					}
+					custom_tooltip = {
+						text = king_tier_tt
+						primary_title.tier >= tier_kingdom
+					}
+				}
+				trigger_else = {
+					AND = { # To force the correct tooltip in loc
+						custom_tooltip = {
+							text = empire_tier_tt
+							primary_title.tier >= tier_empire
+						}
+						root = { save_temporary_scope_as = root_scope }
+						custom_tooltip = {
+							text = small_realm_size_tt
+							realm_size >= small_empire_size_value
+						}
+					}
+				}
+			}
+		}
+		trigger_if = {
+			limit = {
+				top_liege = this
+				is_ai = no
+			}
+			prestige_level >= 3
+		}
+		trigger_if = {
+			limit = {
+				top_liege = this
+				is_ai = no
+			}
+			custom_tooltip = {
+				text = all_powerful_vassals_required_tt
+				any_powerful_vassal = {
+					count = all
+					opinion = {
+						target = root
+						value >= 50
+					}
+				}
+			}
+		}
+		trigger_if = {
+			limit = { is_ai = yes }
+			calc_true_if = {
+				amount >= 2
+				culture = { has_cultural_pillar = ethos_bureaucratic }
+				culture = { has_cultural_pillar = ethos_courtly }
+				culture = { has_cultural_pillar = ethos_egalitarian }
+				culture = { has_cultural_tradition = tradition_legalistic }
+				has_realm_law = crown_authority_3
+				capital_county = { development_level > medium_development_level }
+				faith = { has_doctrine = tenet_legalism }
+				dynasty = { has_dynasty_perk = erudition_legacy_5 }
+				dynasty = { has_dynasty_perk = law_legacy_5 }
+			}
+		}
+	}
+	
+	is_valid_showing_failures_only = {
+		OR = {
+			has_ep3_dlc_trigger = yes
+			tgp_should_become_meritocratic_trigger = yes
+		}
+		is_at_war = no
+	}
+
+	cost = {
+		prestige = {
+			value = 1000
+			if = {
+				limit = {
+					is_ai = no
+					primary_title.tier = tier_kingdom
+				}
+				multiply = 1.5
+			}
+			if = { # Much cheaper for vassals wanting to adopt their admin liege's government
+				limit = { top_liege != this }
+				multiply = 0.1
+			}
+		}
+		gold = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = no
+				}
+				add = 800
+				if = {
+					limit = { is_ai = no }
+					#Realm size
+					if = {
+						limit = { root.realm_size >= 300 }
+						multiply = 3.5
+					}
+					else_if = {
+						limit = { root.realm_size >= 250 }
+						multiply = 3
+					}
+					else_if = {
+						limit = { root.realm_size >= 200 }
+						multiply = 2.5
+					}
+					else_if = {
+						limit = { root.realm_size >= 150 }
+						multiply = 2
+					}
+					else_if = {
+						limit = { root.realm_size >= 100 }
+						multiply = 1.5
+					}
+				}
+				#Era
+				culture = {
+					if = {
+						limit = { has_cultural_era_or_later = culture_era_late_medieval }
+						multiply = 1.75
+					}
+					else_if = {
+						limit = { has_cultural_era_or_later = culture_era_high_medieval }
+						multiply = 1.25
+					}
+					else_if = {
+						limit = { has_cultural_era_or_later = culture_era_early_medieval }
+						multiply = 1
+					}
+					else = {
+						multiply = 0.75
+					}
+				}
+				#Income
+				if = {
+					limit = { root.monthly_character_income >= 100 }
+					multiply = 3
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 80 }
+					multiply = 2.5
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 60 }
+					multiply = 2
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 40 }
+					multiply = 1.5
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 20 }
+					multiply = 1.1
+				}
+
+				max = 3000
+				
+				if = { # Much cheaper for vassals wanting to adopt their admin liege's government
+					limit = {
+						is_independent_ruler = no
+					}
+					multiply = 0.1
+				}
+			}
+		}
+		treasury = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = yes
+				}
+				add = 800
+				if = {
+					limit = { is_ai = no }
+					#Realm size
+					if = {
+						limit = { root.realm_size >= 300 }
+						multiply = 3.5
+					}
+					else_if = {
+						limit = { root.realm_size >= 250 }
+						multiply = 3
+					}
+					else_if = {
+						limit = { root.realm_size >= 200 }
+						multiply = 2.5
+					}
+					else_if = {
+						limit = { root.realm_size >= 150 }
+						multiply = 2
+					}
+					else_if = {
+						limit = { root.realm_size >= 100 }
+						multiply = 1.5
+					}
+				}
+				#Era
+				culture = {
+					if = {
+						limit = { has_cultural_era_or_later = culture_era_late_medieval }
+						multiply = 1.75
+					}
+					else_if = {
+						limit = { has_cultural_era_or_later = culture_era_high_medieval }
+						multiply = 1.25
+					}
+					else_if = {
+						limit = { has_cultural_era_or_later = culture_era_early_medieval }
+						multiply = 1
+					}
+					else = {
+						multiply = 0.75
+					}
+				}
+				#Income
+				if = {
+					limit = { root.monthly_character_income >= 100 }
+					multiply = 3
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 80 }
+					multiply = 2.5
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 60 }
+					multiply = 2
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 40 }
+					multiply = 1.5
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 20 }
+					multiply = 1.1
+				}
+
+				max = 3000
+				
+				if = { # Much cheaper for vassals wanting to adopt their admin liege's government
+					limit = {
+						top_liege != this
+					}
+					multiply = 0.1
+				}
+			}
+		}
+	}
+	
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_ACTION"
+		show_from_start = no
+
+		item = { # Administrative
+			value = go_administrative_government
+			is_shown = {
+				has_ep3_dlc_trigger = yes
+			}
+			is_valid = {
+				top_liege = {
+					NOR = {
+						has_government = celestial_government
+						has_government = meritocratic_government
+						has_government = japan_administrative_government
+					}
+				}
+			}
+			current_description = go_administrative_government_desc
+			localization = go_administrative_government_name
+			icon = "gfx/interface/icons/government_types/administrative_government.dds"
+			ai_chance = {
+				value = 10
+			}
+		}
+		item = { # Celestial
+			value = go_celestial_government
+			is_shown = {
+				has_tgp_dlc_trigger = yes
+			}
+			is_valid = {
+				top_liege = {
+					NOR = {
+						has_government = administrative_government
+						has_government = meritocratic_government
+						has_government = japan_administrative_government
+					}
+				}
+				custom_tooltip = {
+					text = convert_to_administrative_celestial_desc
+					tgp_can_become_celestial_trigger = yes
+				}
+			}
+			current_description = go_celestial_government_desc
+			localization = go_celestial_government_name
+			icon = "gfx/interface/icons/government_types/celestial_government.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = { # Meritocratic
+			value = go_meritocratic_government
+			is_shown = {
+				has_tgp_dlc_trigger = yes
+			}
+			is_valid = {
+				top_liege = {
+					NOR = {
+						has_government = administrative_government
+						has_government = celestial_government
+						has_government = japan_administrative_government
+					}
+				}
+				custom_tooltip = {
+					text = convert_to_administrative_meritocratic_desc
+					tgp_should_become_meritocratic_trigger = yes
+				}
+			}
+			current_description = go_meritocratic_government_desc
+			localization = go_meritocratic_government_name
+			icon = "gfx/interface/icons/government_types/meritocratic_government.dds"
+			ai_chance = {
+				value = 50
+			}
+		}
+		item = { # Ritsuryo / AKA Japan Administrative
+			value = go_japan_administrative_government
+			is_shown = {
+				has_tgp_dlc_trigger = yes
+			}
+			is_valid = {
+				top_liege = {
+					NOR = {
+						has_government = administrative_government
+						has_government = celestial_government
+						has_government = meritocratic_government
+					}
+				}
+				custom_tooltip = {
+					text = convert_to_administrative_japanese_desc
+					tgp_can_become_japan_administrative_trigger = yes
+				}
+			}
+			current_description = go_japan_administrative_government_desc
+			localization = go_japan_administrative_government_name
+			icon = "gfx/interface/icons/government_types/japan_administrative_government.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+	}
+
+	effect = {
+		# Change to your selected government
+		if = {
+			limit = {
+				scope:go_administrative_government = yes
+			}
+			convert_to_administrative_from_feudalism_effect = { GOVERNMENT_TO_ADOPT = flag:administrative }
+		}
+		else_if = {
+			limit = { scope:go_celestial_government = yes }
+			convert_to_administrative_from_feudalism_effect = { GOVERNMENT_TO_ADOPT = flag:celestial }
+		}
+		else_if = {
+			limit = { scope:go_meritocratic_government = yes }
+			convert_to_administrative_from_feudalism_effect = { GOVERNMENT_TO_ADOPT = flag:meritocratic }
+		}
+		else_if = {
+			limit = { scope:go_japan_administrative_government = yes }
+			convert_to_administrative_from_feudalism_effect = { GOVERNMENT_TO_ADOPT = flag:japan_administrative }
+		}
+		save_scope_as = actor
+		if = {
+			limit = {
+				is_independent_ruler = yes
+			}
+			add_legitimacy_effect = { LEGITIMACY = admin_convert_legitimacy_value } #One Time Legitimacy Boost
+		}
+		trigger_event = ep3_decisions_event.4060 #Also sends information event to human vassals
+		#Letter event for the vassals
+		hidden_effect = {
+			if = {
+				limit = {
+					is_ai = no
+				}
+				add_achievement_global_variable_effect = {
+					VARIABLE = achieved_epic_paperwork_achievement
+					VALUE = yes
+				}
+			}
+			if = {
+				limit = {
+					is_ai = no
+					religion = religion:islam_religion
+					has_title = title:k_rum
+					OR = {
+						has_title = title:c_byzantion
+						any_sub_realm_title = {
+							this = title:c_byzantion
+						}
+					}
+				}
+				add_achievement_global_variable_effect = {
+					VARIABLE = finished_new_management_achievement
+					VALUE = yes
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+		OR = {
+			government_has_flag = government_is_feudal
+			government_has_flag = government_is_clan
+		}
+		top_liege = this
+	}
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			OR = {
+				is_roman_emperor_primary_title_trigger = yes
+			}
+			add = 100
+		}
+		modifier = {
+			culture = {
+				OR = {
+					has_cultural_pillar = ethos_bureaucratic 
+					has_cultural_pillar = ethos_courtly 
+					has_cultural_pillar = ethos_egalitarian 
+				}
+			}
+			add = 50
+		}
+		modifier = {
+			culture = {
+				has_cultural_tradition = tradition_legalistic
+			}
+			add = 50
+		}
+		modifier = {
+			culture = {
+				OR = {
+					has_cultural_tradition = tradition_fp3_enlightened_magnates 
+					has_cultural_tradition = tradition_loyal_soldiers 
+				}
+			}
+			add = 20
+		}
+		modifier = {
+			culture = {
+				OR = {
+					has_cultural_tradition = tradition_staunch_traditionalists
+					has_cultural_tradition = tradition_ep3_audacious_cadets
+				}
+			}
+			add = -20
+		}
+		modifier = {
+			culture = {
+				has_cultural_tradition = tradition_hereditary_hierarchy
+			}
+			add = -20
+		}
+		modifier = {
+			culture = {
+				OR = {
+					has_cultural_tradition = tradition_ep3_indomitable_azatani
+					has_cultural_tradition = tradition_quarrelsome
+					has_cultural_tradition = tradition_warrior_culture
+					has_cultural_tradition = tradition_fp3_fierce_independence
+				}
+			}
+			add = -50
+		}
+		modifier = {
+			culture = {
+				OR = {
+					has_cultural_pillar = ethos_stoic
+					has_cultural_pillar = ethos_bellicose 
+					has_cultural_pillar = ethos_communal 
+				}
+			}
+			add = -50
+		}
+		modifier = {
+			culture = {
+				any_parent_culture_or_above = {
+					OR = {
+						this = culture:han
+						this = culture:greek
+					}
+				}
+			}
+			add = 100
+		}
+	}
+}
+
+##################################################
+# Convert Realm to Feudalism from Administrative #
+##################################################
+
+### Adopt [ROOT.Char.Custom('GetTribalReformGovernment')|U] Ways ###
+convert_to_feudalism_from_administrative_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_realm.dds"
+	}
+	decision_group_type = major
+	desc = convert_to_feudalism_from_administrative_decision_desc
+
+	is_shown = {
+		trigger_if = {
+			limit = { has_title = title:h_china }
+			NOT = { government_has_flag = government_is_celestial }
+		}
+		government_allows = administrative
+		tgp_is_ceremonial_liege_trigger = no
+		tgp_is_ceremonial_regent_trigger = no
+		tgp_is_any_minister = no
+		# Ritsuryo gov has its own decisions
+		NOT = { government_has_flag = government_is_japan_administrative }
+	}
+
+	is_valid = {
+		is_landed = yes
+		trigger_if = {
+			limit = {
+				is_independent_ruler = no
+			}
+			top_liege ?= {
+				trigger_if = {
+					limit = {
+						has_realm_law_in_group = imperial_bureaucracy
+					}
+					has_realm_law = imperial_bureaucracy_0 
+				}
+				trigger_if = {
+					limit = {
+						has_realm_law_in_group = celestial_bureaucracy
+					}
+					has_realm_law = celestial_bureaucracy_0 
+				}
+				trigger_if = {
+					limit = {
+						has_realm_law_in_group = meritocratic_bureaucracy
+					}
+					has_realm_law = meritocratic_bureaucracy_0 
+				}
+				trigger_if = {
+					limit = {
+						has_realm_law_in_group = japanese_bureaucracy
+					}
+					has_realm_law = japanese_bureaucracy_0 
+				}
+			}
+			custom_tooltip = {
+				text = governorship_is_on_the_border_tt
+				any_sub_realm_county = {
+					any_neighboring_county = {
+						holder.top_liege != root.top_liege
+					}
+				}
+			}
+			custom_tooltip = {
+				text = you_have_governorship_rights_tt
+				primary_title.var:petition_house_rights ?= house
+			}
+			prestige_level >= 3
+			influence_level >= 3
+		}
+		trigger_else = {
+			prestige_level >= { # Depends on tier
+				value = 2
+				if = {
+					limit = {
+						primary_title.tier >= tier_empire
+					}
+					add = 1
+				}
+			}
+		}
+	}
+
+	cost = {
+		prestige = 1000
+		gold = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = no
+				}
+				add = 1000 #Them pens be expensive
+				#Realm size
+				if = {
+					limit = { root.realm_size >= 300 }
+					multiply = 3.5
+				}
+				else_if = {
+					limit = { root.realm_size >= 250 }
+					multiply = 3
+				}
+				else_if = {
+					limit = { root.realm_size >= 200 }
+					multiply = 2.5
+				}
+				else_if = {
+					limit = { root.realm_size >= 150 }
+					multiply = 2
+				}
+				else_if = {
+					limit = { root.realm_size >= 100 }
+					multiply = 1.5
+				}
+				#Era
+				culture = {
+					if = {
+						limit = { has_cultural_era_or_later = culture_era_late_medieval }
+						multiply = 1.75
+					}
+					else_if = {
+						limit = { has_cultural_era_or_later = culture_era_high_medieval }
+						multiply = 1.25
+					}
+					else_if = {
+						limit = { has_cultural_era_or_later = culture_era_early_medieval }
+						multiply = 1
+					}
+					else = {
+						multiply = 0.75
+					}
+				}
+				#Income
+				if = {
+					limit = { root.monthly_character_income >= 100 }
+					multiply = 3
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 80 }
+					multiply = 2.5
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 60 }
+					multiply = 2
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 40 }
+					multiply = 1.5
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 20 }
+					multiply = 1.1
+				}
+				
+				# Vassals has a slightly reduced cost
+				if = {
+					limit = {
+						is_independent_ruler = no
+					}
+					multiply = 0.7
+				}
+			}
+		}
+		treasury = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = yes
+				}
+				add = 1000  #Them pens be expensive
+				#Realm size
+				if = {
+					limit = { root.realm_size >= 300 }
+					multiply = 3.5
+				}
+				else_if = {
+					limit = { root.realm_size >= 250 }
+					multiply = 3
+				}
+				else_if = {
+					limit = { root.realm_size >= 200 }
+					multiply = 2.5
+				}
+				else_if = {
+					limit = { root.realm_size >= 150 }
+					multiply = 2
+				}
+				else_if = {
+					limit = { root.realm_size >= 100 }
+					multiply = 1.5
+				}
+				#Era
+				culture = {
+					if = {
+						limit = { has_cultural_era_or_later = culture_era_late_medieval }
+						multiply = 1.75
+					}
+					else_if = {
+						limit = { has_cultural_era_or_later = culture_era_high_medieval }
+						multiply = 1.25
+					}
+					else_if = {
+						limit = { has_cultural_era_or_later = culture_era_early_medieval }
+						multiply = 1
+					}
+					else = {
+						multiply = 0.75
+					}
+				}
+				#Income
+				if = {
+					limit = { root.monthly_character_income >= 100 }
+					multiply = 3
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 80 }
+					multiply = 2.5
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 60 }
+					multiply = 2
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 40 }
+					multiply = 1.5
+				}
+				else_if = {
+					limit = { root.monthly_character_income >= 20 }
+					multiply = 1.1
+				}
+				
+				# Vassals has a slightly reduced cost
+				if = {
+					limit = {
+						is_independent_ruler = no
+					}
+					multiply = 0.7
+				}
+			}
+		}
+	}
+
+	effect = {
+		convert_to_feudalism_from_administrative_effect = yes
+		save_scope_as = actor
+		trigger_event = ep3_decisions_event.4070
+		hidden_effect = {
+			every_vassal = {
+				trigger_event = {
+					id = ep3_decisions_event.4075
+					days = 3
+				}
+			}
+		}
+	}
+
+	ai_check_interval = 0
+
+	ai_potential = {
+		always = no
+	}
+}
+
+#############################################
+# Renounce Governorship						#
+#############################################
+
+### Withdraw from Governorship ###
+### Withdraw from Ministry ###
+renounce_governorship_decision = {
+	picture = {
+		trigger = {
+			government_allows = merit
+		}
+		reference = "gfx/interface/illustrations/decisions/tgp_retire.dds"
+	}
+	picture = {
+		trigger = {
+			government_is_japanese_trigger = yes
+		}
+		reference = "gfx/interface/illustrations/decisions/tgp_house_fief.dds"
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_dynasty_house.dds"
+	}
+	sort_order = 85
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 120
+		duchy = 120
+		kingdom = 120
+		empire = 120
+		hegemony = 0
+	}
+	title = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					tgp_is_any_minister = yes
+				}
+				desc = renounce_ministership_decision
+			}
+			desc = renounce_governorship_decision
+		}
+	}
+	desc = {
+		first_valid = {
+			triggered_desc = {	
+				trigger = {
+					government_allows = merit
+				}
+				desc = renounce_governorship_decision_desc_merit
+			}
+			triggered_desc = {	
+				trigger = {
+					government_is_japanese_trigger = yes
+				}
+				desc = renounce_governorship_decision_desc_japan
+			}
+			desc = renounce_governorship_decision_desc
+		}
+	}
+	selection_tooltip = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					tgp_is_any_minister = yes
+				}
+				desc = renounce_ministership_decision_tooltip
+			}
+			desc = renounce_governorship_decision_tooltip
+		}
+	}
+	decision_group_type = admin
+
+	is_shown = {
+		is_playable_character = yes
+		OR = {
+			is_governor_or_admin_count = yes
+			tgp_is_any_minister = yes
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		is_at_war_with_liege = no
+		custom_tooltip = {
+			text = renounce_governorship_family_title_tt
+			any_held_title = { # To avoid accidentally game-overing yourself
+				is_noble_family_title = yes
+			}
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				tgp_is_any_minister = yes
+			}
+			custom_tooltip = renounce_ministership_decision_effect_tt
+		}
+		else = {
+			custom_tooltip = renounce_governorship_decision_effect_tt
+		}
+		show_as_tooltip = {
+			tgp_step_down_title_recipient_tooltip_effect = yes
+			if = {
+				limit = {
+					government_allows = merit 
+				}
+				add_character_modifier = {
+					modifier = ep3_renounced_governorship_merit
+					years = 15
+				}
+				set_appointment_timeout = {
+					years = 3
+					desc = appointment_timeout_desc_retired_governor
+				}
+			}
+			else_if = {
+				limit = {
+					government_is_japanese_trigger = yes
+				}
+				add_gold = major_gold_value
+				change_influence = major_influence_value
+				add_character_modifier = {
+					modifier = renounced_governorship_japan
+					years = 15
+				}
+			}
+			else = { 
+				add_gold = massive_gold_value
+				add_character_modifier = {
+					modifier = ep3_renounced_governorship
+					years = 15
+				}
+			}
+			if = {
+				limit = {
+					tgp_is_any_minister = yes
+				}
+				liege = { save_scope_as = councillor_liege } # Needed for the effect
+				fired_minister_position_effect = yes
+			}
+		}
+		trigger_event = ep3_decisions_event.4090
+		close_view = {
+			view = decisions
+			player = root
+		}
+	}
+	
+	cost = {
+		influence = minor_influence_value
+	}
+
+	ai_potential = {
+		is_at_war = no
+		highest_held_title_tier >= main_administrative_tier
+		# Don't step down freely if you don't have any other house members holding a governorship or inherit any held governorship
+		OR = {
+			house ?= {
+				any_house_member = {
+					is_governor = yes
+					top_liege = root.top_liege
+				}
+			}
+			any_held_title = {
+				title_tier >= duchy
+				is_noble_family_title = no
+				current_heir.house = root.house
+			}
+		}
+	}
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			add = 5
+			has_trait = lazy
+			NOT = {
+				any_character_situation = {
+					situation_type = dynastic_cycle
+				}
+			}
+		}
+		modifier = {
+			add = 10
+			has_trait = humble
+			NOT = {
+				any_character_situation = {
+					situation_type = dynastic_cycle
+				}
+			}
+		}
+		modifier = {
+			add = 15
+			has_trait = content
+			NOT = {
+				any_character_situation = {
+					situation_type = dynastic_cycle
+				}
+			}
+		}
+		modifier = {
+			add = 50
+			OR = {
+				debt_level > 1
+				treasury_debt_level > 1
+			}
+		}
+		modifier = {
+			add = 5
+			OR = {
+				has_trait = ambitious
+				has_trait = greedy
+				has_trait = arrogant
+			}
+			any_character_situation = {
+				situation_type = dynastic_cycle
+			}
+		}
+		modifier = {
+			factor = 0
+			OR = {
+				has_trait = ambitious
+				has_trait = greedy
+				has_trait = arrogant
+			}
+			NOT = {
+				any_character_situation = {
+					situation_type = dynastic_cycle
+				}
+			}
+		}
+		modifier = {
+			factor = 0 #In China you should step down only if you can pass more exams
+			has_character_flag = passed_metropolitan_exam
+		}
+	}
+}
+
+#############################################
+# Change Imperial Aspirations				#
+#############################################
+### Change [GetPlayer.GetTopLiege.Custom('GetRoyalCourtRank')|U] Aspirations ###
+change_imperial_aspirations_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/ep3_cerimonial_decision.dds"
+	}
+	sort_order = 80
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 120
+		duchy = 120
+		kingdom = 120
+		empire = 120
+		hegemony = 120
+	}
+
+	desc = change_imperial_aspirations_decision_desc
+	selection_tooltip = change_imperial_aspirations_decision_tooltip
+	decision_group_type = admin
+
+	is_shown = {
+		has_ep3_dlc_trigger = yes
+		is_playable_character = yes
+		government_has_flag = government_is_administrative
+		liege ?= {
+			has_realm_law = acclamation_succession_law
+		}
+	}
+
+	is_valid = {
+		custom_tooltip = {
+			text = has_admin_government
+			government_has_flag = government_is_administrative
+		}
+		trigger_if = { # Unavailable if you are the top liege - Unless you have either modifier, so you may remove it.
+			limit = {
+				top_liege = this
+			}
+			OR = {
+				has_character_modifier = ep3_admin_renounce_throne_personal
+				house ?= { has_house_modifier = ep3_admin_renounce_throne_house }
+			}
+		}
+		trigger_else = {
+			custom_tooltip = { # The Emperor is your liege
+				text = admin_confirmation_liege_tt
+				top_liege ?= { highest_held_title_tier >= tier_kingdom }
+				liege ?= top_liege
+				liege != root
+			}
+		}
+		liege ?= {
+			has_realm_law = acclamation_succession_law
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		is_at_war_with_liege = no
+		NOT = { top_liege ?= root }
+	}
+	
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_ACTION"
+		#show_from_start = yes
+
+		### Remove yourself from competing for the throne
+		item = {
+			value = admin_renounce_throne_personal
+			is_valid = {
+				NOR = {
+					has_character_modifier = ep3_admin_renounce_throne_personal
+					house ?= { has_house_modifier = ep3_admin_renounce_throne_house }
+				}
+				NOT = { top_liege ?= root }
+				is_diarch = no
+			}
+			current_description = admin_renounce_throne_personal_desc
+			localization = admin_renounce_throne_personal_name
+			icon = "gfx/interface/icons/character_interactions/icon_liege.dds"
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						has_trait = content
+					}
+					add = 100
+				}
+			}
+		}
+		### Make yourself available to compete for the throne
+		item = {
+			value = admin_desire_throne_personal
+			is_valid = {
+				has_character_modifier = ep3_admin_renounce_throne_personal
+			}
+			current_description = admin_desire_throne_personal_desc
+			localization = admin_desire_throne_personal_name
+			icon = "gfx/interface/icons/character_interactions/icon_liege.dds"
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						has_character_modifier = ep3_admin_renounce_throne_personal
+						NOT = { has_trait = content }
+					}
+					add = 100
+				}
+			}
+		}
+		### Remove your house from competing for the throne
+		item = {
+			value = admin_renounce_throne_house
+			is_valid = {
+				house ?= {
+					custom_tooltip = {
+						text = HOF_INTERACTION_IS_HOUSE_HEAD
+						house_head ?= root
+					}
+					NOT = { has_house_modifier = ep3_admin_renounce_throne_house }
+				}
+				NOT = { top_liege.house ?= root.house }
+			}
+			current_description = admin_renounce_throne_house_desc
+			localization = admin_renounce_throne_house_name
+			icon = "gfx/interface/icons/character_interactions/icon_dynasty.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		### Make your house available to compete for the throne
+		item = {
+			value = admin_desire_throne_house
+			is_valid = {
+				house ?= {
+					custom_tooltip = {
+						text = HOF_INTERACTION_IS_HOUSE_HEAD
+						house_head ?= root
+					}
+					has_house_modifier = ep3_admin_renounce_throne_house
+				}
+			}
+			current_description = admin_desire_throne_house_desc
+			localization = admin_desire_throne_house_name
+			icon = "gfx/interface/icons/character_interactions/icon_dynasty.dds"
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						house ?= { has_house_modifier = ep3_admin_renounce_throne_house }
+					}
+					add = 100
+				}
+			}
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				scope:admin_renounce_throne_personal = yes
+			}
+			add_character_modifier = {
+				modifier = ep3_admin_renounce_throne_personal
+			}
+		}
+		else_if = {
+			limit = {
+				scope:admin_desire_throne_personal = yes
+			}
+			remove_character_modifier = ep3_admin_renounce_throne_personal
+		}
+		else_if = {
+			limit = {
+				scope:admin_renounce_throne_house = yes
+			}
+			house ?= {
+				add_house_modifier = ep3_admin_renounce_throne_house
+			}
+		}
+		else_if = {
+			limit = {
+				scope:admin_desire_throne_house = yes
+			}
+			house ?= {
+				remove_house_modifier = ep3_admin_renounce_throne_house
+			}
+		}
+	}
+
+	ai_potential = {
+		OR = {
+			has_character_modifier = ep3_admin_renounce_throne_personal
+			house ?= { has_house_modifier = ep3_admin_renounce_throne_house }
+			has_trait = content
+		}
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			add = 80
+			OR = {
+				has_character_modifier = ep3_admin_renounce_throne_personal
+				house ?= { has_house_modifier = ep3_admin_renounce_throne_house }
+			}
+			NOT = { has_trait = content }
+		}
+	}
+}

--- a/common/decisions/dlc_decisions/tgp/tgp_china_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_china_decisions.txt
@@ -1,0 +1,1598 @@
+﻿# Attend Children's Examination
+### Attend Children's Examination ###
+tgp_china_attend_child_exam_decision = {
+	title = tgp_china_attend_child_exam_decision
+	desc = tgp_china_attend_child_exam_decision_desc
+	selection_tooltip = tgp_china_attend_child_exam_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_examination_room.dds"
+	}
+
+	cooldown = { years = 3 }
+	sort_order = 80
+	decision_group_type = major
+
+	cost = {
+		influence = {
+			value = minor_influence_value
+		}
+	}
+
+	is_shown = {
+		age >= child_exam_min_age
+		age <= 16
+		has_tgp_dlc_trigger = yes
+		government_allows = merit
+		is_playable_character = yes
+		NOT = { has_character_flag = passed_child_exam }
+		has_domicile = yes
+		is_landed = no
+		trigger_if = {
+			limit = {
+				faith = { has_doctrine = doctrine_gender_female_dominated }
+			}
+			is_female = yes
+		}
+		trigger_else_if = {
+			limit = {
+				faith = { has_doctrine = doctrine_gender_male_dominated }
+			}
+			is_female = no
+		}
+		trigger_else = { always = yes }
+	}
+
+	is_valid = {
+		top_liege.highest_held_title_tier >= tier_hegemony
+	}
+
+	is_valid_showing_failures_only = {
+		custom_tooltip = {
+			text = tgp_china_attend_child_exam_age_limit
+			age >= child_exam_min_age
+		}
+		is_imprisoned = no
+		is_incapable = no
+		has_contagious_deadly_disease_trigger = no
+	}
+
+	effect = {
+		custom_tooltip = tgp_china_decision_effect_tt
+		if = {
+			limit = {
+				employs_court_position = court_tutor_court_position
+			}
+			custom_description_no_bullet = {
+				text = tutor_improved_exam_chances_tt
+				object = root
+			}
+		}
+		else = {
+			custom_description_no_bullet = {
+				text = tutor_needed_for_exam_chances_tt
+				object = root
+			}						
+		}
+		#Set variable for nr of safe bets player has made, so we do not need to check for it in every event.
+		set_variable = {
+			name = safe_bets
+			value = 0
+		}
+		set_variable = {
+			name = child_examination_success_chance
+			value = child_examination_success_chance_value
+		}
+		trigger_event = tgp_china_decision.1000
+	}
+
+	ai_check_interval = 0
+
+	ai_potential = {
+	}
+
+	ai_will_do = {
+		base = 100
+		modifier = {
+			any_close_or_extended_family_member = { is_governor = yes }
+			add = 25
+		}
+		modifier = {
+			has_trait = ambitious
+			add = 25
+		}
+		modifier = {
+			has_trait = content
+			add = -25
+		}
+		modifier = {
+			has_religion = religion:confucianism_religion
+			add = 25
+		}
+		modifier = {
+			learning > high_skill_rating
+			add = 25
+		}
+	}
+}
+
+# Command Family to attend Exams
+tgp_command_family_to_take_exams_decision = {
+	decision_group_type = admin
+	title = tgp_command_family_to_take_exams_decision
+	desc = tgp_command_family_to_take_exams_decision_desc
+	selection_tooltip = tgp_command_family_to_take_exams_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_examination_room.dds"
+	}
+	sort_order = 90
+
+	is_shown = {
+		is_ai = no
+		government_allows = merit
+		has_tgp_dlc_trigger = yes
+		this != top_liege
+		exists = house.house_head
+	}
+	
+	is_valid = {
+		is_house_head = yes
+	}
+
+	is_valid_showing_failures_only = {
+	}
+	
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_ACTION"
+		show_from_start = yes
+
+		item = { # Command to attend
+			value = command_to_attend
+			is_valid = {
+				custom_tooltip = {
+					text = command_to_attend_requirements_desc
+					NOT = {
+						has_character_flag = command_to_attend_flag
+					}
+				}
+			}
+			current_description = command_to_attend_desc
+			localization = command_to_attend_name
+			icon = "gfx/interface/icons/activities/activity_imperial_examination.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = { # Command to stop attending
+			value = command_to_stop_attending
+			is_valid = {
+				custom_tooltip = {
+					text = command_to_stop_attending_requirements_desc
+					has_character_flag = command_to_attend_flag
+				}
+			}
+			current_description = command_to_stop_attending_desc
+			localization = command_to_stop_attending_name
+			icon = "gfx/interface/icons/map_icons/map_icon_chinese_manor.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				scope:command_to_attend = yes
+			}
+			custom_tooltip = {
+				text = command_to_attend_effect_desc
+				add_character_flag = command_to_attend_flag
+			}
+		}
+		else = {
+			custom_tooltip = {
+				text = command_to_stop_attending_effect_desc
+				remove_character_flag = command_to_attend_flag
+			}
+		}
+	}
+	
+	ai_check_interval = 0
+}
+
+# Choose Career Path Decision
+### Choose Career Path ###
+tgp_choose_career_path_decision = {
+	decision_group_type = admin
+	title = tgp_choose_career_path_decision
+	desc = tgp_choose_career_path_decision_desc
+	selection_tooltip = tgp_choose_career_path_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_career.dds"
+	}
+	sort_order = 90
+
+	is_shown = {
+		is_ai = no
+		government_allows = merit
+		has_tgp_dlc_trigger = yes
+		this != top_liege
+	}
+	
+	is_valid = {
+		is_landed = no
+		custom_tooltip = {
+			text = you_are_not_a_minister_desc
+			tgp_has_minister_title = no
+		}
+		custom_tooltip = {
+			text = you_are_not_refusing_appointments_desc
+			trigger_if = {
+				limit = {
+					has_variable = appointment_trait_override
+				}
+				var:appointment_trait_override != trait:intellect_good_3
+			}
+			trigger_else = {
+				always = yes
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_at_war = no
+		is_adult = yes
+	}
+	
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_ACTION"
+		show_from_start = no
+
+		item = { # Choose a civilian career
+			value = civilian_career
+			is_valid = {
+				custom_tooltip = {
+					text = you_have_a_civilian_career_desc
+					trigger_if = {
+						limit = {
+							has_variable = appointment_trait_override
+						}
+						var:appointment_trait_override != trait:education_stewardship_1
+					}
+					trigger_else = {
+						NOT = { has_trait_with_flag = civilian_province }
+					}
+				}
+			}
+			current_description = tgp_choose_career_path_civilian_desc
+			localization = tgp_choose_career_path_civilian_name
+			icon = "gfx/interface/icons/celestial_administration_types/icon_game_concept_celestial_standard_administration.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = { # Choose a military career
+			value = military_career
+			is_valid = {
+				custom_tooltip = {
+					text = you_have_a_military_career_desc
+					trigger_if = {
+						limit = {
+							has_variable = appointment_trait_override
+						}
+						var:appointment_trait_override != trait:education_martial_1
+					}
+					trigger_else = {
+						NOT = { has_trait_with_flag = military_province }
+					}
+				}
+			}
+			current_description = tgp_choose_career_path_military_desc
+			localization = tgp_choose_career_path_military_name
+			icon = "gfx/interface/icons/celestial_administration_types/icon_game_concept_celestial_military_administration.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+	}
+
+	cost = {
+		influence = {
+			value = 50
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				scope:military_career = yes
+			}
+			custom_tooltip = {
+				text = change_to_military_career_desc
+				set_variable = {
+					name = appointment_trait_override
+					value = trait:education_martial_1
+				}
+			}
+		}
+		else = {
+			custom_tooltip = {
+				text = change_to_civilian_career_desc
+				set_variable = {
+					name = appointment_trait_override
+					value = trait:education_stewardship_1
+				}
+			}
+		}
+	}
+	
+	ai_check_interval = 0
+}
+
+# Refuse Appointments
+### Refuse Further Appointments ###
+tgp_refuse_appointments_decision = {
+	decision_group_type = admin
+	title = tgp_refuse_appointments_decision
+	desc = tgp_refuse_appointments_decision_desc
+	selection_tooltip = tgp_refuse_appointments_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_retire.dds"
+	}
+	confirm_text = tgp_refuse_appointments_decision_confirm
+	sort_order = 75
+
+	is_shown = {
+		government_has_flag = government_has_merit
+		has_tgp_dlc_trigger = yes
+		this != top_liege
+		custom_tooltip = {
+			text = you_are_not_refusing_appointments_desc
+			appointment_timeout_days < 36500
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_adult = yes
+		is_available = yes
+	}
+
+	cost = {
+		influence = {
+			value = 50
+		}
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = tgp_refuse_appointments_decision_refuse_desc
+			set_appointment_timeout = {
+				years = 150 # I.e. we make it pseudo-permanent
+				desc = appointment_timeout_desc_refusing
+			}
+		}
+	}
+	
+	ai_check_interval = 0
+	
+	ai_potential = { always = no }
+}
+
+# Resume Appointments
+### Resume New Appointments ###
+tgp_resume_appointments_decision = {
+	decision_group_type = admin
+	title = tgp_resume_appointments_decision
+	desc = tgp_resume_appointments_decision_desc
+	selection_tooltip = tgp_resume_appointments_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_career.dds"
+	}
+	confirm_text = tgp_resume_appointments_decision_confirm
+	sort_order = 75
+
+	is_shown = {
+		government_has_flag = government_has_merit
+		has_tgp_dlc_trigger = yes
+		this != top_liege
+		appointment_timeout_days > 0
+	}
+
+	is_valid_showing_failures_only = {
+		is_adult = yes
+		is_available = yes
+	}
+
+	cost = {
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = tgp_refuse_appointments_decision_accept_desc
+			clear_appointment_timeout = yes
+		}
+	}
+	
+	ai_check_interval = 0
+	
+	ai_potential = { always = no }
+}
+
+### Request Bestowal of Honors ###
+tgp_minister_request_bestowal_of_honors_decision = {
+	decision_group_type = major
+	title = tgp_minister_request_bestowal_of_honors_decision
+	desc = tgp_minister_request_bestowal_of_honors_decision_desc
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_kowtow.dds"
+	}
+	sort_order = 1000
+
+	is_shown = {
+		exists = house
+		government_has_flag = government_is_celestial
+		liege = { tgp_has_access_to_ministry_trigger = yes }
+		# keep them in hard enum, since we can not avoid touch this decision by encapsulation
+		OR = {
+			has_title = title:e_minister_chancellor
+			has_title = title:e_minister_censor
+			has_title = title:e_minister_grand_marshal
+			has_title = title:e_minister_of_personnel
+			has_title = title:e_minister_of_revenue
+			has_title = title:e_minister_of_rites
+			has_title = title:e_minister_of_war
+			has_title = title:e_minister_of_justice
+			has_title = title:e_minister_of_works
+		}
+	}
+	
+	is_valid = {
+		influence_level >= 5
+		OR = {
+			has_title = title:e_minister_chancellor
+			has_title = title:e_minister_censor
+			has_title = title:e_minister_grand_marshal
+			has_title = title:e_minister_of_personnel
+			has_title = title:e_minister_of_revenue
+			has_title = title:e_minister_of_rites
+			has_title = title:e_minister_of_war
+			has_title = title:e_minister_of_justice
+			has_title = title:e_minister_of_works
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_at_war = no
+		is_adult = yes
+		root.top_liege = {
+			is_physically_able = yes
+		}
+		trigger_if = {
+			limit = {
+				has_title = title:e_minister_chancellor
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_chancellor_modifier
+				}
+			}
+		}
+		trigger_else_if = {
+			limit = {
+				has_title = title:e_minister_censor
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_censor_modifier
+				}
+			}
+		}
+		trigger_else_if = {
+			limit = {
+				has_title = title:e_minister_grand_marshal
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_grand_marshal_modifier
+				}
+			}
+		}
+		trigger_else_if = {
+			limit = {
+				has_title = title:e_minister_of_personnel
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_of_personnel_modifier
+				}
+			}
+		}
+		trigger_else_if = {
+			limit = {
+				has_title = title:e_minister_of_revenue
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_of_revenue_modifier
+				}
+			}
+		}
+		trigger_else_if = {
+			limit = {
+				has_title = title:e_minister_of_rites
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_of_rites_modifier
+				}
+			}
+		}
+		trigger_else_if = {
+			limit = {
+				has_title = title:e_minister_of_war
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_of_war_modifier
+				}
+			}
+		}
+		trigger_else_if = {
+			limit = {
+				has_title = title:e_minister_of_justice
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_of_justice_modifier
+				}
+			}
+		}
+		trigger_else_if = {
+			limit = {
+				has_title = title:e_minister_of_works
+			}
+			NOT = {
+				house = {
+					has_house_modifier = tgp_e_minister_of_works_modifier
+				}
+			}
+		}
+		trigger_else = {
+			always = yes
+		}
+	}
+	
+	cost = {
+		influence = {
+			value = 5000
+		}
+	}
+
+	effect = {
+		close_view = {
+			view = decisions
+			player = root
+		}
+		trigger_event = tgp_china_ministry.1000
+		show_as_tooltip = {
+			reverse_add_opinion = {
+				target = root.top_liege
+				modifier = honorable_opinion
+				opinion = 50
+			}
+			add_character_modifier = tgp_personal_honors_modifier
+			if = {
+				limit = {
+					has_title = title:e_minister_chancellor
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_chancellor_modifier
+				}
+			}
+			else_if = {
+				limit = {
+					has_title = title:e_minister_censor
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_censor_modifier
+				}
+			}
+			else_if = {
+				limit = {
+					has_title = title:e_minister_grand_marshal
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_grand_marshal_modifier
+				}
+			}
+			else_if = {
+				limit = {
+					has_title = title:e_minister_of_personnel
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_of_personnel_modifier
+				}
+			}
+			else_if = {
+				limit = {
+					has_title = title:e_minister_of_revenue
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_of_revenue_modifier
+				}
+			}
+			else_if = {
+				limit = {
+					has_title = title:e_minister_of_rites
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_of_rites_modifier
+				}
+			}
+			else_if = {
+				limit = {
+					has_title = title:e_minister_of_war
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_of_war_modifier
+				}
+			}
+			else_if = {
+				limit = {
+					has_title = title:e_minister_of_justice
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_of_justice_modifier
+				}
+			}
+			else_if = {
+				limit = {
+					has_title = title:e_minister_of_works
+				}
+				house = {
+					add_house_modifier = tgp_e_minister_of_works_modifier
+				}
+			}
+			dynasty = { add_dynasty_prestige = 2000 }
+		}
+	}
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 0
+		empire = 12
+		hegemony = 0
+	}
+	
+	ai_potential = {
+		government_has_flag = government_is_celestial
+	}
+	
+	ai_will_do = { base = 100 }
+}
+
+# Recruit Courtiers from Celestial Capital
+### Summon Courtiers for the Celestial Bureau ###
+tgp_minister_recruit_courtiers_decision = {
+	decision_group_type = courtier
+	title = tgp_minister_recruit_courtiers_decision
+	desc = tgp_minister_recruit_courtiers_decision_desc
+	selection_tooltip = tgp_minister_recruit_courtiers_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_courtyard_asia.dds"
+	}
+	sort_order = 110
+
+	is_shown = {
+		government_has_flag = government_is_celestial
+		liege = { tgp_has_access_to_ministry_trigger = yes }
+		OR = {
+			has_title = title:e_minister_chancellor
+			has_title = title:e_minister_censor
+			has_title = title:e_minister_grand_marshal
+			has_title = title:e_minister_of_personnel
+			has_title = title:e_minister_of_revenue
+			has_title = title:e_minister_of_rites
+			has_title = title:e_minister_of_war
+			has_title = title:e_minister_of_justice
+			has_title = title:e_minister_of_works
+		}
+	}
+	
+	is_valid = {
+	}
+
+	is_valid_showing_failures_only = {
+		is_at_war = no
+		is_adult = yes
+	}
+	
+	cooldown = { years = 2 }
+	
+	widget = {
+		gui = "decision_view_widget_option_list_generic"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "CHOOSE_NOMAD_COURTIER_DECISION_NEXT_STEP_BUTTON"
+		show_from_start = yes
+
+		item = {
+			value = minister_recruit_administrator
+			is_valid = {
+				NOR = {
+					has_title = title:e_minister_grand_marshal
+					has_title = title:e_minister_of_rites
+					has_title = title:e_minister_of_war
+				}
+			}
+			current_description = minister_recruit_administrator_desc
+			localization = minister_recruit_administrator_desc
+			icon = "gfx/interface/icons/modifiers/icon_merit_07.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = minister_recruit_diplomat
+			is_valid = {
+				NOR = {
+					has_title = title:e_minister_grand_marshal
+					has_title = title:e_minister_of_rites
+					has_title = title:e_minister_of_war
+					has_title = title:e_minister_of_works
+				}
+			}
+			current_description = minister_recruit_diplomat_desc
+			localization = minister_recruit_diplomat_desc
+			icon = "gfx/interface/icons/court_position_types/grand_historian_court_position.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = minister_recruit_commander
+			is_valid = {
+				NOR = {
+					has_title = title:e_minister_censor
+					has_title = title:e_minister_of_revenue
+					has_title = title:e_minister_of_rites
+					has_title = title:e_minister_of_justice
+					has_title = title:e_minister_of_works
+				}
+			}
+			current_description = minister_recruit_commander_desc
+			localization = minister_recruit_commander_desc
+			icon = "gfx/interface/icons/character_interactions/icon_coax_to_war.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = minister_recruit_warrior
+			is_valid = {
+				NOR = {
+					has_title = title:e_minister_censor
+					has_title = title:e_minister_of_revenue
+					has_title = title:e_minister_of_rites
+					has_title = title:e_minister_of_justice
+					has_title = title:e_minister_of_works
+				}
+			}
+			current_description = minister_recruit_warrior_desc
+			localization = minister_recruit_warrior_desc
+			icon = "gfx/interface/icons/character_interactions/icon_combat.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = minister_recruit_scholar
+			is_valid = {
+				NOR = {
+					has_title = title:e_minister_censor
+					has_title = title:e_minister_grand_marshal
+					has_title = title:e_minister_of_revenue
+					has_title = title:e_minister_of_war
+				}
+			}
+			current_description = minister_recruit_scholar_desc
+			localization = minister_recruit_scholar_desc
+			icon = "gfx/interface/icons/character_interactions/imperial_examination.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = minister_recruit_confucian_scholar
+			is_valid = {
+				NOR = {
+					has_title = title:e_minister_censor
+					has_title = title:e_minister_grand_marshal
+					has_title = title:e_minister_of_revenue
+					has_title = title:e_minister_of_war
+					has_title = title:e_minister_of_works
+				}
+			}
+			current_description = minister_recruit_confucian_scholar_desc
+			localization = minister_recruit_confucian_scholar_desc
+			icon = "gfx/interface/icons/modifiers/icon_piety_confucianism_02.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = minister_recruit_eunuch
+			is_valid = {
+				NOR = {
+					has_title = title:e_minister_grand_marshal
+					has_title = title:e_minister_of_revenue
+					has_title = title:e_minister_of_rites
+					has_title = title:e_minister_of_war
+					has_title = title:e_minister_of_justice
+					has_title = title:e_minister_of_works
+				}
+			}
+			current_description = minister_recruit_eunuch_desc
+			localization = minister_recruit_eunuch_desc
+			icon = "gfx/interface/icons/character_interactions/provincial_examination.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+	}
+
+	cost = {
+		treasury = {
+			value = 100
+		}
+	}
+
+	effect = {
+		save_scope_as = minister_scope
+		custom_tooltip = tgp_minister_recruit_courtiers_decision_effect_desc
+		hidden_effect = {
+			if = {
+				limit = { scope:minister_recruit_administrator = yes }
+				minister_courtier_recruitment_effect = { COURTIER_TEMPLATE = tgp_minister_administrator_template }
+			}
+			else_if = {
+				limit = { scope:minister_recruit_diplomat = yes }
+				minister_courtier_recruitment_effect = { COURTIER_TEMPLATE = tgp_minister_diplomat_template }
+			}
+			else_if = {
+				limit = { scope:minister_recruit_commander = yes }
+				minister_courtier_recruitment_effect = { COURTIER_TEMPLATE = tgp_minister_commander_template }
+			}
+			else_if = {
+				limit = { scope:minister_recruit_warrior = yes }
+				minister_courtier_recruitment_effect = { COURTIER_TEMPLATE = tgp_minister_warrior_template }
+			}
+			else_if = {
+				limit = { scope:minister_recruit_scholar = yes }
+				minister_courtier_recruitment_effect = { COURTIER_TEMPLATE = tgp_minister_scholar_template }
+			}
+			else_if = {
+				limit = { scope:minister_recruit_confucian_scholar = yes }
+				minister_courtier_recruitment_effect = { COURTIER_TEMPLATE = tgp_minister_confucian_scholar_template }
+			}
+			else_if = {
+				limit = { scope:minister_recruit_eunuch = yes }
+				minister_courtier_recruitment_effect = { COURTIER_TEMPLATE = tgp_minister_eunuch_template }
+			}
+		}
+	}
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 0
+		empire = 12
+		hegemony = 0
+	}
+	
+	ai_potential = {
+		liege = { tgp_has_access_to_ministry_trigger = yes }
+		is_councillor = yes
+		any_courtier = { count <= 10 }
+	}
+	
+	ai_will_do = { base = 100 }
+}
+
+# Study Confucian Classics
+### Study the Confucian Classics ###
+tgp_china_study_confucian_classics_decision = {
+	decision_group_type = admin
+	title = tgp_china_study_confucian_classics_decision
+	desc = tgp_china_study_confucian_classics_decision_desc
+	selection_tooltip = tgp_china_study_confucian_classics_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_debate.dds"
+	}
+	sort_order = 120
+	
+	cooldown = { years = 5 }
+
+	cost = {
+	}
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		government_allows = merit
+		is_playable_character = yes
+		NOT = { top_liege = root }
+	}
+
+	is_valid = {
+		knows_language = language_chinese
+		custom_tooltip = {
+			text = tgp_china_study_confucian_classics_decision_req_tt
+			NOT = {
+				any_scheme = {
+					type = study_confucian_classics
+				}
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		NOT = {
+			has_character_modifier = tgp_gave_up_modifier
+		}
+		is_available = yes
+		can_start_scheme = {
+			type = study_confucian_classics
+			target_character = root
+		}
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = tgp_china_study_confucian_classics_decision_tt
+			start_scheme = {
+				type = study_confucian_classics
+				target_character = root
+			}
+			close_view = {
+				view = decisions
+				player = root
+			}
+			random_scheme = {
+				type = study_confucian_classics
+				save_scope_as = scheme
+			}
+			save_scope_as = owner
+			trigger_event = study_confucian_classics_outcome.10
+		}
+		if = {
+			limit = {
+				any_scheme = { is_scheme_category = personal }
+			}
+			custom_tooltip = tgp_china_study_confucian_classics_decision_end_scheme_tt
+		}
+		if = {
+			limit = { is_landed = yes }
+			custom_tooltip = tgp_china_study_confucian_classics_decision_recommendations_tt
+		}
+	}
+
+	ai_check_interval = 0
+
+	ai_potential = {
+	}
+
+	ai_will_do = {
+		base = 100
+	}
+}
+
+### Claim the Mantle of Maitreya ###
+tgp_claim_the_mantle_of_maitreya_decision = {
+	ai_check_interval = 0
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_holysite_asia.dds"
+	}
+	desc = claim_the_mantle_of_maitreya_decision_desc
+	decision_group_type = major
+
+	selection_tooltip = claim_the_mantle_of_maitreya_decision_tooltip
+
+	cooldown = { years = 30 }
+
+	is_shown = {
+		faith = {
+			has_doctrine = tenet_extinction_of_dharma
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		custom_tooltip = {
+			text = the_maitreya_already_exists
+			NOT = {
+				has_global_variable = the_maitreya_has_descended
+			}
+		}
+		is_available_adult = yes
+	}
+
+	is_valid = {
+		is_independent_ruler = yes
+		capital_county.faith = root.faith
+		piety_level >= 5
+		OR = {
+			has_trait = zealous
+			has_trait = peasant_leader
+			has_trait = possessed
+			has_trait = lunatic
+		}
+		highest_held_title_tier >= tier_kingdom
+		custom_tooltip = {
+			text = maitreya_hof_requirement
+			OR = {
+				NOT = {
+					exists = faith.religious_head
+				}
+				faith.religious_head ?= this
+			}
+		}
+	}
+
+	cost = {
+		prestige = {
+			value = monumental_prestige_value
+		}
+		piety = {
+			value = monumental_piety_value
+		}
+	}
+
+	effect = {
+		faith = {
+			change_fervor = {
+				value = 100
+				desc = maitreya_has_descended_fervor_desc
+			}
+		}
+		add_character_modifier = claimed_mantle_of_maitreya_modifier
+		hidden_effect = {
+			set_global_variable = {
+				name = the_maitreya_has_descended
+				value = yes
+			}
+		}
+		spawn_army = {
+			levies = maitreya_devotee_army_value
+			location = root.capital_province
+			origin = root.capital_province
+			inheritable = no
+			name = maitreya_devotees
+		}
+	}
+	
+	ai_potential = {
+		always = no
+	}
+
+	ai_will_do = {
+		base = 0
+	}
+}
+
+# Drink Tea/Perform Tea Ceremony - Unlocked from the Asian Estate
+### Drink Tea ###
+tgp_tea_ceremony_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_relaxing_room_asia.dds"
+	}
+	title = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					culture = { has_cultural_pillar = heritage_chinese }
+				}
+				desc = tgp_tea_ceremony_decision
+			}
+			desc = tgp_tea_ceremony_decision_ceremony_name
+		}
+	}
+	desc = tgp_tea_ceremony_decision_desc
+	sort_order = 200
+
+	selection_tooltip = tgp_tea_ceremony_decision_tooltip
+
+	cooldown = { years = 5 }
+
+	is_shown = {
+		domicile ?= { has_domicile_parameter = estate_unlock_tea_ceremony }
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+	}
+
+	is_valid = {
+	}
+
+	cost = {
+		piety = {
+			value = minor_piety_value
+		}
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = tgp_tea_ceremony_decision_effect_desc
+			
+			random_courtier = {
+				limit = {
+					is_available_adult = yes
+				}
+				weight = {
+					base = 5
+					
+					modifier = {
+						add = 5
+						is_close_family_of = root
+					}
+					modifier = {
+						add = 3
+						exists = house
+						house = root.house
+					}
+					modifier = {
+						add = {
+							value = learning
+							divide = 4
+						}
+						learning >= 10
+					}
+				}
+				save_scope_as = inspired_courtier
+			}
+			
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = tgp_tea_ceremony_decision_toast
+				left_icon = root
+				
+				# Lose stress
+				if = {
+					limit = { stress > 0 }
+					stress_impact = {
+						base = -25
+						content = medium_stress_impact_loss
+						humble = minor_stress_impact_loss
+						patient = minor_stress_impact_loss
+						calm = minor_stress_impact_loss
+						gregarious = minor_stress_impact_loss
+					}
+				}
+				# Gain a random effect
+				random_list = {
+					20 = { # Gain opinion
+						trigger = {
+							exists = scope:inspired_courtier
+						}
+						
+						progress_towards_friend_effect = {
+							REASON = friend_drinking_tea
+							CHARACTER = scope:inspired_courtier
+							OPINION = default_friend_opinion
+						}
+					}
+					10 = { # Courtier becomes inspired
+						trigger = {
+							exists = scope:inspired_courtier
+						}
+						
+						# Add inspiration
+						if = {
+							limit = {
+								has_royal_court = yes
+							}
+							grant_inspiration_to_character_effect = { CHARACTER = scope:inspired_courtier }
+						}
+						else = {
+							grant_inspiration_to_character_no_court_artifacts_effect = { CHARACTER = scope:inspired_courtier }
+						}
+						# Custom tooltip to explain that a courtier was inspired
+						custom_tooltip = courtier_inspired_effect
+					}
+					10 = { # Health negation
+						add_character_modifier = {
+							modifier = tea_ceremony_health_benefit
+							years = 5
+						}
+					}
+					10 = { # Diplomacy
+						add_character_modifier = {
+							modifier = tea_ceremony_perfect_tea
+							years = 5
+						}
+					}
+					10 = { # Stress
+						add_character_modifier = {
+							modifier = tea_ceremony_peace_of_mind
+							years = 5
+						}
+					}
+					10 = { # Spirit/piety
+						add_character_modifier = {
+							modifier = tea_ceremony_spirit
+							years = 5
+						}
+					}
+					10 = { # Family
+						add_character_modifier = {
+							modifier = tea_ceremony_family
+							years = 5
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	ai_check_interval = 0
+	
+	ai_potential = {
+		always = no
+	}
+
+	ai_will_do = {
+		base = 0
+	}
+}
+
+# Suggest Treasury Audit
+### Suggest Treasury Audit ###
+tgp_suggest_budget_change_decision = {
+	decision_group_type = admin
+	title = tgp_suggest_budget_change_decision
+	desc = tgp_suggest_budget_change_decision_desc
+	selection_tooltip = tgp_suggest_budget_change_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_scholars.dds"
+	}
+	sort_order = 110
+
+	is_shown = {
+		government_has_flag = government_is_celestial
+		liege = { tgp_has_access_to_ministry_trigger = yes }
+		has_title = title:e_minister_of_revenue
+	}
+	
+	is_valid = {
+	}
+
+	is_valid_showing_failures_only = {
+		is_at_war = no
+		is_adult = yes
+	}
+	
+	cooldown = { years = 3 }
+	
+	widget = {
+		gui = "decision_view_widget_option_list_generic"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_ACTION"
+		show_from_start = yes
+
+		item = {
+			value = suggest_salary_budget
+			is_valid = {
+				custom_tooltip = {
+					text = liege_already_has_budget_desc
+					can_suggest_budget_salary_template_trigger = yes
+				}
+			}
+			current_description = suggest_salary_budget_desc
+			localization = suggest_salary_budget_desc
+			icon = "gfx/interface/icons/character_interactions/icon_gold.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = suggest_ministry_budget
+			is_valid = {
+				custom_tooltip = {
+					text = liege_already_has_budget_desc
+					can_suggest_budget_ministry_template_trigger = yes
+				}
+			}
+			current_description = suggest_ministry_budget_desc
+			localization = suggest_ministry_budget_desc
+			icon = "gfx/interface/icons/government_types/celestial_government.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = suggest_military_budget
+			is_valid = {
+				custom_tooltip = {
+					text = liege_already_has_budget_desc
+					can_suggest_budget_military_template_trigger = yes
+				}
+			}
+			current_description = suggest_military_budget_desc
+			localization = suggest_military_budget_desc
+			icon = "gfx/interface/icons/celestial_administration_types/icon_game_concept_celestial_military_administration.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = suggest_hegemon_budget
+			is_valid = {
+				custom_tooltip = {
+					text = liege_already_has_budget_desc
+					can_suggest_budget_hegemon_template_trigger = yes
+				}
+			}
+			current_description = suggest_hegemon_budget_desc
+			localization = suggest_hegemon_budget_desc
+			icon = "gfx/interface/icons/legitimacy_types/mandate_legitimacy.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = suggest_balanced_budget
+			is_valid = {
+				custom_tooltip = {
+					text = liege_already_has_budget_desc
+					can_suggest_budget_balanced_template_trigger = yes
+				}
+			}
+			current_description = suggest_balanced_budget_desc
+			localization = suggest_balanced_budget_desc
+			icon = "gfx/interface/icons/character_interactions/scroll_scales.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = suggest_salary_increase
+			is_valid = {
+				liege = {
+					NOT = { realm_law_group_at_maximum_level = budget_allocation_salary_law }
+				}
+			}
+			current_description = increase_budget_salary_desc
+			localization = increase_budget_salary_name
+			icon = "gfx/interface/icons/character_interactions/icon_gold.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = suggest_ministry_increase
+			is_valid = {
+				liege = {
+					NOT = { realm_law_group_at_maximum_level = budget_allocation_ministry_law }
+				}
+			}
+			current_description = increase_budget_ministry_desc
+			localization = increase_budget_ministry_name
+			icon = "gfx/interface/icons/court_position_types/favored_minister_court_position.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = suggest_military_increase
+			is_valid = {
+				liege = {
+					NOT = { realm_law_group_at_maximum_level = budget_allocation_military_law }
+				}
+			}
+			current_description = increase_budget_military_desc
+			localization = increase_budget_military_name
+			icon = "gfx/interface/icons/message_feed/soldier.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+	}
+
+	cost = {
+		influence = {
+			value = medium_influence_value
+		}
+	}
+
+	effect = {
+		save_scope_as = minister_of_revenue
+		liege = { save_scope_as = treasury_ruler }
+		custom_tooltip = tgp_suggest_budget_change_decision_liege_desc
+		if = {
+			limit = { scope:suggest_salary_budget = yes }
+			custom_tooltip = tgp_treasury_enact_salary_budget_desc
+			save_scope_as = budget_suggestion_salary_template
+		}
+		else_if = {
+			limit = { scope:suggest_ministry_budget= yes }
+			custom_tooltip = tgp_treasury_enact_ministry_budget_desc
+			save_scope_as = budget_suggestion_ministry_template
+		}
+		else_if = {
+			limit = { scope:suggest_military_budget = yes }
+			custom_tooltip = tgp_treasury_enact_military_budget_desc
+			save_scope_as = budget_suggestion_military_template
+		}
+		else_if = {
+			limit = { scope:suggest_hegemon_budget = yes }
+			custom_tooltip = tgp_treasury_enact_hegemon_budget_desc
+			save_scope_as = budget_suggestion_hegemon_template
+		}
+		else_if = {
+			limit = { scope:suggest_balanced_budget = yes }
+			custom_tooltip = tgp_treasury_enact_balanced_budget_desc
+			save_scope_as = budget_suggestion_balanced_template
+		}
+		else_if = {
+			limit = { scope:suggest_salary_increase = yes }
+			custom_tooltip = increase_budget_salary_tooltip
+			save_scope_as = budget_suggestion_salary_increase
+		}
+		else_if = {
+			limit = { scope:suggest_ministry_increase = yes }
+			custom_tooltip = increase_budget_ministry_tooltip
+			save_scope_as = budget_suggestion_ministry_increase
+		}
+		else_if = {
+			limit = { scope:suggest_military_increase = yes }
+			custom_tooltip = increase_budget_military_tooltip
+			save_scope_as = budget_suggestion_military_increase
+		}
+		liege = {
+			trigger_event = { id = tgp_china_ministry.0200 days = 1 }
+		}
+	}
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 0
+		empire = 0
+		hegemony = 0
+	}
+	
+	ai_potential = {
+		always = no
+	}
+	
+	ai_will_do = { base = 0 }
+}
+
+
+### Withdraw Fund from Treasury ###
+extract_gold_from_treasury = {
+	picture = {
+		trigger = {
+			culture = {
+				has_graphical_east_asia_culture_group_trigger = yes
+			}
+		}
+		reference = "gfx/interface/illustrations/decisions/tgp_scholars.dds"
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/fp3_decision_tax_collector.dds"
+	}
+
+	desc = extract_gold_from_treasury_desc
+	decision_group_type = admin
+	selection_tooltip = extract_gold_from_treasury_tooltip
+	sort_order = 110
+
+	cooldown = { years = 2 }
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 12
+		empire = 12
+		hegemony = 12
+	}
+
+	is_shown = {
+		is_playable_character = yes
+		has_treasury = yes
+		OR = {
+			is_independent_ruler = yes
+			tgp_is_any_minister = yes
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		treasury >= medium_treasury_value
+		trigger_if = {
+			limit = {
+				is_valid_for_legitimacy_change = yes
+			}
+			legitimacy_level > 0
+		}
+	}
+
+	effect = {
+		remove_short_term_treasury = medium_treasury_value
+		add_short_term_gold = medium_treasury_value
+
+		if = {
+			limit = {
+				is_valid_for_legitimacy_change = yes
+			}
+
+			add_legitimacy = {
+				value = major_legitimacy_loss
+				min = {
+					value = medium_treasury_value
+					multiply = -0.5
+				}
+			}
+			add_character_modifier = {
+				modifier = tgp_dipped_into_treasury_modifier
+				years = 3
+			}
+		}
+		else_if = {
+			limit = {
+				tgp_is_any_minister = yes
+			}
+			add_character_modifier = {
+				modifier = tgp_minister_dipped_into_treasury_modifier
+				years = 3
+			}
+		}
+
+		if = {
+			limit = {
+				top_liege.primary_title = title:h_china
+			}
+			tgp_activate_catalyst_against_hegemon_effect = {
+				HEGEMON = root.top_liege
+				CATALYST = catalyst_dipped_into_treasury
+			}
+		}
+	}
+
+	cost = {
+		influence = {
+			value = 0
+			if = {
+				limit = { is_valid_for_legitimacy_change = no }
+				add = massive_influence_value
+			}
+		}
+	}
+
+	ai_potential = {
+		OR = {
+			gold < 0
+			AND = {
+				top_liege = this
+				gold < massive_gold_value
+				ai_greed > high_positive_ai_value
+			}
+		}
+		# Don't do it if this when at low legitimacy, as the top ruler
+		OR = {
+			top_liege != this
+			legitimacy_level > 1
+		}
+	}
+
+	ai_will_do = {
+		base = 100
+	}
+}

--- a/common/decisions/dlc_decisions/tgp/tgp_china_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_china_decisions.txt
@@ -448,6 +448,11 @@ tgp_minister_request_bestowal_of_honors_decision = {
 			has_title = title:e_minister_of_justice
 			has_title = title:e_minister_of_works
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= 5000
+		}
 	}
 	
 	is_valid = {
@@ -567,12 +572,18 @@ tgp_minister_request_bestowal_of_honors_decision = {
 	}
 	
 	cost = {
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
 		influence = {
-			value = 5000
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = 5000
+			}
 		}
 	}
 
 	effect = {
+		debug_log = "unop_475 tgp_minister_request_bestowal_of_honors_decision" #Unop debug log to confirm issue #475
 		close_view = {
 			view = decisions
 			player = root
@@ -659,8 +670,13 @@ tgp_minister_request_bestowal_of_honors_decision = {
 			}
 			dynasty = { add_dynasty_prestige = 2000 }
 		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = -5000
+		}
 	}
-	
+
 	ai_check_interval_by_tier = {
 		barony = 0
 		county = 0

--- a/common/decisions/dlc_decisions/tgp/tgp_dynastic_cycle_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_dynastic_cycle_decisions.txt
@@ -1,0 +1,3437 @@
+﻿### Claim the Mandate of Heaven ###
+situation_dynastic_cycle_claim_mandate_decision = {
+	decision_group_type = dynastic_cycle
+	title = situation_dynastic_cycle_claim_mandate_decision
+	desc = situation_dynastic_cycle_claim_mandate_decision_desc
+	selection_tooltip = situation_dynastic_cycle_claim_mandate_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_stability.dds"
+	}
+	extra_picture = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_stability.dds"
+	sort_order = 80
+
+	cooldown = { years = 5 }
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		exists = top_participant_group:dynastic_cycle #I am part of the dynastic cycle
+		situation:dynastic_cycle = { situation_current_phase = situation_dynastic_cycle_phase_chaos } #The era is division
+	}
+
+	is_valid = {
+		situation:dynastic_cycle = { situation_current_phase = situation_dynastic_cycle_phase_chaos }
+		is_independent_ruler = yes
+		custom_tooltip = {
+			text = claim_mandate_decision_county_percentage_tt
+			title:h_china = {
+				any_de_jure_county = {
+					percent >= claim_mandate_china_county_percentage_value
+					holder.top_liege = {
+						OR = {
+							this = root
+							is_tributary_of_suzerain_or_above = root
+						}
+					}
+				}
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_at_peace_adult = yes
+	}
+
+	effect = {
+		add_character_flag = {
+			flag = claimed_the_mandate_of_heaven
+			days = 3
+		}
+		#GoK stops really being GoK
+		gok_government_change_story_end_effect = yes
+		situation:dynastic_cycle = { save_scope_as = situation }
+		tgp_claim_mandate_of_heaven_effect = yes
+	}
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 36
+		empire = 3
+		hegemony = 12
+	}
+	ai_potential = { 
+		situation:dynastic_cycle ?= { situation_current_phase = situation_dynastic_cycle_phase_chaos }
+		NOT = {
+			any_owned_story = {
+				OR = {
+					story_type = story_mongol_invasion
+					story_type = story_greatest_of_khans
+				}
+			}
+		}
+	}
+	ai_will_do = { base = 10000 }
+}
+
+situation_dynastic_cycle_favor_own_culture_for_appointments = {
+	title = situation_dynastic_cycle_favor_own_culture_for_appointments
+	desc = situation_dynastic_cycle_favor_own_culture_for_appointments_desc
+	selection_tooltip = situation_dynastic_cycle_favor_own_culture_for_appointments_tooltip
+	confirm_text = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:situation_dynastic_cycle_remove_favor = yes }
+				desc = situation_dynastic_cycle_favor_own_culture_for_appointments_confirm_2
+			}
+			desc = situation_dynastic_cycle_favor_own_culture_for_appointments_confirm_1
+		}
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_debate.dds"
+	}
+	sort_order = 70
+	decision_group_type = dynastic_cycle
+
+	is_shown = {
+		has_title = title:h_china
+		top_participant_group:dynastic_cycle ?= {
+			has_participant_group_parameter = dynastic_cycle_hegemon_may_favour_own_culture_for_appointments
+		}
+	}
+
+	is_valid = {
+		custom_tooltip = {
+			text = government_is_celestial_tt
+			government_has_flag = government_is_celestial
+		}
+		situation:dynastic_cycle = { situation_current_phase =  situation_dynastic_cycle_phase_instability_conquest }
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+	}
+	
+	cost = {
+		prestige = 250
+	}
+	
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_ACTION"
+
+		### Favor your own culture
+		item = {
+			value = situation_dynastic_cycle_favor_own_culture
+			is_valid = {
+				custom_tooltip = {
+					text = situation_dynastic_cycle_own_culture_already_favored_desc
+					situation:dynastic_cycle ?= {
+						OR = {
+							NOT = { has_variable = dynastic_cycle_favored_culture }
+							var:dynastic_cycle_favored_culture != root.culture
+						}
+					}
+				}
+				#culture ?= {
+				#	NOT = { has_cultural_pillar = heritage_chinese }
+				#}
+			}
+			current_description = situation_dynastic_cycle_favor_own_culture_desc
+			localization = situation_dynastic_cycle_favor_own_culture_name
+			icon = "gfx/interface/icons/message_feed/culture.dds"
+			ai_chance = {
+				value = 100
+			}
+		}
+		### Remove currently favored culture
+		item = {
+			value = situation_dynastic_cycle_remove_favor
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					save_temporary_scope_as = situation_scope
+					custom_tooltip = {
+						text = situation_dynastic_cycle_no_favored_culture_desc
+						has_variable = dynastic_cycle_favored_culture
+					}
+				}
+			}
+			current_description = situation_dynastic_cycle_remove_favor_desc
+			localization = situation_dynastic_cycle_remove_favor_name
+			icon = "gfx/interface/icons/message_feed/culture.dds"
+			ai_chance = {
+				value = 0 # The AI doesn't need to do this
+			}
+		}
+	}
+
+	effect = {
+		situation:dynastic_cycle ?= { save_scope_as = situation }
+		culture = {
+			save_scope_as = hegemon_favored_culture
+		}
+		if = { # Promote your own culture
+			limit = { scope:situation_dynastic_cycle_favor_own_culture = yes }
+			custom_tooltip = {
+				text = situation_dynastic_cycle_conquest_favor_own_culture_desc
+				situation:dynastic_cycle ?= {
+					set_variable = {
+						name = dynastic_cycle_favored_culture
+						value = scope:hegemon_favored_culture
+					}
+				}
+				
+				# Notify any vassal players
+				every_player = {
+					limit = { target_is_liege_or_above = root }
+					
+				}
+			}
+		}
+		else_if = { # Stop promoting currently promoted culture
+			limit = { scope:situation_dynastic_cycle_remove_favor = yes }
+			custom_tooltip = {
+				text = situation_dynastic_cycle_conquest_stop_favored_culture_desc
+				situation:dynastic_cycle ?= {
+					remove_variable = dynastic_cycle_favored_culture
+				}
+				
+				# Notify any vassal players
+				every_player = {
+					limit = { target_is_liege_or_above = root }
+					
+				}
+			}
+		}
+	}
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 0
+		empire = 0
+		hegemony = 36
+	}
+	
+	ai_potential = { always = yes }
+	
+	ai_will_do = {
+		base = 30
+		
+		modifier = {
+			ai_boldness >= high_positive_ai_value
+			add = 45
+		}
+		modifier = {
+			ai_honor >= very_high_positive_ai_value
+			ai_rationality >= very_high_positive_ai_value
+			add = -30
+		}
+	}
+}
+
+#only for Players - ability to choose a participation group in the Dynastic Cycle
+### Join Movement ###
+situation_dynastic_cycle_choose_movement_decision = {
+	decision_group_type = dynastic_cycle
+	title = situation_dynastic_cycle_choose_movement_decision
+	desc = situation_dynastic_cycle_choose_movement_decision_desc
+	selection_tooltip = situation_dynastic_cycle_choose_movement_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_scholars.dds"
+	}
+	sort_order = 80
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		is_ai = no
+		any_character_situation = {
+			situation_type = dynastic_cycle
+			NOT = { situation_current_phase = situation_dynastic_cycle_phase_chaos }
+		}
+		top_participant_group:dynastic_cycle ?= {
+			NOR = {
+				participant_group_type = other_rulers
+				participant_group_type = hegemon_ruler
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_adult = yes
+		custom_tooltip = {
+			text = situation_dynastic_cycle_choose_movement_decision_cannot_leave_var
+			NOT = { has_variable = dynastic_cycle_cannot_leave_movement_var }
+		}
+	}
+	cooldown = { years = 5 }
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_ACTION"
+		show_from_start = yes
+
+		item = {
+			value = pro_hegemon_movement
+			is_valid = {
+				custom_tooltip = {
+					text = already_in_this_movement_desc
+					situation:dynastic_cycle ?= {
+						situation_participant_group:pro_hegemon_movement = {
+							NOT = { participant_group_has_character = root }
+						}
+					}
+				}
+			}
+			current_description = choose_pro_hegemon_movement_desc
+			localization = choose_pro_hegemon_movement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_pro.dds"
+			flat = yes
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = expansion_movement
+			is_valid = {
+				custom_tooltip = {
+					text = already_in_this_movement_desc
+					situation:dynastic_cycle ?= {
+						situation_participant_group:expansion_movement = {
+							NOT = { participant_group_has_character = root }
+						}
+					}
+				}
+			}
+			current_description = choose_expansion_movement_desc
+			localization = choose_expansion_movement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_expand.dds"
+			flat = yes
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = advancement_movement
+			is_valid = {
+				custom_tooltip = {
+					text = already_in_this_movement_desc
+					situation:dynastic_cycle ?= {
+						situation_participant_group:advancement_movement = {
+							NOT = { participant_group_has_character = root }
+						}
+					}
+				}
+			}
+			current_description = choose_advancement_movement_desc
+			localization = choose_advancement_movement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_advance.dds"
+			flat = yes
+			ai_chance = {
+				value = 100
+			}
+		}
+		item = {
+			value = conservative_movement
+			is_valid = {
+				custom_tooltip = {
+					text = already_in_this_movement_desc
+					situation:dynastic_cycle ?= {
+						situation_participant_group:conservative_movement = {
+							NOT = { participant_group_has_character = root }
+						}
+					}
+				}
+			}
+			current_description = choose_conservative_movement_desc
+			localization = choose_conservative_movement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_anti.dds"
+			flat = yes
+			ai_chance = {
+				value = 100
+			}
+		}
+	}
+
+	cost = {
+		influence = {
+			value = 0
+			if = {
+				limit = {
+					government_allows = administrative
+				}
+				# Base cost
+				value = monumental_influence_value
+				# More expensive for each disciple
+				add = {
+					value = 10
+					multiply = root.number_of_disciples
+				}
+				# Less expensive to go out of the undecided movement to any other movement
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							situation_participant_group:undecided_movement = {
+								participant_group_has_character = root
+							}
+						}
+					}
+					multiply = 0.5
+				}
+				# Reduce the cost if your elder is in the selected movement
+				if = {
+					limit = {
+						any_relation = {
+							type = elder
+							save_temporary_scope_as = elder
+						}
+						situation:dynastic_cycle ?= {
+							OR = {
+								AND = {
+									situation_participant_group:pro_hegemon_movement = {
+										participant_group_has_character = scope:elder
+									}
+									scope:pro_hegemon_movement ?= yes
+								}
+								AND = {
+									situation_participant_group:expansion_movement = {
+										participant_group_has_character = scope:elder
+									}
+									scope:expansion_movement ?= yes
+								}
+								AND = {
+									situation_participant_group:advancement_movement = {
+										participant_group_has_character = scope:elder
+									}
+									scope:advancement_movement ?= yes
+								}
+								AND = {
+									situation_participant_group:conservative_movement = {
+										participant_group_has_character = scope:elder
+									}
+									scope:conservative_movement ?= yes
+								}
+							}
+						}
+					}
+					multiply = 0.5
+				}
+			}
+		}
+		# Non-admins pay prestige instead
+		prestige = {
+			value = 0
+			if = {
+				limit = {
+					NOT = { government_allows = administrative }
+				}
+				# Base cost
+				value = {
+					value = monumental_influence_value
+					multiply = 2
+				}
+				# Less expensive to go out of the undecided movement to any other movement
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							situation_participant_group:undecided_movement = {
+								participant_group_has_character = root
+							}
+						}
+					}
+					multiply = 0.5
+				}
+			}
+		}
+	}
+
+	effect = {
+		save_scope_as = recipient #for loc
+		switch = {
+			trigger = yes
+			scope:pro_hegemon_movement = {
+				custom_tooltip = choose_pro_hegemon_movement_tt
+				situation:dynastic_cycle ?= {
+					situation_participant_group:pro_hegemon_movement = {
+						save_scope_as = situation_participant_group
+					}
+				}
+				if = {
+					limit = {
+						scope:recipient.var:movement_power >= high_movement_power_value
+					}
+					tgp_activate_catalyst_against_hegemon_effect = {
+						HEGEMON = scope:recipient.top_liege
+						CATALYST = catalyst_movement_gained_power_pro_hegemon
+					}
+				}
+				set_variable = {
+					name = movement_member
+					value = flag:pro_hegemon
+				}
+			}
+			scope:expansion_movement = {
+				custom_tooltip = choose_expansion_movement_tt
+				situation:dynastic_cycle ?= {
+					situation_participant_group:expansion_movement = {
+						save_scope_as = situation_participant_group
+					}
+				}
+				if = {
+					limit = {
+						scope:recipient.var:movement_power >= high_movement_power_value
+					}
+					tgp_activate_catalyst_against_hegemon_effect = {
+						HEGEMON = scope:recipient.top_liege
+						CATALYST = catalyst_movement_gained_power_expansion
+					}
+				}
+				set_variable = {
+					name = movement_member
+					value = flag:expansion
+				}
+			}
+			scope:advancement_movement = {
+				custom_tooltip = choose_advancement_movement_tt
+				situation:dynastic_cycle ?= {
+					situation_participant_group:advancement_movement = {
+						save_scope_as = situation_participant_group
+					}
+				}
+				if = {
+					limit = {
+						scope:recipient.var:movement_power >= high_movement_power_value
+					}
+					tgp_activate_catalyst_against_hegemon_effect = {
+						HEGEMON = scope:recipient.top_liege
+						CATALYST = catalyst_movement_gained_power_advancement
+					}
+				}
+				set_variable = {
+					name = movement_member
+					value = flag:advancement
+				}
+			}
+			scope:conservative_movement = {
+				custom_tooltip = choose_conservative_movement_tt
+				situation:dynastic_cycle ?= {
+					situation_participant_group:conservative_movement = {
+						save_scope_as = situation_participant_group
+					}
+				}
+				if = {
+					limit = {
+						scope:recipient.var:movement_power >= high_movement_power_value
+					}
+					tgp_activate_catalyst_against_hegemon_effect = {
+						HEGEMON = scope:recipient.top_liege
+						CATALYST = catalyst_movement_gained_power_conservative
+					}
+				}
+				set_variable = {
+					name = movement_member
+					value = flag:conservative
+				}
+			}
+		}
+		custom_tooltip = adds_movement_power_tt
+		if = {
+			limit = {
+				any_relation = {
+					type = disciple
+				}
+			}
+			custom_tooltip = {
+				text = every_disciple_adds_movement_power_tt
+				every_relation = {
+					type = disciple
+					recalculate_participant_group = situation:dynastic_cycle
+				}
+			}
+		}
+		if = { # break up with the elder if the movement is not the same after applying previous effects and changing your own
+			limit = {
+				any_relation = {
+					type = elder
+					save_temporary_scope_as = elder
+				}
+				scope:elder = {
+					top_participant_group:dynastic_cycle = root.top_participant_group:dynastic_cycle
+				}
+			}
+			custom_tooltip = {
+				text = situation_dynastic_cycle_choose_movement_decision_elder_tt
+				run_interaction = {
+					interaction = break_with_elder
+					actor = root
+					recipient = scope:elder
+					execute_threshold = accept
+				}
+			}
+		}
+		hidden_effect = { recalculate_participant_group = situation:dynastic_cycle }
+	}
+
+	#AI is slotted into the groups automatically by the situation participant groups script in the tgp_dynastic_cycle file
+	ai_check_interval = 0
+}
+# a petition in the name of your movement to be delivered to hegemon/relevant minister
+### Make Movement Petition ###
+movement_petition_decision = {
+	decision_group_type = dynastic_cycle
+	title = movement_petition_decision
+	desc = movement_petition_decision_desc
+	selection_tooltip = movement_petition_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_stability.dds"
+	}
+	sort_order = 80
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		top_participant_group:dynastic_cycle ?= {
+			NOR = {
+				participant_group_type = other_rulers
+				participant_group_type = hegemon_ruler
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		is_any_movement_leader = yes
+		influence >= major_influence_value
+		trigger_if = {
+			limit = {
+				situation:dynastic_cycle ?= {
+					any_participant_group = {
+						var:recent_movement_petition ?= {
+							is_ai = no
+						}
+						save_temporary_scope_as = petitioning_movement_recent
+					}
+				}
+			}
+			custom_tooltip = {
+				text = movement_petition_decision.recent_movement_petition_reason
+				always = no
+			}
+		}
+		trigger_if = {
+			limit = {
+				situation:dynastic_cycle ?= {
+					any_participant_group = {
+						var:movement_petition_in_progress ?= {
+							is_ai = no
+						}
+						save_temporary_scope_as = petitioning_movement_progress
+					}
+				}
+			}
+			custom_tooltip = {
+				text = movement_petition_decision.movement_petition_in_progress_reason
+				always = no
+			}
+		}
+	}
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "movement_petition_decision_select_petition"
+		show_from_start = yes
+
+		item = {
+			value = change_celestial_bureaucracy
+			is_valid = {
+				title:h_china.holder ?= {
+					government_has_flag = government_is_celestial
+				}
+			}
+			current_description = change_celestial_bureaucracy_desc
+			localization = change_celestial_bureaucracy_name
+			icon = "gfx/interface/icons/message_feed/law.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = change_celestial_army_liege_law
+			is_valid = {
+				title:h_china.holder ?= {
+					government_has_flag = government_is_celestial
+				}
+			}
+			current_description = change_celestial_army_liege_law_desc
+			localization = change_celestial_army_liege_law_name
+			icon = "gfx/interface/icons/message_feed/soldier.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = change_province_type
+			is_valid = {
+				title:h_china.holder ?= {
+					government_has_flag = government_is_celestial
+				}
+				custom_tooltip = {
+					text = change_province_type_vassal_contract_blocked_reason
+					top_participant_group:dynastic_cycle ?= {
+						any_situation_group_participant = {
+							vassal_contract_has_modifiable_obligations = yes
+						}
+					}
+				}
+			}
+			current_description = change_province_type_desc
+			localization = change_province_type_name
+			icon = "gfx/interface/icons/celestial_administration_types/icon_standard_administration.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = change_retirement_law
+			is_valid = {
+				title:h_china.holder ?= {
+					government_has_flag = government_is_celestial
+				}
+			}
+			current_description = change_retirement_law_desc
+			localization = change_retirement_law_name
+			icon = "gfx/interface/icons/message_feed/icon_scheme_promote.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = increase_budget
+			is_valid = {
+				title:h_china.holder ?= {
+					government_has_flag = government_is_celestial
+				}
+			}
+			current_description = increase_budget_desc
+			localization = increase_budget_name
+			icon = "gfx/interface/icons/icon_imperial_treasury.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = hold_examinations
+			is_valid = {
+				top_participant_group:dynastic_cycle ?= {
+					participant_group_type = advancement_movement
+				}
+			}
+			current_description = hold_examinations_desc
+			localization = hold_examinations_name
+			icon = "gfx/interface/icons/activities/activity_imperial_examination.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = change_candidate_score_law
+			is_valid = {
+				trigger_if = {
+					limit = {
+						top_liege = {
+							has_realm_law = candidate_score_merit_law
+						}
+					}
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = conservative_movement
+					}
+					top_liege = {
+						can_pass_candidate_score_prestige_law_trigger = yes
+					}
+				}
+				trigger_else = {
+					top_participant_group:dynastic_cycle ?= {
+						NOT = { participant_group_type = conservative_movement }
+					}
+					top_liege = {
+						can_pass_candidate_score_merit_law_trigger = yes
+					}
+				}
+			}
+			current_description = change_candidate_score_law_desc
+			localization = change_candidate_score_law_name
+			icon = "gfx/interface/icons/appointment_score.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+	}
+
+	effect = {
+		situation:dynastic_cycle ?= {
+			random_participant_group = {
+				limit = {
+					var:movement_leader ?= root
+				}
+				save_scope_as = actors_movement
+			}
+		}
+		save_scope_as = petitioner
+		title:h_china.holder ?= {
+            save_scope_as = hegemon
+			save_scope_as = petition_recipient
+		}
+		display_movement_petition_recipient_acceptance_chance_effect = yes
+		switch = {
+			trigger = yes
+			scope:change_celestial_bureaucracy = {
+				custom_tooltip = celestial_movement_demands_interaction.tt.change_celestial_bureaucracy
+				set_variable = {
+					name = movement_petition
+					value = flag:change_bureaucracy_laws
+				}
+				open_view_data = {
+					view = decision_detail
+					data = decision:movement_petition_change_laws_decision
+					player = root
+				}
+			}
+			scope:change_celestial_army_liege_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_army_laws
+				}
+				custom_tooltip = celestial_movement_demands_interaction.tt.change_celestial_army_law
+				open_view_data = {
+					view = decision_detail
+					data = decision:movement_petition_change_laws_decision
+					player = root
+				}
+			}
+			scope:change_province_type = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_province
+				}
+				custom_tooltip = celestial_movement_demands_interaction.tt.change_province_type
+				open_view_data = {
+					view = decision_detail
+					data = decision:movement_petition_change_laws_decision
+					player = root
+				}
+			}
+			scope:change_retirement_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_retirement_law
+				}
+				custom_tooltip = celestial_movement_demands_interaction.tt.change_retirement_law
+				open_view_data = {
+					view = decision_detail
+					data = decision:movement_petition_change_laws_decision
+					player = root
+				}
+			}
+			scope:change_candidate_score_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_candidate_score_law
+				}
+				custom_tooltip = celestial_movement_demands_interaction.tt.change_candidate_score_law
+				if = {
+					limit = {
+						scope:petitioner.location != scope:petition_recipient.capital_province
+					}
+					start_travel_plan = {
+						destination = scope:petition_recipient.capital_province
+						on_arrival_event = tgp_decision_events.0100
+						on_travel_planner_cancel_event = tgp_decision_events.0199
+					}
+				}
+				else = {
+					trigger_event = tgp_decision_events.0100
+				}
+			}
+			scope:increase_budget = {
+				set_variable = {
+					name = movement_petition
+					value = flag:increase_budget
+				}
+				custom_tooltip = celestial_movement_demands_interaction.tt.increase_budget
+				open_view_data = {
+					view = decision_detail
+					data = decision:movement_petition_change_laws_decision
+					player = root
+				}
+			}
+			scope:hold_examinations = {
+				set_variable = {
+					name = movement_petition
+					value = flag:hold_examinations
+				}
+				scope:hegemon = {
+					save_scope_as = recipient #for loc to work
+				}
+				custom_tooltip = celestial_movement_demands_interaction.tt.hold_examinations_effect
+				if = {
+					limit = {
+						scope:petitioner.location != scope:petition_recipient.capital_province
+					}
+					start_travel_plan = {
+						destination = scope:petition_recipient.capital_province
+						on_arrival_event = tgp_decision_events.0100
+						on_travel_planner_cancel_event = tgp_decision_events.0199
+					}
+				}
+				else = {
+					trigger_event = tgp_decision_events.0100
+				}
+			}
+		}
+		show_as_tooltip = {
+			change_influence = major_influence_loss
+			if = {
+				limit = {
+					scope:petitioner.location != scope:petition_recipient.capital_province
+				}
+				custom_tooltip = movement_petition_decision.travel
+			}
+		}
+	}
+
+	ai_potential = { 
+		always = no
+	}
+	ai_check_interval = 0
+}
+# a second step of the decision above to select the details of the petition
+### Movement Petition Change Laws Decision ###
+movement_petition_change_laws_decision = {
+	decision_group_type = dynastic_cycle
+	title = movement_petition_decision
+	desc = movement_petition_decision_desc
+	selection_tooltip = movement_petition_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_stability.dds"
+	}
+	is_invisible = yes
+	
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		is_any_movement_leader = yes
+		influence >= major_influence_value
+		trigger_if = {
+			limit = {
+				situation:dynastic_cycle ?= {
+					any_participant_group = {
+						var:recent_movement_petition ?= {
+							is_ai = no
+						}
+						save_temporary_scope_as = petitioning_movement_recent
+					}
+				}
+			}
+			custom_tooltip = {
+				text = movement_petition_decision.recent_movement_petition_reason
+				always = no
+			}
+		}
+		trigger_if = {
+			limit = {
+				situation:dynastic_cycle ?= {
+					any_participant_group = {
+						var:movement_petition_in_progress ?= {
+							is_ai = no
+						}
+						save_temporary_scope_as = petitioning_movement_progress
+					}
+				}
+			}
+			custom_tooltip = {
+				text = movement_petition_decision.movement_petition_in_progress_reason
+				always = no
+			}
+		}
+	}
+
+	widget = {
+		gui = "decision_view_widget_option_list_generic"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "movement_petition_decision_select_petition"
+		show_from_start = yes
+
+		item = {
+			value = increase_law
+			is_shown = {
+				var:movement_petition ?= flag:change_bureaucracy_laws
+			}
+			is_valid = {
+				title:h_china.holder = {
+					NOT = {
+						realm_law_group_at_maximum_level = celestial_bureaucracy
+					}
+					trigger_if = {
+						limit = {
+							has_realm_law = celestial_bureaucracy_2
+						}
+						situation:dynastic_cycle ?= {
+							NOR = {
+								situation_current_phase = situation_dynastic_cycle_phase_instability
+								situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+							}
+						}
+					}
+					culture = { has_innovation = innovation_all_things }
+				}
+			}
+			current_description = change_celestial_bureaucracy_increase_desc
+			localization = change_celestial_bureaucracy_increase_name
+			icon = "gfx/interface/icons/symbols/icon_arrow_up.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = decrease_law
+			is_shown = {
+				var:movement_petition ?= flag:change_bureaucracy_laws
+			}
+			is_valid = {
+				title:h_china.holder = {
+					NOT = {
+						realm_law_group_at_minimum_level = celestial_bureaucracy
+					}
+				}
+			}
+			current_description = change_celestial_bureaucracy_decrease_desc
+			localization = change_celestial_bureaucracy_decrease_name
+			icon = "gfx/interface/icons/symbols/icon_arrow_green_down.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = increase_army_law
+			is_shown = {
+				var:movement_petition ?= flag:change_army_laws
+			}
+			is_valid = {
+				title:h_china.holder = {
+					NOT = {
+						has_realm_law = celestial_army_liege_law_3
+					}
+					trigger_if = {
+						limit = {
+							has_realm_law = celestial_army_liege_law_2
+						}
+						has_realm_law = celestial_bureaucracy_3
+						situation:dynastic_cycle ?= {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+						}
+					}
+					trigger_if = {
+						limit = {
+							OR = {
+								has_realm_law = celestial_army_liege_law_0
+								has_realm_law = celestial_army_liege_law_1
+							}
+						}
+						custom_tooltip = {
+							text = have_bureaucracy_2_or_higher
+							OR = {
+								has_realm_law = celestial_bureaucracy_2
+								has_realm_law = celestial_bureaucracy_3
+							}
+						}
+					}
+				}
+			}
+			current_description = change_army_laws_increase_desc
+			localization = change_army_laws_increase_name
+			icon = "gfx/interface/icons/symbols/icon_arrow_up.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = decrease_army_law
+			is_shown = {
+				var:movement_petition ?= flag:change_army_laws
+			}
+			is_valid = {
+				title:h_china.holder = {
+					NOT = {
+						has_realm_law = celestial_army_liege_law_0
+					}
+				}
+			}
+			current_description = change_army_laws_decrease_desc
+			localization = change_army_laws_decrease_name
+			icon = "gfx/interface/icons/symbols/icon_arrow_green_down.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = increase_budget_salary
+			is_shown = {
+				var:movement_petition ?= flag:increase_budget
+			}
+			is_valid = {
+				top_liege = {
+					NOT = { realm_law_group_at_maximum_level = budget_allocation_salary_law }
+				}
+			}
+			current_description = increase_budget_salary_desc
+			localization = increase_budget_salary_name
+			icon = "gfx/interface/icons/icon_imperial_treasury.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = increase_budget_ministry
+			is_shown = {
+				var:movement_petition ?= flag:increase_budget
+			}
+			is_valid = {
+				top_liege = {
+					NOT = { realm_law_group_at_maximum_level = budget_allocation_ministry_law }
+				}
+			}
+			current_description = increase_budget_ministry_desc
+			localization = increase_budget_ministry_name
+			icon = "gfx/interface/icons/court_position_types/favored_minister_court_position.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = increase_budget_military
+			is_shown = {
+				var:movement_petition ?= flag:increase_budget
+			}
+			is_valid = {
+				top_liege = {
+					NOT = { realm_law_group_at_maximum_level = budget_allocation_military_law }
+				}
+			}
+			current_description = increase_budget_military_desc
+			localization = increase_budget_military_name
+			icon = "gfx/interface/icons/message_feed/soldier.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = province_metropolitan
+			is_shown = {
+				var:movement_petition ?= flag:change_province
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_participant_group:expansion_movement = {
+						any_situation_group_participant = {
+							vassal_contract_obligation_level:celestial_provinces != 2
+						}
+					}
+				}
+			}
+			current_description = change_province_metropolitan_desc
+			localization = change_province_metropolitan_name
+			icon = "gfx/interface/icons/celestial_administration_types/icon_game_concept_celestial_metropolitan_administration.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = province_industrial
+			is_shown = {
+				var:movement_petition ?= flag:change_province
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_participant_group:expansion_movement = {
+						any_situation_group_participant = {
+							vassal_contract_obligation_level:celestial_provinces != 1
+						}
+					}
+				}
+			}
+			current_description = change_province_industrial_desc
+			localization = change_province_industrial_name
+			icon = "gfx/interface/icons/celestial_administration_types/icon_game_concept_celestial_industrial_administration.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = province_military
+			is_shown = {
+				var:movement_petition ?= flag:change_province
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_participant_group:expansion_movement = {
+						any_situation_group_participant = {
+							vassal_contract_obligation_level:celestial_provinces != 3
+						}
+					}
+				}
+			}
+			current_description = change_province_military_desc
+			localization = change_province_military_name
+			icon = "gfx/interface/icons/celestial_administration_types/icon_game_concept_celestial_military_administration.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = province_protectorate
+			is_shown = {
+				var:movement_petition ?= flag:change_province
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_participant_group:expansion_movement = {
+						any_situation_group_participant = {
+							vassal_contract_obligation_level:celestial_provinces != 4
+						}
+					}
+				}
+			}
+			current_description = change_province_protectorate_desc
+			localization = change_province_protectorate_name
+			icon = "gfx/interface/icons/celestial_administration_types/icon_game_concept_celestial_protectorate_administration.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = increase_retirement_law
+			is_shown = {
+				var:movement_petition ?= flag:change_retirement_law
+			}
+			is_valid = {
+				title:h_china.holder = {
+					NOT = {
+						has_realm_law = celestial_retirement_law_5
+					}
+					custom_tooltip = {
+						text = have_celestial_bureaucracy_1_or_higher
+						NOT = { realm_law_group_at_minimum_level = celestial_bureaucracy }
+					}
+				}
+			}
+			current_description = change_retirement_law_increase_desc
+			localization = change_retirement_law_increase_name
+			icon = "gfx/interface/icons/symbols/icon_arrow_up.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = decrease_retirement_law
+			is_shown = {
+				var:movement_petition ?= flag:change_retirement_law
+			}
+			is_valid = {
+				title:h_china.holder = {
+					NOT = {
+						has_realm_law = celestial_retirement_law_0
+					}
+					custom_tooltip = {
+						text = have_celestial_bureaucracy_1_or_higher
+						NOT = { realm_law_group_at_minimum_level = celestial_bureaucracy }
+					}
+				}
+			}
+			current_description = change_retirement_law_decrease_desc
+			localization = change_retirement_law_decrease_name
+			icon = "gfx/interface/icons/symbols/icon_arrow_green_down.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+	}
+	effect = {
+		save_scope_as = petitioner
+		situation:dynastic_cycle ?= {
+			random_participant_group = {
+				limit = {
+					var:movement_leader ?= root
+				}
+				save_scope_as = actors_movement
+			}
+		}
+		title:h_china.holder ?= {
+            save_scope_as = hegemon
+			save_scope_as = petition_recipient
+		}
+		switch = {
+			trigger = yes
+			scope:increase_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_bureaucracy_laws_increase
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_bureaucracy_laws_increase
+				}
+			}
+			scope:decrease_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_bureaucracy_laws_decrease
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_bureaucracy_laws_decrease
+				}
+			}
+			scope:increase_army_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_army_laws_increase
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_army_laws_increase
+				}
+			}
+			scope:decrease_army_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_army_laws_decrease
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_army_laws_decrease
+				}
+			}
+			scope:province_metropolitan = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_province_metropolitan
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_province_metropolitan
+				}
+			}
+			scope:province_industrial = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_province_industrial
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_province_industrial
+				}
+			}
+			scope:province_military = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_province_military
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_province_military
+				}
+			}
+			scope:province_protectorate = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_province_protectorate
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_province_protectorate
+				}
+			}
+			scope:increase_retirement_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_retirement_law_increase
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_retirement_law_increase
+				}
+			}
+			scope:decrease_retirement_law = {
+				set_variable = {
+					name = movement_petition
+					value = flag:change_retirement_law_decrease
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:change_retirement_law_decrease
+				}
+			}
+			scope:increase_budget_salary = {
+				set_variable = {
+					name = movement_petition
+					value = flag:increase_budget_salary
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:increase_budget_salary
+				}
+			}
+			scope:increase_budget_ministry = {
+				set_variable = {
+					name = movement_petition
+					value = flag:increase_budget_ministry
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:increase_budget_ministry
+				}
+			}
+			scope:increase_budget_military = {
+				set_variable = {
+					name = movement_petition
+					value = flag:increase_budget_military
+				}
+				save_scope_value_as = {
+					name = movement_petition_effect
+					value = flag:increase_budget_military
+				}
+			}
+		}
+		display_movement_petition_recipient_acceptance_effect = yes
+		if = {
+			limit = {
+				scope:petitioner.location != scope:petition_recipient.capital_province
+			}
+			start_travel_plan = {
+				destination = scope:petition_recipient.capital_province
+				on_arrival_event = tgp_decision_events.0100
+				on_travel_planner_cancel_event = tgp_decision_events.0199
+			}
+		}
+		else = {
+			trigger_event = tgp_decision_events.0100
+		}
+		show_as_tooltip = {
+			change_influence = major_influence_loss
+			custom_tooltip = movement_petition_decision.travel
+		}
+		scope:actors_movement = {
+			set_variable = {
+				name = movement_petition_in_progress
+				value = scope:petitioner
+				years = 3
+			}
+		}
+	}
+	ai_potential = {
+		always = no
+	}
+	ai_check_interval = 0
+}
+# AI only - petition to change laws in China, replaces the 2 petitions above for the AI
+### Make Movement Petition ###
+ai_movement_petition_change_laws_decision = {
+	decision_group_type = dynastic_cycle
+	title = movement_petition_decision
+	desc = movement_petition_decision_desc
+	selection_tooltip = movement_petition_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_stability.dds"
+	}
+	is_invisible = yes
+	cooldown = { years = 10 }
+	
+	is_valid = {
+		is_available_ai_adult = yes
+		is_any_movement_leader = yes
+		influence >= major_influence_value
+		trigger_if = {
+			limit = {
+				situation:dynastic_cycle ?= {
+					any_participant_group = {
+						exists = var:recent_movement_petition
+						save_temporary_scope_as = petitioning_movement_recent
+					}
+				}
+			}
+			custom_tooltip = {
+				text = movement_petition_decision.recent_movement_petition_reason
+				always = no
+			}
+		}
+		trigger_if = {
+			limit = {
+				situation:dynastic_cycle ?= {
+					any_participant_group = {
+						exists = var:movement_petition_in_progress
+						save_temporary_scope_as = petitioning_movement_progress
+					}
+				}
+			}
+			custom_tooltip = {
+				text = movement_petition_decision.movement_petition_in_progress_reason
+				always = no
+			}
+		}
+	}
+	effect = {
+		save_scope_as = petitioner
+		situation:dynastic_cycle ?= {
+			random_participant_group = {
+				limit = {
+					var:movement_leader ?= root
+				}
+				save_scope_as = actors_movement
+			}
+		}
+		title:h_china.holder ?= {
+            save_scope_as = hegemon
+			save_scope_as = petition_recipient
+		}
+		# Decide for the AI which petition they should go for
+		random_list = {
+			0 = { # Increase Bureaucracy
+				trigger = {
+					NOT = { # Bureaucracy not at max
+						top_liege = { realm_law_group_at_maximum_level = celestial_bureaucracy }
+					}
+					trigger_if = {
+						limit = {
+							has_realm_law = celestial_bureaucracy_2
+						}
+						situation:dynastic_cycle ?= {
+							NOR = {
+								situation_current_phase = situation_dynastic_cycle_phase_instability
+								situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+							}
+						}
+					}
+					top_liege.culture = { has_innovation = innovation_all_things }
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = advancement_movement
+					}
+					add = 50
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+					}
+					add = 10
+				}
+				save_scope_value_as = {
+					name = increase_law
+					value = yes
+				}
+			}
+			0 = { # Decrease Bureaucracy
+				trigger = {
+					NOT = { # Bureaucracy not a min
+						top_liege = { realm_law_group_at_minimum_level = celestial_bureaucracy }
+					}
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = expansion_movement
+					}
+					add = 50	
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+							situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+						}
+					}
+					add = 10
+				}
+				save_scope_value_as = {
+					name = decrease_law
+					value = yes
+				}
+			}
+			0 = { # Increase Army
+				trigger = {
+					top_liege = {
+						trigger_if = { # Higher levels require high bureaucracy
+							limit = { has_realm_law = celestial_army_liege_law_0 }
+							NOT = { has_realm_law = celestial_bureaucracy_0 }
+						}
+						trigger_else_if = { # Higher levels require high bureaucracy
+							limit = { has_realm_law = celestial_army_liege_law_1 }
+							OR = {
+								has_realm_law = celestial_bureaucracy_2
+								has_realm_law = celestial_bureaucracy_3
+							}
+						}
+						trigger_else_if = { # Higher levels require high bureaucracy
+							limit = { has_realm_law = celestial_army_liege_law_2 }
+							has_realm_law = celestial_bureaucracy_3
+							# Highest only in Expansion Phase
+							situation:dynastic_cycle ?= { situation_current_phase = situation_dynastic_cycle_phase_stability_expansion }
+						}
+						trigger_else = { always = no }
+					}
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = expansion_movement
+					}
+					add = 50
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+							situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+						}
+					}
+					add = 10
+				}
+				save_scope_value_as = {
+					name = increase_army_law
+					value = yes
+				}
+			}
+			0 = { # Decrease Army
+				trigger = {
+					NOT = { # Army not a min
+						top_liege = { realm_law_group_at_minimum_level = celestial_army_liege_law }
+					}
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = advancement_movement
+					}
+					add = 50
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+							situation_current_phase = situation_dynastic_cycle_phase_instability
+						}
+					}
+					add = 10
+				}
+				save_scope_value_as = {
+					name = decrease_army_law
+					value = yes
+				}
+			}
+			0 = { # Metropolitan Province
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = advancement_movement
+					}
+					add = 20
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+							situation_current_phase = situation_dynastic_cycle_phase_instability
+						}
+					}
+					add = 20
+				}
+				save_scope_value_as = {
+					name = province_metropolitan
+					value = yes
+				}
+			}
+			0 = { # Industrial Province
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = advancement_movement
+					}
+					add = 10
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+							situation_current_phase = situation_dynastic_cycle_phase_instability
+						}
+					}
+					add = 10
+				}
+				save_scope_value_as = {
+					name = province_industrial
+					value = yes
+				}
+			}
+			0 = { # Military Province
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = expansion_movement
+					}
+					add = 10
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+							situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+						}
+					}
+					add = 10
+				}
+				save_scope_value_as = {
+					name = province_military
+					value = yes
+				}
+			}
+			0 = { # Protectorate Province
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = expansion_movement
+					}
+					add = 20
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+							situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+						}
+					}
+					add = 20
+				}
+				save_scope_value_as = {
+					name = province_protectorate
+					value = yes
+				}
+			}
+			0 = { # Hold Exams
+				trigger = {
+					NOT = { # Conservatives don't like exams
+						top_participant_group:dynastic_cycle ?= { participant_group_type = conservative_movement }
+					}
+				}
+				modifier = {
+					title:h_china ?= {
+						exists = var:years_since_imperial_examination
+						var:years_since_imperial_examination >= catalyst_imperial_examinations_gap_short_yearly_value
+					}
+					add = 10
+				}
+				save_scope_value_as = {
+					name = hold_examinations
+					value = yes
+				}
+			}
+			0 = { # Increase Retirement
+				trigger = {
+					top_liege = {
+						NOR = {
+							# Some bureaucracy needed for retirement
+							realm_law_group_at_minimum_level = celestial_bureaucracy
+							# Retirement not at max
+							realm_law_group_at_maximum_level = celestial_retirement_law
+						}
+					}
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+							situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+						}
+					}
+					add = 10
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = conservative_movement
+					}
+					add = 50
+				}
+				save_scope_value_as = {
+					name = increase_retirement_law
+					value = yes
+				}
+			}
+			0 = { # Decrease Retirement
+				trigger = {
+					top_liege = {
+						NOR = {
+							# Some bureaucracy needed for retirement
+							realm_law_group_at_minimum_level = celestial_bureaucracy
+							# Retirement not at max
+							realm_law_group_at_maximum_level = celestial_retirement_law
+						}
+					}
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+							situation_current_phase = situation_dynastic_cycle_phase_instability
+						}
+					}
+					add = 10
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = conservative_movement
+					}
+					factor = 0
+				}
+				save_scope_value_as = {
+					name = decrease_retirement_law
+					value = yes
+				}
+			}
+			0 = { # Increase Salary Budget
+				trigger = {
+					NOR = {
+						# Treasury not empty
+						top_liege = { monthly_character_treasury_balance <= 0 }
+						# Salaries don't go up in Conservative/Expansion
+						top_participant_group:dynastic_cycle ?= {
+							OR = {
+								participant_group_type = conservative_movement
+								participant_group_type = expansion_movement
+							}
+						}
+					}
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+							situation_current_phase = situation_dynastic_cycle_phase_instability
+						}
+					}
+					add = 1
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = advancement_movement
+					}
+					add = 1
+				}
+				save_scope_value_as = {
+					name = increase_budget_salary
+					value = yes
+				}
+			}
+			0 = { # Increase Ministry Budget
+				trigger = {
+					NOR = {
+						# Treasury not empty
+						top_liege = { monthly_character_treasury_balance <= 0 }
+						# Salaries don't go down in Advancement/Expansion
+						top_participant_group:dynastic_cycle ?= {
+							OR = {
+								participant_group_type = advancement_movement
+								participant_group_type = expansion_movement
+							}
+						}
+					}
+				}
+				modifier = {
+					situation:dynastic_cycle ?= {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+							situation_current_phase = situation_dynastic_cycle_phase_instability
+						}
+					}
+					add = 1
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = conservative_movement
+					}
+					add = 1
+				}
+				save_scope_value_as = {
+					name = increase_budget_ministry
+					value = yes
+				}
+			}
+			0 = { # Candidate Score
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						participant_group_type = conservative_movement
+					}
+					top_liege = {
+						has_realm_law = candidate_score_merit_law
+						any_councillor = {
+							count = all
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = conservative_movement
+							}
+						}
+						any_powerful_vassal = {
+							count = all
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = conservative_movement
+							}
+						}
+					}
+					add = 1
+				}
+				modifier = {
+					top_participant_group:dynastic_cycle ?= {
+						NOT = { participant_group_type = conservative_movement }
+					}
+					top_liege = {
+						has_realm_law = candidate_score_prestige_law
+						any_councillor = {
+							count = all
+							top_participant_group:dynastic_cycle ?= {
+								NOT = { participant_group_type = conservative_movement }
+							}
+						}
+						any_powerful_vassal = {
+							count = all
+							top_participant_group:dynastic_cycle ?= {
+								NOT = { participant_group_type = conservative_movement }
+							}
+						}
+					}
+					add = 1
+				}
+				save_scope_value_as = {
+					name = change_candidate_score_law
+					value = yes
+				}
+			}
+		}
+		# Set the variable to reference the chosen petition in the follow up events
+		if = {
+            limit = {
+                exists = scope:increase_law
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_bureaucracy_laws_increase
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:decrease_law
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_bureaucracy_laws_decrease
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:increase_army_law
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_army_laws_increase
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:decrease_army_law
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_army_laws_decrease
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:province_metropolitan
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_province_metropolitan
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:province_industrial
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_province_industrial
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:province_military
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_province_military
+       		}
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:province_protectorate
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_province_protectorate
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:hold_examinations
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:hold_examinations
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:increase_retirement_law
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_retirement_law_increase
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:decrease_retirement_law
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_retirement_law_decrease
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:increase_budget_salary
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:increase_budget_salary
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:increase_budget_ministry
+            }
+            set_variable = {
+                    name = movement_petition
+                    value = flag:increase_budget_ministry
+            }
+	    }
+	    else_if = {
+            limit = {
+                exists = scope:increase_budget_military
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:increase_budget_military
+            }
+	    }
+	    else_if = {
+            limit = {
+            	exists = scope:change_candidate_score_law
+            }
+            set_variable = {
+                name = movement_petition
+                value = flag:change_candidate_score_law
+            }
+	    }
+	    else = {
+	    	# Left for debugging in case something goes wrong with saving proper flag above
+            set_variable = {
+                name = movement_petition
+                value = flag:error
+            }	    	
+	    }
+		if = {
+			limit = {
+				has_variable = movement_petition
+				var:movement_petition != flag:error
+			}
+			if = {
+				limit = {
+					scope:petitioner.location != scope:petition_recipient.capital_province
+				}
+				start_travel_plan = {
+					destination = scope:petition_recipient.capital_province
+					on_arrival_event = tgp_decision_events.0100
+					on_travel_planner_cancel_event = tgp_decision_events.0199
+				}
+			}
+			else = {
+				trigger_event = tgp_decision_events.0100
+			}
+			scope:actors_movement = {
+				set_variable = {
+					name = movement_petition_in_progress
+					value = scope:petitioner
+					years = 3
+				}
+			}
+		}
+		else = {
+			debug_log = "AI tried to use Movement Petition, but failed to pick the topic"
+		}
+	}
+	ai_potential = {
+		is_any_movement_leader = yes
+	}
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 72
+		kingdom = 36
+		empire = 24
+		hegemony = 0
+	}
+	ai_will_do = {
+		base = 100
+	}
+}
+# Renounce Family Title
+### Retire from Heading the [ROOT.Char.GetHouse.GetNameNoTooltip] House ###
+renounce_noble_family_title_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_asia_estate.dds"
+	}
+	sort_order = 85
+
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					any_held_title = {
+						is_noble_family_title = yes
+						exists = current_heir
+					}
+				}
+				desc = renounce_noble_family_title_decision_desc
+			}
+			desc = renounce_noble_family_title_decision_no_heir_desc
+		}
+	}
+	selection_tooltip = renounce_noble_family_title_decision_tooltip
+	decision_group_type = admin
+
+	is_shown = {
+		NOT = { top_liege = root } #This is not a general abdication decision
+		has_tgp_dlc_trigger = yes
+		is_playable_character = yes
+		is_house_head = yes
+		any_held_title = { is_noble_family_title = yes }
+		NOT = { religion = religion:buddhism_religion } # Uses tgp_japan_become_a_monk_decision
+	}
+
+	is_valid = {
+		custom_tooltip = {
+			text = renounce_noble_family_title_decision_tt.title
+			any_held_title = { is_noble_family_title = yes }
+		}
+		custom_tooltip = {
+			text = renounce_noble_family_title_decision_tt.heir
+			any_held_title = {
+				is_noble_family_title = yes
+				current_heir ?= { is_available_ai_adult = yes }
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		is_at_war_with_liege = no
+		trigger_if = {
+			limit = {
+				has_realm_law_flag = celestial_retirement_law
+			}
+			tgp_is_above_retirement_age_trigger = { REALM_OWNER = root }
+		}
+	}
+
+	effect = {
+		if = {
+			limit = { is_ai = no }
+			random_held_title = {
+				limit = { is_noble_family_title = yes }
+				current_heir = {  save_scope_as = new_player }
+			}
+		}
+		show_as_tooltip = {
+			add_character_modifier = { modifier = ep3_renounced_estate }
+			custom_tooltip = renounce_noble_family_title_decision_tt
+			if = {
+				limit = { exists = scope:new_player }
+				house = { set_house_head = scope:new_player }
+				set_player_character = scope:new_player
+			}
+			tgp_step_down_title_recipient_tooltip_effect = yes
+		}
+		trigger_event = tgp_dynastic_cycle_decision_event.0101
+		close_view = {
+			view = decisions
+			player = root
+		}
+	}
+	
+	cost = {
+		influence = {
+			value = 0
+			if = {
+				limit = { government_has_flag = government_has_influence }
+				add = minor_influence_value
+			}
+		}
+		prestige = {
+			value = 0
+			if = {
+				limit = {
+					NOT = { government_has_flag = government_has_influence }
+				}
+				add = minor_prestige_value
+			}
+		}
+	}
+
+	ai_check_interval = 0
+
+	ai_potential = {
+		is_at_war = no
+		# Don't step down freely if you don't have any other house members holding a noble_family_title or inherit any held noble_family_title
+		OR = {
+			house ?= {
+				any_house_member = {
+					is_governor = yes
+					top_liege = root.top_liege
+				}
+			}
+			any_held_title = {
+				tier = root.highest_held_title_tier
+				is_noble_family_title = no
+				current_heir.house = root.house
+			}
+		}
+		tgp_is_above_retirement_age_trigger = { REALM_OWNER = root }
+	}
+
+	ai_will_do = {
+		base = -10
+		modifier = {
+			add = 10
+			has_trait = lazy
+		}
+		modifier = {
+			add = 10
+			has_trait = humble
+		}
+		modifier = {
+			add = 10
+			has_trait = content
+		}
+		modifier = {
+			add = -100
+			OR = {
+				has_trait = ambitious
+				has_trait = greedy
+				has_trait = arrogant
+			}
+		}
+	}
+}
+
+#only for Players - ability to choose a favored Stability Era in the Dynastic Cycle, the AI uses hegemon_favored_stability_phase_value instead
+### Favor Dynastic Cycle Era Decision ###
+favor_dynastic_cycle_era_decision = {
+	decision_group_type = dynastic_cycle
+	title = favor_dynastic_cycle_era
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_title = title:h_china
+				}
+				desc = favor_dynastic_cycle_era_hegemon_desc
+			}
+			desc = favor_dynastic_cycle_era_chaos_desc
+		}
+	}
+	selection_tooltip = {
+
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_title = title:h_china
+				}
+				desc = favor_dynastic_cycle_era_decision_hegemon_tooltip
+			}
+			desc = favor_dynastic_cycle_era_decision_chaos_tooltip
+		}
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_corruption.dds"
+	}
+	sort_order = 80
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		is_ai = no
+		OR = {
+			AND = {
+				situation:dynastic_cycle ?= {
+					NOT = { situation_current_phase = situation_dynastic_cycle_phase_chaos }
+				}
+				top_participant_group:dynastic_cycle ?= {
+					participant_group_type = hegemon_ruler
+				}
+			}
+			AND = {
+				situation:dynastic_cycle ?= {
+					situation_current_phase = situation_dynastic_cycle_phase_chaos
+				}
+				top_participant_group:dynastic_cycle ?= {
+					participant_group_type = other_rulers
+				}
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_adult = yes
+	}
+	cooldown = { years = 20 }
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_FAVOR_ERA"
+		show_from_start = no
+
+		item = {
+			value = favor_advancement
+			current_description = favor_advancement_desc
+			localization = favor_advancement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_advancement.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+		item = {
+			value = favor_expansion
+			current_description = favor_expansion_desc
+			localization = favor_expansion_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_expansion.dds"
+			ai_chance = {
+				value = 0
+			}
+		}
+	}
+
+	cost = {
+		influence = {
+			value = monumental_influence_value
+		}
+	}
+
+	effect = {
+		switch = {
+			trigger = yes
+			scope:favor_advancement = {
+				set_variable = {
+					name = favor_era
+					value = flag:advancement
+				}
+				custom_tooltip = favor_advancement_tt
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							situation_current_phase = situation_dynastic_cycle_phase_chaos
+						}
+					}
+					custom_tooltip = favor_advancement_movement_power_chaos_tt
+				}
+				else = {
+					custom_tooltip = favor_advancement_movement_power_tt
+				}
+			}
+			scope:favor_expansion = {
+				set_variable = {
+					name = favor_era
+					value = flag:expansion
+				}
+				custom_tooltip = favor_expansion_tt
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							situation_current_phase = situation_dynastic_cycle_phase_chaos
+						}
+					}
+					custom_tooltip = favor_expansion_movement_power_chaos_tt
+				}
+				else = {
+					custom_tooltip = favor_expansion_movement_power_tt
+				}
+			}
+		}
+	}
+
+	ai_check_interval = 0
+}
+
+#only for Players - ability to choose a favored Movement, the AI will always follow the Debates activity outcomes instead
+### Favor a Movement ###
+favor_movement_decision = {
+	decision_group_type = dynastic_cycle
+	title = favor_movement_decision
+	desc = favor_movement_decision_desc
+	selection_tooltip = favor_movement_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_corruption.dds"
+	}
+	sort_order = 80
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		is_ai = no
+		any_character_situation = {
+			situation_type = dynastic_cycle
+			NOT = { situation_current_phase = situation_dynastic_cycle_phase_chaos }
+		}
+		has_title = title:h_china
+	}
+
+	is_valid_showing_failures_only = {
+		is_adult = yes
+	}
+	cooldown = { years = 20 }
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_FAVOR_MOVEMENT"
+		show_from_start = no
+
+		item = {
+			value = advancement_movement
+			current_description = favor_advancement_movement_desc
+			localization = favor_advancement_movement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_advance.dds"
+			flat = yes
+			is_valid = {
+				NOT = {
+					is_movement_in_power = {
+						MOVEMENT = advancement_movement
+					}
+				}
+			}
+		}
+		item = {
+			value = expansion_movement
+			current_description = favor_expansion_movement_desc
+			localization = favor_expansion_movement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_expand.dds"
+			flat = yes
+			is_valid = {
+				NOT = {
+					is_movement_in_power = {
+						MOVEMENT = expansion_movement
+					}
+				}
+			}
+		}
+		item = {
+			value = conservative_movement
+			current_description = favor_conservative_movement_desc
+			localization = favor_conservative_movement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_anti.dds"
+			flat = yes
+			is_valid = {
+				NOT = {
+					is_movement_in_power = {
+						MOVEMENT = conservative_movement
+					}
+				}
+			}
+		}
+		item = {
+			value = pro_hegemon_movement
+			current_description = favor_pro_hegemon_movement_desc
+			localization = favor_pro_hegemon_movement_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_pro.dds"
+			flat = yes
+			is_valid = {
+				NOT = {
+					is_movement_in_power = {
+						MOVEMENT = pro_hegemon_movement
+					}
+				}
+			}
+		}
+	}
+
+	cost = {
+		influence = {
+			value = monumental_influence_value
+		}
+	}
+
+	effect = {
+		save_scope_as = hegemon
+		situation:dynastic_cycle ?= {
+			random_participant_group = {
+				limit = {
+					has_variable = movement_favored
+				}
+				save_scope_as = former_favored_movement
+			}
+			switch = {
+				trigger = yes
+				scope:advancement_movement = {
+					situation_participant_group:advancement_movement = {
+						make_movement_favored_effect = yes
+						save_scope_as = new_favored_movement
+					}
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_gained_power_advancement
+						}
+						trigger_situation_catalyst = catalyst_movement_gained_power_advancement
+					}
+				}
+				scope:expansion_movement = {
+					situation_participant_group:expansion_movement = {
+						make_movement_favored_effect = yes
+						save_scope_as = new_favored_movement
+					}
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_gained_power_expansion
+						}
+						trigger_situation_catalyst = catalyst_movement_gained_power_expansion
+					}
+				}
+				scope:conservative_movement = {
+					situation_participant_group:conservative_movement = {
+						make_movement_favored_effect = yes
+						save_scope_as = new_favored_movement
+					}
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_gained_power_conservative
+						}
+						trigger_situation_catalyst = catalyst_movement_gained_power_conservative
+					}
+				}
+				scope:pro_hegemon_movement = {
+					situation_participant_group:pro_hegemon_movement = {
+						make_movement_favored_effect = yes
+						save_scope_as = new_favored_movement
+					}
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_gained_power_pro_hegemon
+						}
+						trigger_situation_catalyst = catalyst_movement_gained_power_pro_hegemon
+					}
+				}
+			}
+			every_participant_group = {
+				var:movement_leader ?= {
+					trigger_event = tgp_dynastic_cycle_decision_event.0111
+				}
+			}
+		}
+		hidden_effect = {
+			every_player = {
+				limit = {
+					tgp_does_this_player_care_about_the_dynastic_cycle = yes
+					is_any_movement_leader = no
+				}
+				send_interface_message = {
+					type = event_struggle_neutral
+					title = favor_movement_decision.tt
+					left_icon = scope:hegemon
+					right_icon = scope:new_favored_movement.var:movement_leader
+					show_as_tooltip = {
+						scope:new_favored_movement = {
+							make_movement_favored_effect = yes
+						}
+					}
+				}
+			}
+		}
+	}
+
+	ai_check_interval = 0
+}
+
+#Ability to trigger a catalyst towards or away from chosen phase
+### Shape the Dynastic Cycle ###
+favored_movement_consults_heaven_decision = {
+	decision_group_type = dynastic_cycle
+	title = favored_movement_consults_heaven_decision
+	desc = favored_movement_consults_heaven_decision_desc
+	selection_tooltip = favored_movement_consults_heaven_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_asia_throne_room.dds"
+	}
+	sort_order = 80
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		any_character_situation = {
+			situation_type = dynastic_cycle
+			NOT = { situation_current_phase = situation_dynastic_cycle_phase_chaos }
+		}
+		top_participant_group:dynastic_cycle ?= {
+			NOT = { participant_group_type = other_rulers }
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_adult = yes
+		custom_tooltip = {
+			text = can_consult_heaven_tt
+			OR = {
+				AND = {
+					is_any_movement_leader = yes
+					top_participant_group:dynastic_cycle ?= {
+						exists = var:movement_favored
+						var:movement_leader ?= root
+					}
+				}
+				has_title = title:h_china
+				has_title = title:e_minister_chancellor
+			}
+		}
+	}
+	cooldown = { years = 10 }
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_CONSULT_HEAVEN"
+		show_from_start = yes
+
+		item = {
+			value = positive_advancement_catalyst
+			current_description = positive_advancement_catalyst_desc
+			localization = positive_advancement_catalyst_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_advancement.dds"
+			is_shown = {
+				situation:dynastic_cycle ?= {
+					NOT = { situation_current_phase = situation_dynastic_cycle_phase_stability_advancement }
+				}
+			}
+			is_valid = {
+				custom_tooltip = {
+					text = positive_advancement_catalyst_tt
+					root = {
+						top_participant_group:dynastic_cycle ?= {
+							OR = {
+								participant_group_type = advancement_movement
+								participant_group_type = hegemon_ruler
+							}
+						}
+					}
+				}
+			}
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							trigger_if = {
+								limit = {
+									OR = {
+										situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+										situation_current_phase = situation_dynastic_cycle_phase_instability
+									}
+								}
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_chaos >= 150
+								}
+							}
+							trigger_else = {
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_instability >= 150
+								}
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = {
+			value = negative_advancement_catalyst
+			current_description = negative_advancement_catalyst_desc
+			localization = negative_advancement_catalyst_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_advancement.dds"
+			is_shown = {
+				situation:dynastic_cycle ?= {
+					OR = {
+						situation_current_phase = situation_dynastic_cycle_phase_instability
+						situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+					}
+				}
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_top_has_catalyst = catalyst_movement_consulted_heaven_advancement_negative
+					trigger_if = {
+						limit = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+						}
+						custom_tooltip = {
+							text = negative_advancement_catalyst_tt
+							root = {
+								top_participant_group:dynastic_cycle ?= {
+									OR = {
+										participant_group_type = advancement_movement
+										participant_group_type = hegemon_ruler
+									}
+								}
+							}
+						}
+					}
+					trigger_else = {
+						root = {
+							top_participant_group:dynastic_cycle ?= {
+								NOT = { participant_group_type = advancement_movement }
+							}
+						}
+					}
+				}
+			}
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							NOR = {
+								situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+								situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+							}
+							situation_top_sub_region = {
+								phase_takeover_points:situation_dynastic_cycle_phase_stability_advancement >= 150
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = {
+			value = positive_expansion_catalyst
+			current_description = positive_expansion_catalyst_desc
+			localization = positive_expansion_catalyst_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_expansion.dds"
+			is_shown = {
+				situation:dynastic_cycle ?= {
+					NOT = { situation_current_phase = situation_dynastic_cycle_phase_stability_expansion }
+				}
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					trigger_if = {
+						limit = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+						}
+						root = {
+							top_participant_group:dynastic_cycle ?= {
+								NOT = {	participant_group_type = expansion_movement }
+							}
+						}
+					}
+					trigger_else = {
+						custom_tooltip = {
+							text = positive_expansion_catalyst_tt
+							root = {
+								top_participant_group:dynastic_cycle ?= {
+									OR = {
+										participant_group_type = expansion_movement
+										participant_group_type = hegemon_ruler
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							trigger_if = {
+								limit = {
+									OR = {
+										situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+										situation_current_phase = situation_dynastic_cycle_phase_instability
+									}
+								}
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_chaos >= 150
+								}
+							}
+							trigger_else = {
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_instability >= 150
+								}
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = {
+			value = negative_expansion_catalyst
+			current_description = negative_expansion_catalyst_desc
+			localization = negative_expansion_catalyst_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_expansion.dds"
+			is_shown = {
+				situation:dynastic_cycle ?= {
+					OR = {
+						situation_current_phase = situation_dynastic_cycle_phase_instability
+						situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+					}
+				}
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_top_has_catalyst = catalyst_movement_consulted_heaven_expansion_negative
+					trigger_if = {
+						limit = {
+							situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+						}
+						custom_tooltip = {
+							text = negative_expansion_catalyst_tt
+							root = {
+								top_participant_group:dynastic_cycle ?= {
+									OR = {
+										participant_group_type = expansion_movement
+										participant_group_type = hegemon_ruler
+									}
+								}
+							}
+						}
+					}
+					trigger_else = {
+						root = {
+							top_participant_group:dynastic_cycle ?= {
+								NOT = {	participant_group_type = expansion_movement }
+							}
+						}
+					}
+				}
+			}
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							NOR = {
+								situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+								situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+							}
+							situation_top_sub_region = {
+								phase_takeover_points:situation_dynastic_cycle_phase_stability_expansion >= 150
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = {
+			value = positive_chaos_catalyst
+			current_description = positive_chaos_catalyst_desc
+			localization = positive_chaos_catalyst_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_chaos.dds"
+			is_shown = {
+				situation:dynastic_cycle ?= {
+					NOR = {
+						situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+						situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+					}
+				}
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_top_has_catalyst = catalyst_movement_consulted_heaven_chaos_positive
+				}
+			}
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							trigger_if = {
+								limit = {
+									OR = {
+										situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+										situation_current_phase = situation_dynastic_cycle_phase_instability
+									}
+								}
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_chaos <= 250
+								}
+							}
+							trigger_else = {
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_instability <= 250
+								}
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = {
+			value = negative_chaos_catalyst
+			current_description = negative_chaos_catalyst_desc
+			localization = negative_chaos_catalyst_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_chaos.dds"
+			is_shown = {
+				situation:dynastic_cycle ?= {
+					NOR = {
+						situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+						situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+					}
+				}
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_top_has_catalyst = catalyst_movement_consulted_heaven_chaos_negative
+				}
+			}
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							trigger_if = {
+								limit = {
+									OR = {
+										situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+										situation_current_phase = situation_dynastic_cycle_phase_instability
+									}
+								}
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_chaos <= 250
+								}
+							}
+							trigger_else = {
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_instability <= 250
+								}
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = {
+			value = positive_instability_catalyst
+			current_description = positive_instability_catalyst_desc
+			localization = positive_instability_catalyst_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_instability.dds"
+			is_shown = {
+				situation:dynastic_cycle ?= {
+					OR = {
+						situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+						situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+					}
+				}
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_top_has_catalyst = catalyst_movement_consulted_heaven_instability_positive
+				}
+			}
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							trigger_if = {
+								limit = {
+									OR = {
+										situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+										situation_current_phase = situation_dynastic_cycle_phase_instability
+									}
+								}
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_chaos <= 250
+								}
+							}
+							trigger_else = {
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_instability <= 250
+								}
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = {
+			value = negative_instability_catalyst
+			current_description = negative_instability_catalyst_desc
+			localization = negative_instability_catalyst_name
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_instability.dds"
+			is_shown = {
+				situation:dynastic_cycle ?= {
+					OR = {
+						situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+						situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+					}
+				}
+			}
+			is_valid = {
+				situation:dynastic_cycle ?= {
+					situation_top_has_catalyst = catalyst_movement_consulted_heaven_instability_negative
+				}
+			}
+			ai_chance = {
+				value = 0
+				if = {
+					limit = {
+						situation:dynastic_cycle ?= {
+							trigger_if = {
+								limit = {
+									OR = {
+										situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+										situation_current_phase = situation_dynastic_cycle_phase_instability
+									}
+								}
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_chaos <= 250
+								}
+							}
+							trigger_else = {
+								situation_top_sub_region = {
+									phase_takeover_points:situation_dynastic_cycle_phase_instability <= 250
+								}
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+	}
+
+	cost = {
+		influence = {
+			value = monumental_influence_value
+		}
+	}
+
+	effect = {
+		top_participant_group:dynastic_cycle ?= {
+	        if = {
+	        	limit = {
+	        		participant_group_type = hegemon_ruler
+	        	}
+	        	situation:dynastic_cycle.situation_participant_group:pro_hegemon_movement = {
+					save_scope_as = actors_movement
+				}
+	        }
+	        else = {
+				save_scope_as = actors_movement
+		    }
+		}
+		scope:actors_movement = {
+			petition_change_movement_power_effect = {
+				VALUE = -200
+			}
+		}
+		situation:dynastic_cycle ?= {
+			switch = {
+				trigger = yes
+				scope:positive_advancement_catalyst = {
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_advancement_positive
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_advancement_positive
+					}
+					else_if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_instability_positive
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_instability_positive
+					}
+					else_if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_chaos_positive
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_chaos_positive
+					}
+				}
+				scope:negative_advancement_catalyst = {
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_advancement_negative
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_advancement_negative
+					}
+				}
+				scope:positive_expansion_catalyst = {
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_expansion_positive
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_expansion_positive
+					}
+					else_if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_instability_positive
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_instability_positive
+					}
+					else_if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_chaos_positive
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_chaos_positive
+					}
+				}
+				scope:negative_expansion_catalyst = {
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_expansion_negative
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_expansion_negative
+					}
+				}
+				scope:positive_chaos_catalyst = {
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_chaos_positive
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_chaos_positive
+					}
+				}
+				scope:negative_chaos_catalyst = {
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_chaos_negative
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_chaos_negative
+					}
+				}
+				scope:positive_instability_catalyst = {
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_instability_positive
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_instability_positive
+					}
+				}
+				scope:negative_instability_catalyst = {
+					if = {
+						limit = {
+							situation_top_has_catalyst = catalyst_movement_consulted_heaven_instability_negative
+						}
+						trigger_situation_catalyst = catalyst_movement_consulted_heaven_instability_negative
+					}
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+		is_any_movement_leader = yes
+	}
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 120
+		duchy = 120
+		kingdom = 36
+		empire = 12
+		hegemony = 12
+	}
+	ai_will_do = {
+		base = 100
+	}
+}
+
+#House Heads' ability to trigger a catalyst towards or away from a phase according to their movement
+### Consult Heaven ###
+house_head_consults_heaven_decision = {
+	decision_group_type = dynastic_cycle
+	title = house_head_consults_heaven_decision
+	desc = house_head_consults_heaven_decision_desc
+	selection_tooltip = house_head_consults_heaven_decision_tooltip
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_asia_estate.dds"
+	}
+	sort_order = 80
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		any_character_situation = {
+			situation_type = dynastic_cycle
+			NOT = { situation_current_phase = situation_dynastic_cycle_phase_chaos }
+		}
+		top_participant_group:dynastic_cycle ?= {
+			NOT = { participant_group_type = other_rulers }
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		custom_tooltip = {
+			text = is_in_a_movement_with_leader_tt
+			OR = {
+				is_house_head = yes
+				top_participant_group:dynastic_cycle ?= {
+					var:movement_leader ?= root
+				}
+				has_title = title:e_minister_chancellor
+			}
+		}
+	}
+	cooldown = { years = 10 }
+
+	cost = {
+		influence = {
+			value = 2000
+			add = {
+				value = 0
+				every_close_or_extended_family_member = {
+					limit = {
+						is_governor = yes
+					}
+					add = 10
+				}
+				multiply = -1
+			}
+			add = {
+				value = 0
+				every_close_or_extended_family_member = {
+					limit = {
+						merit_level >= 4
+					}
+					add = 10
+				}
+				multiply = -1
+			}
+			if = {
+				limit = {
+					scope:discount_none ?= yes
+				}
+				multiply = 0.5
+			}
+			min = 100
+		}
+		piety = {
+			value = 0
+			if = {
+				limit = {
+					scope:discount_none ?= yes
+				}
+				add = 1000
+			}
+		}
+	}
+	widget = {
+		gui = "decision_view_widget_generic_multichoice_with_effects"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "SELECT_CONSULT_HEAVEN"
+		show_from_start = yes
+
+		item = {
+			value = discount_none
+			current_description = positive_advancement_catalyst_desc
+			localization = discount_none_name
+			icon = "gfx/interface/icons/modifiers/icon_piety_confucianism_04.dds"
+			is_valid = {
+				piety_level >= 4
+			}
+			ai_chance = {
+				value = 10
+			}
+		}
+		item = {
+			value = discount_powerful_family
+			current_description = negative_advancement_catalyst_desc
+			localization = discount_powerful_family_name
+			icon = "gfx/interface/icons/icon_game_concept_powerful_house.dds"
+			is_valid = {
+				custom_tooltip = {
+					text = HOUSE_VIEW_POWERLESS_FAMILY
+					house = {
+						OR = {
+							is_powerful_family = yes
+							title:h_china.holder.house ?= this
+						}
+					}
+				}
+			}
+			ai_chance = {
+				value = 50
+			}
+		}
+		item = {
+			value = discount_family_governors
+			current_description = positive_expansion_catalyst_desc
+			localization = discount_family_governors_name
+			icon = "gfx/interface/icons/message_feed/governor.dds"
+			is_valid = {
+				custom_tooltip = {
+					text = discount_family_governors_tt
+					any_close_or_extended_family_member = {
+						is_governor = yes
+						count >= 20
+					}
+				}
+			}
+			ai_chance = {
+				value = 200
+			}
+		}
+		item = {
+			value = discount_family_merit
+			current_description = negative_expansion_catalyst_desc
+			localization = discount_family_merit_name
+			icon = "gfx/interface/icons/icon_merit.dds"
+			is_valid = {
+				custom_tooltip = {
+					text = discount_family_merit_tt
+					any_close_or_extended_family_member = {
+						merit_level >= 6
+						count >= 10
+					}
+				}
+			}
+			ai_chance = {
+				value = 500
+			}
+		}
+	}
+
+	effect = {
+		top_participant_group:dynastic_cycle ?= {
+	        if = {
+	        	limit = {
+	        		participant_group_type = hegemon_ruler
+	        	}
+	        	situation:dynastic_cycle.situation_participant_group:pro_hegemon_movement = {
+					save_scope_as = actors_movement
+				}
+	        }
+	        else = {
+				save_scope_as = actors_movement
+		    }
+		}
+		show_as_tooltip = {
+			if = {
+				limit = {
+					NOR = {
+						scope:discount_none = yes
+						scope:discount_powerful_family = yes
+						scope:discount_family_governors = yes
+						scope:discount_family_merit = yes
+					}
+				}
+				scope:actors_movement = { tgp_catalyst_from_decision_effect = yes }
+			}
+		}
+		scope:actors_movement = {
+			switch = {
+				trigger = yes
+				scope:discount_none = {
+					tgp_catalyst_from_decision_effect = yes
+				}
+				scope:discount_powerful_family = {
+					tgp_catalyst_from_decision_effect = yes
+
+				}
+				scope:discount_family_governors = {
+					tgp_catalyst_from_decision_effect = yes
+
+				}
+				scope:discount_family_merit = {
+					tgp_catalyst_from_decision_effect = yes
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+		government_allows = merit
+		OR = { # To make sure the cycle isn't nuked by landless families
+			highest_held_title_tier >= tier_duchy
+			house = {
+				is_powerful_family = yes
+			}
+		}
+		situation:dynastic_cycle ?= {
+			trigger_if = {
+				limit = {
+					OR = {
+						situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+						situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+					}
+				}
+				situation_top_sub_region = {
+					phase_takeover_points:situation_dynastic_cycle_phase_instability >= 100
+				}
+			}
+			trigger_else_if = {
+				limit = {
+					OR = {
+						situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+						situation_current_phase = situation_dynastic_cycle_phase_instability
+					}
+				}
+				situation_top_sub_region = {
+					phase_takeover_points:situation_dynastic_cycle_phase_chaos >= 100
+				}
+			}
+			trigger_else = {
+				always = yes
+			}
+		}
+	}
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 120
+		duchy = 120
+		kingdom = 36
+		empire = 12
+		hegemony = 12
+	}
+	ai_will_do = {
+		base = 100
+		modifier = {
+			situation:dynastic_cycle ?= {
+				trigger_if = {
+					limit = {
+						OR = {
+							situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+							situation_current_phase = situation_dynastic_cycle_phase_instability
+						}
+					}
+					situation_top_sub_region = {
+						phase_takeover_points:situation_dynastic_cycle_phase_chaos >= 100
+					}
+				}
+				trigger_else = {
+					situation_top_sub_region = {
+						phase_takeover_points:situation_dynastic_cycle_phase_instability >= 100
+					}
+				}
+			}
+			factor = 10
+		}
+	}
+}

--- a/common/decisions/dlc_decisions/tgp/tgp_dynastic_cycle_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_dynastic_cycle_decisions.txt
@@ -2587,6 +2587,11 @@ favored_movement_consults_heaven_decision = {
 		top_participant_group:dynastic_cycle ?= {
 			NOT = { participant_group_type = other_rulers }
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= monumental_influence_value
+		}
 	}
 
 	is_valid_showing_failures_only = {
@@ -3028,12 +3033,18 @@ favored_movement_consults_heaven_decision = {
 	}
 
 	cost = {
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
 		influence = {
-			value = monumental_influence_value
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = monumental_influence_value
+			}
 		}
 	}
 
 	effect = {
+		debug_log = "unop_475 favored_movement_consults_heaven_decision" #Unop debug log to confirm issue #475
 		top_participant_group:dynastic_cycle ?= {
 	        if = {
 	        	limit = {
@@ -3145,6 +3156,11 @@ favored_movement_consults_heaven_decision = {
 				}
 			}
 		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = monumental_influence_loss
+		}
 	}
 
 	ai_potential = {
@@ -3184,6 +3200,11 @@ house_head_consults_heaven_decision = {
 		top_participant_group:dynastic_cycle ?= {
 			NOT = { participant_group_type = other_rulers }
 		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= unop_house_head_consults_heaven_influence_cost
+		}
 	}
 
 	is_valid_showing_failures_only = {
@@ -3202,35 +3223,13 @@ house_head_consults_heaven_decision = {
 	cooldown = { years = 10 }
 
 	cost = {
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
 		influence = {
-			value = 2000
-			add = {
-				value = 0
-				every_close_or_extended_family_member = {
-					limit = {
-						is_governor = yes
-					}
-					add = 10
-				}
-				multiply = -1
-			}
-			add = {
-				value = 0
-				every_close_or_extended_family_member = {
-					limit = {
-						merit_level >= 4
-					}
-					add = 10
-				}
-				multiply = -1
-			}
+			value = 0
 			if = {
-				limit = {
-					scope:discount_none ?= yes
-				}
-				multiply = 0.5
+				limit = { is_ai = no }
+				add = unop_house_head_consults_heaven_influence_cost
 			}
-			min = 100
 		}
 		piety = {
 			value = 0
@@ -3319,6 +3318,7 @@ house_head_consults_heaven_decision = {
 	}
 
 	effect = {
+		debug_log = "unop_475 house_head_consults_heaven_decision" #Unop debug log to confirm issue #475
 		top_participant_group:dynastic_cycle ?= {
 	        if = {
 	        	limit = {
@@ -3363,6 +3363,11 @@ house_head_consults_heaven_decision = {
 					tgp_catalyst_from_decision_effect = yes
 				}
 			}
+		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = { subtract = unop_house_head_consults_heaven_influence_cost }
 		}
 	}
 

--- a/common/decisions/dlc_decisions/tgp/tgp_japan_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_japan_decisions.txt
@@ -566,10 +566,12 @@ tgp_japan_establish_soryo_administration_decision = {
 		prestige = {
 			value = massive_prestige_gain
 		}
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
 		influence = {
-			value = {
-				value = monumental_influence_gain
-				multiply = 2
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = unop_soryo_administration_influence_cost
 			}
 		}
 	}
@@ -578,9 +580,14 @@ tgp_japan_establish_soryo_administration_decision = {
 		has_tgp_dlc_trigger = yes
 		is_independent_ruler = yes
 		government_is_japanese_trigger = yes
-		NOR = { 
-			government_has_flag = government_is_japan_feudal 
+		NOR = {
+			government_has_flag = government_is_japan_feudal
 			has_global_variable = shogunate_established
+		}
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= unop_soryo_administration_influence_cost
 		}
 	}
 
@@ -617,6 +624,7 @@ tgp_japan_establish_soryo_administration_decision = {
 	}
 
 	effect = {
+		debug_log = "unop_475 tgp_japan_establish_soryo_administration_decision" #Unop debug log to confirm issue #475
 		add_achievement_global_variable_effect = {
 			VARIABLE = achieved_ep4_18_yes_i_need_my_samurai_achievement
 			VALUE = yes
@@ -628,8 +636,13 @@ tgp_japan_establish_soryo_administration_decision = {
 			id = tgp_japan_decision.9601
 			delayed = yes
 		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = { subtract = unop_soryo_administration_influence_cost }
+		}
 	}
-	
+
 	ai_check_interval_by_tier = {
 		barony = 0
 		county = 0
@@ -914,6 +927,7 @@ tgp_japan_imperial_branch_decision = {
 	}
 
 	effect = {
+		debug_log = "unop_475 tgp_japan_imperial_branch_decision" #Unop debug log to confirm issue #475 (control)
 		# Find nearest Emperor
 		top_liege.primary_title.var:administrative_ui_special_title ?= {
 			random_past_holder = {

--- a/common/decisions/dlc_decisions/tgp/tgp_steppe_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_steppe_decisions.txt
@@ -1,0 +1,568 @@
+﻿adopt_steppe_administration = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_great_project.dds"
+	} 
+	decision_group_type = nomad_major
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 60
+		empire = 60
+		hegemony = 0
+	}
+
+	desc = adopt_steppe_administration_desc
+	selection_tooltip = adopt_steppe_administration_tooltip
+
+	is_shown = {
+		has_mpo_dlc_trigger = yes
+		has_tgp_dlc_trigger = yes
+		government_has_flag = government_is_nomadic
+		OR = {
+			highest_held_title_tier = tier_kingdom
+			highest_held_title_tier = tier_empire
+		}
+		is_playable_character = yes
+	}
+
+	is_valid = {
+		custom_tooltip = {
+			text = you_are_the_culture_head
+			culture = {
+				culture_head = root
+			}
+		}
+		OR = { # You need to already be on your way to imperial status, if not already there
+			has_realm_law = nomadic_authority_4
+			has_realm_law = nomadic_authority_5
+		}
+		custom_tooltip = {
+			text = steppe_admin_kingdom_requirement
+			any_realm_de_jure_kingdom = {
+				count >= 3
+				root = {
+					completely_controls = prev
+				}
+				title_capital_county.title_province ?= {
+					OR = {
+						has_holding_type = castle_holding
+						has_holding_type = city_holding
+						has_holding_type = church_holding
+						has_holding_type = temple_citadel_holding
+					}
+				}
+			}
+		}
+		save_temporary_scope_value_as = {
+			name = temp_num_tributaries
+			value = sub_realm_with_tributaries_size
+		}
+		custom_tooltip = { # You need a total realm size big enough to impress
+			text = steppe_admin_tributary_req
+			sub_realm_with_tributaries_size >= 50
+		}
+		custom_tooltip = { # You need somewhere to get the idea to adopt Merit and examinations from
+			text = steppe_admin_merit_req
+			OR = {
+				any_neighboring_top_liege_realm_owner = {
+					AND = {
+						government_has_flag = government_has_merit
+						highest_held_title_tier >= tier_kingdom
+					}
+				}
+				any_tributary = {
+					AND = {
+						government_has_flag = government_has_merit
+						highest_held_title_tier >= tier_kingdom
+					}			
+				}
+				any_vassal_or_below = {
+					AND = {
+						government_has_flag = government_has_merit
+						highest_held_title_tier >= tier_kingdom
+					}			
+				}
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_at_war = no
+		is_tributary = no
+		is_available_adult = yes
+		has_active_diarchy = no
+	}
+
+	cost = {
+        gold = {
+            value = 0
+            if = {
+                limit = {
+                    has_treasury = no
+                }
+                add = massive_prestige_value # building an imperial palace isn't cheap, you know
+           }
+        }
+
+        treasury = {
+            value = 0
+            if = {
+                limit = {
+                    has_treasury = yes
+                }
+                add = 500
+            }
+        }
+		prestige = {
+			value = monumental_prestige_value
+		}
+	}
+
+	effect = {
+		#GoK stops really being GoK
+		gok_government_change_story_end_effect = yes
+		if = {
+			limit = {
+				has_realm_law = nomadic_authority_4
+			}
+			add_character_flag = realm_law_4
+		}
+		else = {
+			add_character_flag = realm_law_5
+		}
+		add_legitimacy_effect = { LEGITIMACY = massive_legitimacy_gain }
+		dynasty = {
+			add_dynasty_prestige = massive_dynasty_prestige_gain
+		}
+		save_scope_as = nomad_settling_down
+		save_scope_value_as = {
+			name = invading_herd_value
+			value = domicile.herd
+		}
+		nomad_domicile_refund_treasury_or_gold_effect = yes # we pay you back for your domicile investments
+		nomad_convert_herds_to_treasury_or_gold_special_troops_effect = yes # we pay you back for your herd investments
+		nomad_to_steppe_admin_new_capital_effect = yes # we arrange a new capital for you the same way we would any other settling nomad
+		change_government = steppe_admin_government
+		give_noble_family_title = {
+			name = noble_family_name
+			tier = county
+			article = DEFAULT_TITLE_NAME_ARTICLE
+			government = steppe_admin_government
+			save_scope_as = new_title
+		}
+		scope:new_title = {
+			set_coa = holder.house
+		}
+		hidden_effect = {
+			switch = {
+				trigger = has_character_flag
+				realm_law_4 = {
+					add_realm_law_skip_effects = meritocratic_bureaucracy_2
+					remove_character_flag = realm_law_4
+				}
+				realm_law_5 = {
+					add_realm_law_skip_effects = meritocratic_bureaucracy_3
+					remove_character_flag = realm_law_5
+				}
+			}
+		}
+		hidden_effect = { # We explain this in an earlier tooltip
+			add_treasury_or_gold = {
+				value = scope:domicile_refund_treasury_or_gold_value
+				add = scope:nomad_convert_herds_to_treasury_or_gold_value
+			}
+		}
+		if = {
+			limit = {
+				any_held_title = {
+					is_nomad_title = yes
+				}
+			}
+			every_held_title = {
+				limit = {
+					is_nomad_title = yes
+				}
+				root = {
+					destroy_title = prev
+				}
+			}
+		}
+		custom_tooltip = {
+			text = merit_based_vassals_convert_to_steppe_admin
+			if = {
+				limit = {
+					any_vassal = {
+						government_has_flag = government_has_merit
+						NOT = { government_has_flag = government_is_steppe_admin }
+					}
+				}
+				every_vassal = {
+					limit = {
+						government_has_flag = government_has_merit
+						NOT = { government_has_flag = government_is_steppe_admin }
+					}
+					change_government = steppe_admin_government
+				}
+			}
+		}
+		hidden_effect = {
+			every_tributary = {
+				add_to_list = tributaries
+			}
+			every_in_list = {
+				list = tributaries
+				start_tributary_interaction_effect = { # to update their contract types for your new status
+					TRIBUTARY = this
+					SUZERAIN = root
+				}
+			}
+		}
+		hidden_effect = {
+			generate_new_steppe_admin_families_effect = yes # we populate your noble families so you have some starting non-nomadic administrators
+		}
+	}
+
+	ai_potential = {
+		#AI greatest of khans shouldn't be doing this and ruining their GoKness
+		NOR = {
+			has_trait = greatest_of_khans
+			any_owned_story = {
+				OR = {
+					story_type = story_mongol_invasion
+					story_type = story_greatest_of_khans
+				}
+			}
+		}
+	}
+
+	ai_will_do = {
+		base = 100 # the bar to doing this is high enoug that if the AI can do it, the AI should do it
+	}
+}
+
+### Return to the Steppe ###
+return_to_the_steppe_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/event_story/mpo_steppe_region.dds"
+	}
+	decision_group_type = nomad_major
+
+	desc = return_to_the_steppe_decision_desc
+	selection_tooltip = return_to_the_steppe_decision_tooltip
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 72 # just in case there's an orphaned steppe admin kingdom somewhere
+		empire = 72
+		hegemony = 0
+	}
+
+	is_shown = {
+		has_mpo_dlc_trigger = yes
+		has_tgp_dlc_trigger = yes
+		government_has_flag = government_is_steppe_admin
+		is_independent_ruler = yes
+		is_playable_character = yes
+		NOT = {
+			any_vassal_or_below = {
+				is_ai = no # the gamestate could conceivably result in as situation where you could game over a player-vassal by doing this, so we just make sure it can't happen
+			}
+		}
+	}
+
+	is_valid = {
+		has_trait = nomadic_philosophy # you need at least some connection to the steppe to want to go back to it
+		custom_tooltip = {
+			text = small_enough_realm_to_abandon
+			any_realm_county = {
+				count <= 10
+				title_province = {
+					OR = {
+						has_holding_type = castle_holding
+						has_holding_type = church_holding
+						has_holding_type = city_holding
+						has_holding_type = temple_citadel_holding
+					}
+				}
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_at_war = no
+		is_available = yes
+		has_active_diarchy = no
+	}
+
+	cost = {
+		prestige = {
+			value = massive_prestige_value # this is already a escape hatch, so we don't want it to be too punishing
+		}
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = treasury_emptying_effect_desc
+			empty_treasury_when_abandoning_landed_life_effect = yes # otherwise the treasury sticks around
+		}
+		refund_noble_family_domicile_buildings_effect = yes
+		custom_tooltip = {
+			text = nomadize_landless_noble_families
+			refund_vassal_noble_families_and_make_them_nomads_effect = yes # for those who share your cultural heritage
+		}
+		custom_tooltip = {
+			text = rehouse_landless_noble_families
+			rehome_noble_families_to_compatible_liege_effect = yes # we find a new home for those who don't share your cultural heritage
+		}
+		custom_tooltip = {
+			text = title_maa_regiments_will_be_destroyed
+			if = {
+				limit = {
+					any_maa_regiment = {
+						is_title_maa_regiment = yes
+					}
+				}
+				every_maa_regiment = {
+					limit = {
+						is_title_maa_regiment = yes
+					}
+					destroy_maa_regiment = yes
+				}
+			}
+		}
+		change_government = nomad_government
+		hidden_effect = {
+			if = {
+				limit = {
+					exists = scope:current_treasury # saved in empty_treasury_when_abandoning_landed_life_effect
+				}
+				add_gold = {
+					value = scope:current_treasury
+				}
+			}
+		}
+		custom_tooltip = {
+			text = convert_steppe_admin_to_meritocratic_tooltip
+			convert_steppe_admin_vassals_to_meritocratic_effect = yes
+		}
+		hidden_effect = {
+			every_tributary = {
+				add_to_list = tributaries
+			}
+			every_in_list = {
+				list = tributaries
+				start_tributary_interaction_effect = { # to update their contract types for your new status
+					TRIBUTARY = this
+					SUZERAIN = root
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+		capital_county.title_province = {
+			NOR = {
+				has_holding_type = castle_holding
+				has_holding_type = church_holding
+				has_holding_type = city_holding
+				has_holding_type = temple_citadel_holding
+			}
+		}
+	}
+
+	ai_will_do = {
+		base = 100 # if the potential is met, the AI should do it
+	}
+}
+
+### Adopt Meritocratic Government ###
+convert_to_meritocratic_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_stability.dds"
+	} 
+	decision_group_type = major
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 60
+		empire = 60
+		hegemony = 0
+	}
+
+	desc = convert_to_meritocratic_desc
+	selection_tooltip = convert_to_meritocratic_tooltip
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		government_has_flag = government_is_steppe_admin
+		OR = {
+			highest_held_title_tier = tier_kingdom # this isn't standard, but will cover some edge cases for orphaned steppe admin kingdoms
+			highest_held_title_tier = tier_empire
+		}
+		any_sub_realm_county = {
+			count > 0
+			title_province = {
+				OR = {
+					has_holding_type = castle_holding
+					has_holding_type = church_holding
+					has_holding_type = city_holding
+					has_holding_type = temple_citadel_holding
+				}
+			}
+		}
+		is_playable_character = yes
+	}
+
+	is_valid = {
+		OR = {
+			has_realm_law = meritocratic_bureaucracy_2
+			has_realm_law = meritocratic_bureaucracy_3
+		}
+		save_temporary_scope_value_as = {
+			name = temp_num_qualifying_counties
+			value = temp_num_qualifying_counties_count
+		}
+		custom_tooltip = {
+			text = convert_to_meritocratic_county_count
+			any_sub_realm_county = {
+				count >= 30
+				holder = {
+					is_governor_or_admin_count = yes
+					government_has_flag = government_has_merit
+				}
+				title_province = {
+					OR = {
+						has_holding_type = castle_holding
+						has_holding_type = church_holding
+						has_holding_type = city_holding
+						has_holding_type = temple_citadel_holding
+					}
+				}
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_at_war = no
+		is_available_adult = yes
+		has_active_diarchy = no
+	}
+
+	cost = {
+		gold = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = no
+				}
+				add = monumental_gold_value
+			}
+		}
+		treasury = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = yes
+				}
+				add = monumental_gold_value
+			}
+		}
+		prestige = {
+			value = massive_prestige_value
+		}
+		influence = {
+			value = monumental_influence_value
+		}
+	}
+
+	effect = {
+		add_legitimacy_effect = { LEGITIMACY = monumental_legitimacy_gain }
+		dynasty = {
+			add_dynasty_prestige = monumental_dynasty_prestige_gain
+		}
+		tgp_domicile_conversion_when_changing_government_type = {
+			NEW_DOMICILE_TYPE = east_asian_estate
+			NEW_GOVERNMENT_TYPE = meritocratic_government
+		}
+		change_government = meritocratic_government
+		hidden_effect = {
+			every_tributary = {
+				add_to_list = tributaries
+			}
+			every_in_list = {
+				list = tributaries
+				start_tributary_interaction_effect = {  # to update their contract types for your new status
+					TRIBUTARY = this
+					SUZERAIN = root
+				}
+			}
+		}
+		custom_tooltip = {
+			text = steppe_admin_vassals_will_convert
+			convert_steppe_admin_vassals_to_meritocratic_effect = yes
+		}
+		custom_tooltip = {
+			text = non_merit_based_vassals_become_tributaries
+			if = {
+				limit = {
+					any_vassal = {
+						NOT = {
+							government_has_flag = government_has_merit
+						}
+					}
+				}
+				create_title_and_vassal_change = {
+					type = independency
+					save_scope_as = change
+					add_claim_on_loss = no
+				}
+				every_vassal = {
+					limit = {
+						NOT = {
+							government_has_flag = government_has_merit
+						}
+					}
+					add_to_list = soon_to_be_former_vassals
+					becomes_independent = { change = scope:change }
+				}
+				resolve_title_and_vassal_change = scope:change
+				every_in_list = {
+					list = soon_to_be_former_vassals
+					start_tributary_interaction_effect = {
+						TRIBUTARY = this
+						SUZERAIN = root
+					}
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+	}
+
+	ai_will_do = {
+		base = 0
+		modifier = {
+			add = 20
+			NOT = { has_trait = nomadic_philosophy }
+		}
+		modifier = {
+			add = 30
+			has_trait = education_learning 
+		}
+		modifier = {
+			add = 50
+			has_religion = religion:confucianism_religion
+		}
+		modifier = {
+			add = 30
+			has_trait = confucian_education
+		}
+	}
+}

--- a/common/decisions/dlc_decisions/tgp/tgp_steppe_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_steppe_decisions.txt
@@ -417,6 +417,11 @@ convert_to_meritocratic_decision = {
 			}
 		}
 		is_playable_character = yes
+		#Unop AI is charged influence in effect, not the cost block, so still require it can afford it
+		trigger_if = {
+			limit = { is_ai = yes }
+			influence >= monumental_influence_value
+		}
 	}
 
 	is_valid = {
@@ -476,12 +481,18 @@ convert_to_meritocratic_decision = {
 		prestige = {
 			value = massive_prestige_value
 		}
+		#Unop AI never budgets cost-block influence; charge it via is_shown/effect below
 		influence = {
-			value = monumental_influence_value
+			value = 0
+			if = {
+				limit = { is_ai = no }
+				add = monumental_influence_value
+			}
 		}
 	}
 
 	effect = {
+		debug_log = "unop_475 convert_to_meritocratic_decision" #Unop debug log to confirm issue #475
 		add_legitimacy_effect = { LEGITIMACY = monumental_legitimacy_gain }
 		dynasty = {
 			add_dynasty_prestige = monumental_dynasty_prestige_gain
@@ -540,6 +551,11 @@ convert_to_meritocratic_decision = {
 					}
 				}
 			}
+		}
+		#Unop AI pays the influence here since the cost block is free for it
+		if = {
+			limit = { is_ai = yes }
+			change_influence = monumental_influence_loss
 		}
 	}
 

--- a/common/script_values/00_fixpack_values.txt
+++ b/common/script_values/00_fixpack_values.txt
@@ -201,6 +201,52 @@ khlon_glan_improve_court_value = {
 	}
 }
 
+# Decision influence costs
+unop_ask_western_help_influence_cost = {
+	value = massive_influence_value
+	multiply = 2
+}
+
+unop_foster_integration_influence_cost = {
+	value = major_influence_value
+	multiply = 2
+}
+
+unop_gather_faction_support_influence_cost = {
+	value = massive_influence_value
+	multiply = 2
+}
+
+unop_soryo_administration_influence_cost = {
+	value = monumental_influence_gain
+	multiply = 2
+}
+
+unop_house_head_consults_heaven_influence_cost = {
+	value = 2000
+	add = {
+		value = 0
+		every_close_or_extended_family_member = {
+			limit = { is_governor = yes }
+			add = 10
+		}
+		multiply = -1
+	}
+	add = {
+		value = 0
+		every_close_or_extended_family_member = {
+			limit = { merit_level >= 4 }
+			add = 10
+		}
+		multiply = -1
+	}
+	if = {
+		limit = { scope:discount_none ?= yes }
+		multiply = 0.5
+	}
+	min = 100
+}
+
 # Those are the values that were used before the nerf made after community hatred of the harm events
 unop_old_harm_event_random_list_low_odd_success_value = 20
 unop_old_harm_event_random_list_low_odd_failure_value = 80

--- a/events/dlc/tgp/tgp_dynastic_cycle_decision_events.txt
+++ b/events/dlc/tgp/tgp_dynastic_cycle_decision_events.txt
@@ -66,7 +66,9 @@ tgp_dynastic_cycle_decision_event.0111 = {
 									situation_top_has_catalyst = catalyst_movement_gained_power_pro_hegemon
 								}
 							}
-							trigger_situation_catalyst = catalyst_movement_gained_power_pro_hegemon
+							situation:dynastic_cycle = { #Unop trigger_situation_catalyst requires situation scope, not participant group
+								trigger_situation_catalyst = catalyst_movement_gained_power_pro_hegemon
+							}
 						}
 					}
 					advancement_movement = {
@@ -76,7 +78,9 @@ tgp_dynastic_cycle_decision_event.0111 = {
 									situation_top_has_catalyst = catalyst_movement_gained_power_advancement
 								}
 							}
-							trigger_situation_catalyst = catalyst_movement_gained_power_advancement
+							situation:dynastic_cycle = { #Unop trigger_situation_catalyst requires situation scope, not participant group
+								trigger_situation_catalyst = catalyst_movement_gained_power_advancement
+							}
 						}
 					}
 					expansion_movement = {
@@ -86,7 +90,9 @@ tgp_dynastic_cycle_decision_event.0111 = {
 									situation_top_has_catalyst = catalyst_movement_gained_power_expansion
 								}
 							}
-							trigger_situation_catalyst = catalyst_movement_gained_power_expansion
+							situation:dynastic_cycle = { #Unop trigger_situation_catalyst requires situation scope, not participant group
+								trigger_situation_catalyst = catalyst_movement_gained_power_expansion
+							}
 						}
 					}
 					conservative_movement = {
@@ -96,7 +102,9 @@ tgp_dynastic_cycle_decision_event.0111 = {
 									situation_top_has_catalyst = catalyst_movement_gained_power_conservative
 								}
 							}
-							trigger_situation_catalyst = catalyst_movement_gained_power_conservative
+							situation:dynastic_cycle = { #Unop trigger_situation_catalyst requires situation scope, not participant group
+								trigger_situation_catalyst = catalyst_movement_gained_power_conservative
+							}
 						}
 					}
 				}

--- a/events/dlc/tgp/tgp_dynastic_cycle_decision_events.txt
+++ b/events/dlc/tgp/tgp_dynastic_cycle_decision_events.txt
@@ -1,0 +1,121 @@
+﻿###################################
+# DYNASTIC CYCLE DECISION EVENTS
+###################################
+
+namespace = tgp_dynastic_cycle_decision_event
+
+# Retire from all Titles
+tgp_dynastic_cycle_decision_event.0101 = {
+	type = character_event
+	title = tgp_dynastic_cycle_decision_event.0101.t
+	desc = tgp_dynastic_cycle_decision_event.0101.desc
+	theme = dynasty
+	left_portrait = {
+		character = root
+		animation = happy_teacher
+	}
+	right_portrait = {
+		character = scope:new_player
+		animation = personality_bold
+	}
+	option = {
+		name = tgp_dynastic_cycle_decision_event.0101.a
+		tgp_renounce_estate_effect = yes
+	}
+	after = {
+		hidden_effect = {
+			if = {
+				limit = {
+					employer != scope:new_player
+				}
+				set_employer = scope:new_player
+			}
+		}
+	}
+}
+
+# Inform Movements of a new Favored Movement - from decision
+tgp_dynastic_cycle_decision_event.0111 = {	
+	type = letter_event
+	opening = tgp_dynastic_cycle_decision_event.0111.opening
+	desc = {
+		desc = tgp_dynastic_cycle_decision_event.0111.desc_intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					exists = scope:former_favored_movement
+				}
+				desc = tgp_dynastic_cycle_decision_event.0111.desc_former
+			}
+			desc = tgp_dynastic_cycle_decision_event.0111.desc
+		}
+		desc = tgp_dynastic_cycle_decision_event.0111.desc_outro
+	}
+	sender = scope:hegemon
+
+	immediate = {
+		show_as_tooltip = {
+			scope:new_favored_movement = {
+				make_movement_favored_effect = yes
+				switch = {
+					trigger = participant_group_type
+					pro_hegemon_movement = {
+						if = {
+							limit = {
+								situation:dynastic_cycle = {
+									situation_top_has_catalyst = catalyst_movement_gained_power_pro_hegemon
+								}
+							}
+							trigger_situation_catalyst = catalyst_movement_gained_power_pro_hegemon
+						}
+					}
+					advancement_movement = {
+						if = {
+							limit = {
+								situation:dynastic_cycle = {
+									situation_top_has_catalyst = catalyst_movement_gained_power_advancement
+								}
+							}
+							trigger_situation_catalyst = catalyst_movement_gained_power_advancement
+						}
+					}
+					expansion_movement = {
+						if = {
+							limit = {
+								situation:dynastic_cycle = {
+									situation_top_has_catalyst = catalyst_movement_gained_power_expansion
+								}
+							}
+							trigger_situation_catalyst = catalyst_movement_gained_power_expansion
+						}
+					}
+					conservative_movement = {
+						if = {
+							limit = {
+								situation:dynastic_cycle = {
+									situation_top_has_catalyst = catalyst_movement_gained_power_conservative
+								}
+							}
+							trigger_situation_catalyst = catalyst_movement_gained_power_conservative
+						}
+					}
+				}
+			}
+		}
+	}
+	option = {
+		name = {
+			trigger = {
+				scope:new_favored_movement ?= top_participant_group:dynastic_cycle
+			}
+			text = tgp_dynastic_cycle_decision_event.0111.a_new
+		}
+		name = {
+			trigger = {
+				scope:former_favored_movement ?= top_participant_group:dynastic_cycle
+			}
+			text = tgp_dynastic_cycle_decision_event.0111.a_former
+		}
+		name = tgp_dynastic_cycle_decision_event.0111.a_other
+	}
+}


### PR DESCRIPTION
Fixes #475

The CK3 AI never budgets a `cost`-block influence cost, so any decision with a non-zero `influence` entry and no `ai_goal = yes` is silently never AI-executed even when every `is_shown`/`is_valid`/`ai_potential`/`ai_will_do` gate passes. This was confirmed in-game for #462 (PR #474) and for the decisions in this PR via `debug_log` + observer mode.

Fix pattern (same as #474):
- `cost`: influence is free for the AI (`value = 0` for AI, full cost for players).
- `is_shown`: AI affordability check added so influence is still a real constraint.
- `effect`: AI pays influence explicitly via `change_influence`.

Calculated influence costs used in multiple places are extracted as named scripted values in `common/script_values/00_fixpack_values.txt`.

Also fixes a vanilla bug where `trigger_situation_catalyst` was called from participant group scope (requires situation scope) in `favor_movement_decision` and its companion event `tgp_dynastic_cycle_decision_events.txt`.