### PR TITLE
Fix restore_backwater_counties_decision: AI never takes it, emperor-tier vassals excluded

### DIFF
--- a/common/decisions/dlc_decisions/ep3_decisions.txt
+++ b/common/decisions/dlc_decisions/ep3_decisions.txt
@@ -131,6 +131,7 @@ restore_backwater_counties_decision = {
 			OR = {
 				tier = tier_duchy
 				tier = tier_kingdom
+				tier = tier_empire #Unop Don't exclude emperor-tier vassals (e.g. under a hegemony)
 			}
 		}
 		any_sub_realm_county = {
@@ -272,6 +273,18 @@ restore_backwater_counties_decision = {
 				# Trigger the event for the emperor to see if all the counties have been cleared
 				trigger_event = ep3_decisions_event.3001
 			}
+		}
+	}
+
+	ai_will_do = { #Unop Add missing weights so the AI takes the decision
+		base = 30
+		modifier = {
+			has_trait = diligent
+			add = 20
+		}
+		modifier = {
+			has_trait = ambitious
+			add = 20
 		}
 	}
 }


### PR DESCRIPTION
Fixes #501

Two vanilla bugs in `restore_backwater_counties_decision` (`common/decisions/dlc_decisions/ep3_decisions.txt`):

1. **AI never takes the decision.** It had `ai_check_interval_by_tier` but no `ai_will_do` block, so the AI had no score to act on. Added an `ai_will_do` block with a base weight and `diligent`/`ambitious` modifiers.
2. **Emperor-tier vassals excluded.** The `is_shown` OR block only allowed `tier_duchy` and `tier_kingdom`, filtering out vassals whose own primary title is empire tier (e.g. under a hegemony). Added `tier = tier_empire`.