### PR TITLE
Drop administration theme when a noble family loses its governorship

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -517,6 +517,14 @@ filter = {
 			text = "`this` produces none but expected character"
 			file = common/on_action/game_start.txt
 		}
+		NAND = { # `scope:liege.top_liege = this` is guarded by `trigger_if = { limit = { exists = this } }`
+			key = scopes
+			OR = {
+				text = "`this` produces none but expected character"
+				text = "`this` produces none but expected any except none scope"
+			}
+			file = common/subject_contracts/contracts/japan_administrative.txt
+		}
 		NAND = { # mysterious_stranger_appeared is only checked for existence
 			key = scopes
 			text = "`scope:mysterious_stranger` produces character but expected bool"

--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -517,14 +517,6 @@ filter = {
 			text = "`this` produces none but expected character"
 			file = common/on_action/game_start.txt
 		}
-		NAND = { # `scope:liege.top_liege = this` is guarded by `trigger_if = { limit = { exists = this } }`
-			key = scopes
-			OR = {
-				text = "`this` produces none but expected character"
-				text = "`this` produces none but expected any except none scope"
-			}
-			file = common/subject_contracts/contracts/japan_administrative.txt
-		}
 		NAND = { # mysterious_stranger_appeared is only checked for existence
 			key = scopes
 			text = "`scope:mysterious_stranger` produces character but expected bool"

--- a/common/subject_contracts/contracts/administrative.txt
+++ b/common/subject_contracts/contracts/administrative.txt
@@ -21,6 +21,7 @@ administrative_themes = {
 	display_mode = radiobutton
 	is_shown = {
 		scope:subject.primary_title.tier >= tier_duchy
+		scope:subject = { is_landless_ruler = no } #Unop A landless ex-governor must not keep an administration theme
 	}
 	obligation_levels = {
 		admin_theme_balanced = {

--- a/common/subject_contracts/contracts/administrative.txt
+++ b/common/subject_contracts/contracts/administrative.txt
@@ -1,0 +1,459 @@
+﻿administrative_obligations = {
+	obligation_levels = {
+		default = {
+			levies = {
+				value = 0.3
+				#multiply = governor_efficiency
+			}
+
+			tax = {
+				value = 0.75
+				#multiply = governor_efficiency
+			}
+		}
+	}
+}
+
+### brief: administrative_themes
+# This is referenced in code. 
+#
+administrative_themes = {
+	display_mode = radiobutton
+	is_shown = {
+		scope:subject.primary_title.tier >= tier_duchy
+	}
+	obligation_levels = {
+		admin_theme_balanced = {
+			default = yes
+			position = { 0 0 }
+			gui_tags = { byzantine_purple }
+			icon = "gfx/interface/icons/theme_administration_types/icon_balanced_administration.dds"
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:subject = {
+							is_ai = yes
+						}
+					}
+					add = 1
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.7 0.7 0.7 1.0 }
+			
+			subject_modifier = {
+				governor_xp_gain_mult = 0.2
+			}
+			
+			flag = admin_theme_balanced
+		}
+		admin_theme_civilian = {
+			position = { 2 0 }
+			icon = "gfx/interface/icons/theme_administration_types/icon_civilian_administration.dds"
+			gui_tags = { byzantine_purple }
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:subject = {
+							is_ai = yes
+							OR = {
+								has_trait = education_stewardship
+								stewardship >= very_high_skill_rating
+								AND = { # Large semi-coastal themes are good for an economic focus
+									any_sub_realm_county = { count >= 2 is_coastal_county = yes }
+									any_sub_realm_county = { count >= 2 is_coastal_county = no }
+								}
+							}
+						}
+					}
+					add = 2
+				}
+				if = {
+					limit = {
+						scope:liege = {
+							ai_has_builder_or_pious_builder_personality = yes
+						}
+					}
+					add = 1
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.2 0.2 0.7 1.0 }
+
+			tax_factor = 0.5
+
+			subject_modifier = {
+				development_growth_factor = 0.2
+				build_gold_cost = -0.1
+				build_speed = -0.1
+				men_at_arms_title_limit = -2
+				men_at_arms_title_cap = -2
+			}
+			
+			flag = admin_stewardship_obligation_bonus
+			flag = admin_influence_construction_bonus
+			flag = admin_ai_is_builder
+			flag = admin_theme_civilian
+			flag = obligation_high_taxes
+		}
+		admin_theme_military = {
+			position = { 1 0 }
+			icon = "gfx/interface/icons/theme_administration_types/icon_military_administration.dds"
+			gui_tags = { byzantine_purple }
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:subject = {
+							is_ai = yes
+							OR = {
+								has_trait = education_martial
+								martial >= very_high_skill_rating
+								primary_title = { any_owned_title_maa_regiment = { count > 4 } }
+								AND = { # Large inland themes are good for military
+									any_sub_realm_county = { count >= 5 }
+									any_sub_realm_county = { percent >= 0.95 is_coastal_county = no }
+								}
+							}
+						}
+					}
+					add = 2
+				}
+				if = {
+					limit = {
+						scope:liege = {
+							ai_has_warlike_personality = yes
+						}
+					}
+					add = 1
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.7 0.2 0.2 1.0 }
+
+			levies_factor = 0.75
+			
+			subject_modifier = {
+				development_growth_factor = -0.25
+				monthly_county_control_growth_factor = 0.1
+				maa_damage_mult = 0.1
+				men_at_arms_title_cap = 2
+				men_at_arms_maintenance = -0.2
+				monthly_treasury_from_military_budget_base = 1
+			}
+			
+			flag = admin_martial_obligation_bonus
+			flag = admin_theme_military
+			flag = obligation_high_levies
+		}
+		admin_theme_frontier = {
+			position = { 0 1 }
+			icon = "gfx/interface/icons/theme_administration_types/icon_frontier_administration.dds"
+			gui_tags = { byzantine_purple }
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:subject = {
+							is_ai = yes
+						}
+					}
+					add = 5
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.2 0.7 0.2 1.0 }
+			
+			is_valid = {
+				custom_tooltip = {
+					text = admin_theme_frontier_valid_desc
+					scope:subject = {
+						any_sub_realm_county = {
+							any_neighboring_county = {
+								holder = {
+									top_liege != scope:subject.top_liege
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			tax_factor = -0.2
+
+			subject_modifier = {
+				fort_level = 2
+				defender_advantage = 6
+				hostile_county_attrition = -0.3
+				hostile_raid_time = 0.75
+				
+				# Values to tweak the AI slightly in order to make them more likely to declare war
+				ai_boldness = 20
+				ai_rationality = -15
+				monthly_treasury_from_military_budget_base = 1.5
+			}
+			
+			flag = admin_prowess_obligation_bonus
+			flag = admin_duchy_expansion_unlocked
+			flag = admin_ai_is_warlike
+			flag = admin_theme_frontier
+			flag = admin_theme_can_raid
+		}
+		admin_theme_imperial = {
+			position = { 1 1 }
+			icon = "gfx/interface/icons/theme_administration_types/icon_imperial_administration.dds"
+			gui_tags = { byzantine_purple }
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:liege = {
+							NOT = {
+								any_vassal = { vassal_contract_has_flag = admin_theme_imperial }
+							}
+						}
+						scope:subject = {
+							is_ai = yes
+							culture = scope:liege.culture
+							faith = top_liege.primary_title.state_faith
+						}
+					}
+					add = 5
+				}
+				if = {
+					limit = {
+						exists = scope:liege.house
+						exists = scope:subject.house
+						scope:liege.house = scope:subject.house
+					}
+					add = 1
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.7 0.0 0.7 1.0 }
+			
+			is_valid = {
+				scope:liege = {
+					highest_held_title_tier >= tier_empire
+				}
+				custom_tooltip = {
+					text = admin_theme_imperial_valid_desc
+					OR = {
+						scope:liege = {
+							NOT = {
+								any_vassal = { vassal_contract_has_flag = admin_theme_imperial }
+							}
+						}
+						AND = {
+							scope:subject = { vassal_contract_has_flag = admin_theme_imperial }
+							scope:liege = {
+								any_vassal = {
+									count = 1
+									vassal_contract_has_flag = admin_theme_imperial
+								}
+							}
+						}
+					}
+				}
+			}
+			
+			tax_factor = 0.1
+
+			liege_modifier = {
+				monthly_prestige_gain_per_legitimacy_level_add = 0.5
+				legitimacy_gain_mult = 0.2
+			}
+
+			subject_modifier = {
+				monthly_prestige = 0.5
+				monthly_influence = 0.25
+			}
+			
+			flag = admin_theme_imperial
+			flag = admin_prestige_obligation_bonus
+			flag = admin_cannot_revoke_titles_without_cause
+			flag = obligation_high_taxes
+		}
+		admin_theme_naval = {
+			position = { 2 1 }
+			icon = "gfx/interface/icons/theme_administration_types/icon_naval_administration.dds"
+			gui_tags = { byzantine_purple }
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:subject = { is_ai = yes }
+					}
+					if = {
+						limit = { # Large coastal areas qualify as good naval themes
+							scope:subject = {
+								any_sub_realm_county = {
+									count >= 3
+									is_coastal_county = yes
+								}
+							}
+							scope:liege = { # But don't go overboard with naval themes
+								any_vassal = {
+									percent < 0.15
+									vassal_contract_has_flag = admin_theme_naval
+								}
+							}
+						}
+						add = 3
+					}
+					
+					if = {
+						limit = { # Islands are good naval candidates
+							scope:subject = {
+								any_sub_realm_county = {
+									percent >= 0.95
+									is_coastal_county = yes
+									OR = {
+										any_neighboring_county = {
+											percent >= 0.95
+											holder = {
+												OR = {
+													this = scope:subject
+													any_liege_or_above = { this = scope:subject }
+												}
+											}
+										}
+										any_neighboring_county = { count < 1 }
+									}
+								}
+							}
+						}
+						add = 8
+					}
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.0 0.4 0.7 1.0 }
+			
+			is_valid = {
+				custom_tooltip = {
+					text = admin_theme_naval_valid_desc
+					scope:subject = {
+						any_sub_realm_county = {
+							is_coastal_county = yes
+						}
+					}
+				}
+			}
+			
+			liege_modifier = {
+				embarkation_cost_mult = -0.1
+				naval_movement_speed_mult = 0.1
+			}
+
+			subject_modifier = {
+				embarkation_cost_mult = -0.5
+				naval_movement_speed_mult = 0.25
+				no_disembark_penalty = yes
+				coastal_advantage = 10
+				development_growth_factor = 0.1
+				monthly_treasury_from_military_budget_base = 1
+			}
+			
+			flag = admin_naval_duchy_expansion_unlocked
+			flag = admin_tradeport_obligation_bonus
+			flag = admin_theme_naval
+		}
+	}
+}
+
+administrative_salary_rank = {
+	display_mode = hidden
+
+	defaults_to_highest_valid_level = yes
+
+	can_be_changed = {
+		always = no
+	}
+
+	obligation_levels = {
+		administrative_salary_rank_none = {
+			position = { 0 0 }
+			default = yes
+
+			ai_liege_desire = 0
+			ai_subject_desire = 0
+		}
+
+		administrative_salary_rank_duchy = {
+			position = { 2 0 }
+
+			parent = administrative_salary_rank_none
+			is_valid = {
+				scope:subject = {
+					any_held_title = {
+						is_noble_family_title = no
+						tier = tier_duchy
+					}
+				}
+			}
+
+			ai_liege_desire = 3
+			ai_subject_desire = 3
+
+			subject_modifier = {
+				monthly_treasury_from_salary_budget_base = 0.75
+			}
+		}
+		administrative_salary_rank_kingdom = {
+			position = { 3 0 }
+
+			parent = administrative_salary_rank_duchy
+			is_valid = {
+				scope:subject = {
+					highest_held_title_tier = tier_kingdom
+				}
+			}
+
+			ai_liege_desire = 4
+			ai_subject_desire = 4
+
+			subject_modifier = {
+				monthly_treasury_from_salary_budget_base = 1.0
+			}
+		}
+		administrative_salary_rank_empire = {
+			position = { 4 0 }
+
+			parent = administrative_salary_rank_kingdom
+
+			ai_liege_desire = 5
+			ai_subject_desire = 5
+
+			is_valid = {
+				scope:subject = {
+					highest_held_title_tier = tier_empire
+					is_landless_ruler = no
+				}
+			}
+			subject_modifier = {
+				monthly_treasury_from_salary_budget_base = 2.0
+			}
+		}
+	}
+}

--- a/common/subject_contracts/contracts/japan_administrative.txt
+++ b/common/subject_contracts/contracts/japan_administrative.txt
@@ -1,0 +1,299 @@
+﻿japan_administrative_obligations = {
+	obligation_levels = {
+		default = {
+			levies = {
+				value = 0.1
+			}
+
+			tax = {
+				value = 0.1
+			}
+		}
+	}
+}
+
+### brief: administrative_themes
+# This is referenced in code. 
+#
+japan_administrative_provinces = {
+	display_mode = radiobutton
+	is_shown = {
+		scope:subject.primary_title.tier >= tier_county
+	}
+	obligation_levels = {
+		japan_administrative_province_standard = {
+			default = yes
+			position = { 0 0 }
+			icon = "gfx/interface/icons/celestial_administration_types/icon_standard_administration.dds"
+			gui_tags = { civilian }
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:subject = { is_ai = yes }
+					}
+					add = 1
+					
+					# Cautious AI should tend to have a minor bias towards the default
+					if = {
+						limit = {
+							scope:liege = { ai_has_cautious_personality = yes }
+						}
+						add = 1
+					}
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.7 0.7 0.7 1.0 }
+			
+			enable_title_maa = no
+			
+			flag = japan_administrative_province_standard
+		}
+		japan_administrative_province_trade = {
+			position = { 1 0 }
+			icon = "gfx/interface/icons/celestial_administration_types/icon_industrial_administration.dds"
+			gui_tags = { civilian }
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:subject = {
+							is_ai = yes
+							OR = {
+								has_trait = education_stewardship
+								stewardship >= very_high_skill_rating
+							}
+						}
+					}
+					add = 2
+					
+					# Economical AI wants more of civic vassals
+					if = {
+						limit = {
+							scope:liege = { ai_has_builder_or_pious_builder_personality = yes }
+						}
+						add = 1
+					}
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.2 0.2 0.7 1.0 }
+			
+			is_valid = {
+				trigger_if = {
+					limit = { exists = this }
+					# Only for direct vassals of the top liege
+					scope:liege.top_liege = this
+				}
+				# There can only be a limited number of industries at a time
+				custom_tooltip = {
+					text = japan_administrative_province_trade_amount_desc
+					OR = {
+						scope:liege = {
+							any_vassal = {
+								count < japan_administrative_province_trade_max_value
+								vassal_contract_has_flag = japan_administrative_province_trade
+							}
+						}
+						scope:subject = {
+							OR = {
+								vassal_contract_has_flag = japan_administrative_province_trade
+								any_sub_realm_county = { is_coastal_county = yes } # Is a coastal province
+							}
+						}
+					}
+				}
+			}
+
+			tax_factor = 0.25
+			enable_title_maa = no
+
+			subject_modifier = {
+				development_growth_factor = 0.15
+				build_gold_cost = -0.1
+				build_speed = -0.2
+			}
+			
+			flag = admin_ai_is_builder
+			flag = japan_administrative_province_trade
+			flag = obligation_high_taxes
+		}
+		japan_administrative_province_military = {
+			position = { 0 1 }
+			icon = "gfx/interface/icons/celestial_administration_types/icon_military_administration.dds"
+			gui_tags = { military }
+			
+			ai_liege_desire = {
+				value = 0
+				if = {
+					limit = {
+						scope:subject = {
+							is_ai = yes
+							OR = {
+								has_trait = education_martial
+								martial >= very_high_skill_rating
+								primary_title = {
+									any_owned_title_maa_regiment = { count >= 3 }
+								}
+								any_sub_realm_county = { # Is a border province
+									any_neighboring_county = { holder.top_liege != scope:subject.top_liege }
+								}
+							}
+						}
+					}
+					add = 2
+					
+					# Preference for vassals along the border
+					if = {
+						limit = {
+							scope:subject = {
+								any_sub_realm_county = {
+									any_neighboring_county = { holder.top_liege != scope:subject.top_liege }
+								}
+							}
+						}
+						add = 3
+					}
+					
+					# Warlike AI wants more military vassals
+					if = {
+						limit = {
+							scope:liege = { ai_has_warlike_personality = yes }
+						}
+						add = 1
+					}
+				}
+			}
+			ai_subject_desire = 0
+			
+			score = 0
+			color = { 0.7 0.2 0.2 1.0 }
+			
+			is_valid = {
+				trigger_if = {
+					limit = { exists = this }
+					# Only for direct vassals of the top liege
+					scope:liege.top_liege = this
+				}
+				# There can only be a limited number of militaries at a time
+				custom_tooltip = {
+					text = japan_administrative_province_military_amount_desc
+					OR = {
+						scope:liege = {
+							any_vassal = {
+								count < japan_administrative_province_military_max_value
+								vassal_contract_has_flag = japan_administrative_province_military
+							}
+						}
+						scope:subject = { vassal_contract_has_flag = japan_administrative_province_military }
+					}
+				}
+			}
+
+			levies_factor = 0.5
+			
+			subject_modifier = {
+				development_growth_factor = -0.2
+				monthly_county_control_growth_factor = 0.1
+				fort_level = 1
+				defender_advantage = 2
+				men_at_arms_maintenance = -0.15
+			}
+			
+			flag = japan_administrative_province_military
+			flag = japan_administrative_military_appointment
+			flag = obligation_high_levies
+		}
+	}
+}
+
+japan_administrative_salary = {
+	display_mode = tree
+	is_shown = {
+		scope:subject.primary_title.tier >= tier_duchy
+	}
+	obligation_levels = {
+		salary_very_low = {
+			position = { 0 2 }
+
+			subject_modifier = {
+				subject_salary_expense_treasury_mult = -0.5
+				subject_salary_income_gold_mult = -0.5
+			}
+
+			ai_liege_desire = 1
+			ai_subject_desire = 5
+
+			subject_opinion = -25
+
+			score = -2
+		}
+		salary_low = {
+			parent = salary_very_low
+			position = { 1 2 }
+
+			subject_modifier = {
+				subject_salary_income_gold_mult = -0.25
+
+			}
+
+			ai_liege_desire = 2
+			ai_subject_desire = 4
+
+			subject_opinion = -15
+
+			score = 1
+		}
+		salary_medium = {
+			parent = salary_low
+			default = yes
+			position = { 2 2 }
+
+			subject_modifier = {
+
+			}
+
+			ai_liege_desire = 3
+			ai_subject_desire = 3
+
+			score = 0
+		}
+		salary_high = {
+			parent = salary_medium
+			position = { 3 2 }
+
+			subject_modifier = {
+				subject_salary_income_gold_mult = 0.25
+			}
+
+			ai_liege_desire = 4
+			ai_subject_desire = 2
+
+			subject_opinion = 5
+
+			score = 1
+		}
+		salary_very_high = {
+			parent = salary_high
+			position = { 4 2 }
+
+			subject_modifier = {
+				subject_salary_income_gold_mult = 0.5
+			}
+
+			ai_liege_desire = 5
+			ai_subject_desire = 1
+
+			subject_opinion = 10
+
+			score = 2
+		}
+	}
+}

--- a/common/subject_contracts/contracts/japan_administrative.txt
+++ b/common/subject_contracts/contracts/japan_administrative.txt
@@ -19,6 +19,7 @@ japan_administrative_provinces = {
 	display_mode = radiobutton
 	is_shown = {
 		scope:subject.primary_title.tier >= tier_county
+		scope:subject = { is_landless_ruler = no } #Unop A landless ex-governor must not keep an administration theme
 	}
 	obligation_levels = {
 		japan_administrative_province_standard = {

--- a/common/subject_contracts/contracts/japan_administrative.txt
+++ b/common/subject_contracts/contracts/japan_administrative.txt
@@ -89,9 +89,9 @@ japan_administrative_provinces = {
 			
 			is_valid = {
 				trigger_if = {
-					limit = { exists = this }
+					limit = { exists = scope:liege } #Unop `this` is none here; the direct-vassal guard must reference the contract liege
 					# Only for direct vassals of the top liege
-					scope:liege.top_liege = this
+					scope:liege.top_liege = scope:liege
 				}
 				# There can only be a limited number of industries at a time
 				custom_tooltip = {
@@ -179,9 +179,9 @@ japan_administrative_provinces = {
 			
 			is_valid = {
 				trigger_if = {
-					limit = { exists = this }
+					limit = { exists = scope:liege } #Unop `this` is none here; the direct-vassal guard must reference the contract liege
 					# Only for direct vassals of the top liege
-					scope:liege.top_liege = this
+					scope:liege.top_liege = scope:liege
 				}
 				# There can only be a limited number of militaries at a time
 				custom_tooltip = {


### PR DESCRIPTION
Fixes #498

When an Administrative noble family that became a governor later loses the governorship and turns into a landless ruler, it keeps its administration theme. On `admin_theme_military` this keeps generating a military budget the landless family can never receive.

The group `administrative_themes.is_shown` only checks `primary_title.tier >= tier_duchy`. A landless ex-governor's primary title falls back to its Noble Family title, which for Administrative is duchy-tier, so the check still passes and the theme persists. Meritocratic and Celestial don't hit this (county-tier NF title and/or an explicit landless guard).

Adding `scope:subject = { is_landless_ruler = no }` to the group `is_shown` — mirroring how Celestial already excludes landless rulers — drops every administration theme/obligation once the family is no longer a landed governor, independent of the title-tier coincidence.