### PR TITLE
Improve Claude skills and agents

### DIFF
--- a/.claude/skills/unop-import-steam-comments/SKILL.md
+++ b/.claude/skills/unop-import-steam-comments/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[count|--since YYYY-MM-DD] [main|suggestions] [identity]"
 
 # Import Unop Steam Comments as GitHub Issues
 
-Scan recent comments on the Unop Steam Workshop page or its "Fix suggestions" discussion, filter to bug reports, group multi-post threads, reconcile against existing issues, and open a GitHub issue for each new bug, or append newly-appeared follow-up posts as comments on an issue that already exists.
+Scan recent comments on the Unop Steam Workshop page or its "Fix suggestions" discussion, filter to bug reports, split and assemble them into threads, reconcile against existing issues, and open a GitHub issue for each new bug, or append newly-appeared follow-up posts as comments on an issue that already exists.
 
 This skill runs **autonomously**, without asking for approval. Any human gates belong to the calling workflow, not here. It reports a summary at the end.
 
@@ -14,8 +14,10 @@ This skill runs **autonomously**, without asking for approval. Any human gates b
 
 - **Steam page (main)**: <https://steamcommunity.com/sharedfiles/filedetails/?id=2871648329>, the mod's Workshop page comment stream.
 - **Steam page (suggestions)**: <https://steamcommunity.com/workshop/filedetails/discussion/2871648329/4697908845434539387/>, the dedicated "Fix suggestions" discussion thread.
-- **Maintainer**: Steam users `Kazarion` and `pharaox`, identify by author username. Maintainer posts are not bug reports themselves but may anchor a thread.
-- **Thread**: One bug report's worth of posts. Steam shows posts flat, so a thread is inferred from chronology and content: typically a user's bug post, a maintainer reply asking for details, then the same user's clarification.
+- **Maintainer**: Steam users `Kazarion` and `pharaox`, identify by author username. Maintainer comments are not bug reports themselves but may anchor a thread.
+- **Comment**: a single Steam comment, with one author and timestamp. Unqualified, "comment" always means this; a GitHub issue comment is always qualified, as a *follow-up comment* or *issue comment*.
+- **Post**: a logical part of a comment about one distinct bug. A comment contains one or more posts. Posts are the unit the rest of the workflow handles.
+- **Thread**: one bug report's worth of posts. Steam shows comments flat, so a thread is inferred from chronology and content: typically a user's bug report, a maintainer reply asking for details, then the same user's clarification.
 - **Marker**: A machine-greppable HTML comment placed on each filed post, of the form `<!-- steam-comment: <author> @ <YYYY-MM-DD HH:MM> -->`. The OP's marker lives in the issue body; each follow-up post's marker lives in its own issue comment. Markers are the per-post dedup key across runs. See **Marker Format**.
 - **Result file**: `tmp/steam-import-<source>-<YYYY-MM-DD-HHMM>.md`, written at the end of each run. Records which issues were created and updated, the outcome of every scanned post, and the Steam acknowledgements. See **Result File**.
 - **GitHub repo**: `ProZeratul/CrusaderKings3UnofficialPatch`. Use the `gh` CLI for all GitHub operations.
@@ -33,8 +35,8 @@ This skill runs **autonomously**, without asking for approval. Any human gates b
 All arguments are optional and order-independent.
 
 - **Scope**, one of:
-  - `<count>`: integer, scan the most recent N posts. Default `20`.
-  - `--since YYYY-MM-DD`: scan posts on or after this date. Overrides `<count>`.
+  - `<count>`: integer, scan the most recent N comments. Default `20`.
+  - `--since YYYY-MM-DD`: scan comments on or after this date. Overrides `<count>`.
 - **Source**, one of: `main` (default) or `suggestions`.
 - **Identity**: the role this skill posts as on follow-up comments. Default `steam-importer`.
 
@@ -49,13 +51,13 @@ Examples: `30`, `main 30`, `suggestions`, `--since 2026-04-01 suggestions`, `50 
 - **Add the post marker** to every issue and follow-up comment. The marker is what prevents duplicates on the next run.
 - **Don't close existing issues, change their labels, or edit their bodies.** You may only create new issues and append follow-up comments to issues that already carry a matching marker.
 - **Don't modify the Steam page.** Steam is read-only here.
-- **Quote the Steam comment text verbatim.** Do not paraphrase, translate, or "fix" the user's wording.
+- **Quote the Steam text verbatim.** Do not paraphrase, translate, or "fix" the user's wording.
 - If a single comment reports multiple distinct bugs, **file one issue per bug**, don't bundle them.
   - Title and quote each issue to its single bug; don't repeat the full comment.
   - Give each split its own marker, suffixed ` #<n>` numbered `1`, `2`, `3` in the order the bugs appear in the comment, so every split is uniquely keyed. See **Marker Format**.
 - If a comment links to an image, fetch it, confirm relevance, and attach it to the issue. See **Fetching Images**. If an image-only follow-up can't be fetched or isn't relevant, don't file an issue.
 - **Skip on positive evidence it's handled:** a maintainer reply links to a GitHub issue, or attributes the report to a stale mod version that has since shipped.
-- **Take the fetch result at face value** Trust what the fetch returns, including an empty result; don't widen the scope to second-guess it.
+- **Take the fetch result at face value.** Trust what the fetch returns, including an empty result; don't widen the scope to second-guess it.
 - **Give up on rate limits.** If a Steam or GitHub call hits a rate limit, stop and report it; don't retry or work around it.
 
 ## Workflow
@@ -77,19 +79,23 @@ Output is a JSON array on stdout, newest-first; each item has `id`, `ts`, `date_
 
 **Fallback**: if the script fails or its output looks structurally wrong, `curl` the endpoints in **Fetching URLs** and parse the `commentthread_comment` blocks with a small `python3` heredoc using the per-comment fields documented there. Note the failure in the final report so the script can be fixed afterwards.
 
-### 3. Group into Threads
+### 3. Split Comments into Posts
 
-Steam posts are flat. Reconstruct threads by walking the posts in chronological order:
+A single comment may cover more than one distinct bug: it may report several new bugs, or contain follow-ups to several existing issues, often citing each as `#N`. Split each comment into one post per distinct bug. Every post inherits the comment's author and timestamp; when a comment yields more than one post they share one `<author> @ <date>` and stay unique through the ` #<n>` marker suffix; see **Marker Format**.
+
+### 4. Group into Threads
+
+Steam comments are flat. Reconstruct threads by walking the posts in chronological order:
 
 1. A non-maintainer post starts a new candidate thread.
 2. A maintainer post attaches to the most recent candidate thread only if it plausibly replies to it.
 3. A later post by the same non-maintainer user attaches to their most recent thread if its content continues the same topic.
 
-The thread's OP is the first non-maintainer post. Each later post gets its own marker built from its own author and date.
+The thread's OP is the first non-maintainer post. Each post carries its own marker built from its comment's author and date.
 
 If a maintainer post stands alone with no preceding user post in scope, drop it; it's a release note or unrelated reply.
 
-### 4. Classify Each Thread
+### 5. Classify Each Thread
 
 Decide one of two outcomes per thread:
 
@@ -108,24 +114,29 @@ Decide one of two outcomes per thread:
 
 Anything that could be a bug but you can't confirm counts as **Bug**; file it, don't drop it. Only the edge cases mentioned in **Guidelines** should be skipped despite looking like bugs.
 
-### 5. Reconcile Against GitHub
+### 6. Reconcile Against GitHub
 
-Build the marker map once per run, passing the oldest post date in scope:
+Build the marker map once per run, passing the oldest comment date in scope:
 
 ```shell
-.claude/skills/unop-import-steam-comments/scripts/build_steam_issue_map.py --since <oldest post date>
+.claude/skills/unop-import-steam-comments/scripts/build_steam_issue_map.py --since <oldest comment date>
 ```
 
 It maps each marker's inner text, `<author> @ <date>`, to its issue number. See **Building the Issue Map**.
 
-Match each bug thread by **any** of its posts, not only the OP, since the OP is often older than the scan window while a later filed post still falls inside it. A post is already filed when a key starts with `<author> @ <date>`; same-minute posts and multi-bug splits add a ` #<n>` suffix.
+Find each bug thread's issue:
 
-- **No post matches**: the thread is new. Create an issue, step 6a.
-- **A post matches issue N**: the thread belongs to issue N. Append every post not yet mapped as a follow-up comment, step 6b. Don't reopen a closed issue. If all posts already match, do nothing.
+- A post that cites an existing issue `#N` belongs to that issue.
+- Otherwise match by the map: a post is already filed when a key starts with its `<author> @ <date>`; comments in the same minute and multi-bug splits add a ` #<n>` suffix. Match a thread by **any** of its posts, not only the OP, since the OP is often older than the scan window while a later filed post still falls inside it.
 
-### 6. File Issues and Post Follow-up Comments
+Then:
 
-#### 6a. Create a new issue
+- **No issue found**: the thread is new. Create an issue, step 7a.
+- **Issue N found**: append every post not yet on it as a follow-up comment, step 7b. Don't reopen a closed issue. If all its posts are already there, do nothing.
+
+### 7. File Issues and Post Follow-up Comments
+
+#### 7a. Create a new issue
 
 Create the issue with the **Issue Template**. Its title is a short imperative summary of the bug. Apply the `steam` label.
 
@@ -138,11 +149,11 @@ EOF
 )"
 ```
 
-Then post each follow-up post in the thread as its own comment, step 6b.
+Then post each follow-up post in the thread as its own follow-up comment, step 7b.
 
-#### 6b. Append follow-up comments
+#### 7b. Append follow-up comments
 
-For each follow-up post, in chronological order, post one comment with the **Follow-up Comment Template**: verbatim text, the author/date header, and the post's own marker.
+For each follow-up post, in chronological order, post one follow-up comment with the **Follow-up Comment Template**: verbatim text, the author/date header, and the post's own marker.
 
 ```shell
 gh issue comment <N> --repo ProZeratul/CrusaderKings3UnofficialPatch --body "$(cat <<'EOF'
@@ -157,7 +168,7 @@ EOF
 
 Leave the issue's labels unchanged.
 
-### 7. Write the Result File and Report
+### 8. Write the Result File and Report
 
 Write `tmp/steam-import-<source>-<YYYY-MM-DD-HHMM>.md`, creating `tmp/` if needed. Format in **Result File**.
 
@@ -178,7 +189,7 @@ The issue body holds only the OP post and the OP marker. Follow-up posts go in s
 ```markdown
 **Reported on Steam by `<OP author>` on `<OP date>`** (<link>).
 
-> <verbatim OP comment text, blockquoted; preserve line breaks>
+> <verbatim OP post text, blockquoted; preserve line breaks>
 
 <!-- steam-comment: <OP author> @ <OP date> -->
 ```
@@ -187,7 +198,7 @@ The marker must be the last line of the body and must match the format exactly.
 
 ### Follow-up Comment Template
 
-One comment per follow-up post, each carrying its own post marker:
+One comment per follow-up post, each carrying its own marker:
 
 ```markdown
 **<identity>:** Follow-up by `<author>` on `<date>`:
@@ -225,7 +236,7 @@ updated: [512]
 ```
 ````
 
-One bullet per scanned post, marker first, then `created N`, `updated N`, or `skipped, <reason>`. One `bbcode` block per Steam comment to post: only created issues are acknowledged, at most 4 issues per block to stay under Steam's 1000-character cap, each block headed with only that block's reporters.
+One bullet per scanned post, marker first, then `created N`, `updated N`, or `skipped, <reason>`. One `bbcode` block per Steam acknowledgement comment: only created issues are acknowledged, at most 4 issues per block to stay under Steam's 1000-character cap, each block headed with only that block's reporters.
 
 ### Fetching URLs
 
@@ -272,7 +283,7 @@ The album hash and image hash differ. Guessing `i.imgur.com/<album-hash>.jpg` re
 - `<author>`: Steam username verbatim, without any `[developer]` tag.
 - Date in 24-hour ISO-ish form, single space between date and time.
 - One marker per post: the OP's marker in the issue body, each follow-up's marker in its own comment.
-- When one `<author> @ <date>` would otherwise map to more than one issue, append ` #<n>` to each marker to keep them unique, numbered `1`, `2`, `3`: in chronological order for multiple posts in the same minute, or in order of appearance for multiple bugs split from a single post. When looking a post up in the issue map, treat a key that starts with `<author> @ <date>` as a match.
+- When one `<author> @ <date>` would otherwise map to more than one issue, append ` #<n>` to each marker to keep them unique, numbered `1`, `2`, `3`: in chronological order for multiple comments in the same minute, or in order of appearance for multiple posts split from a single comment. When looking a post up in the issue map, treat a key that starts with `<author> @ <date>` as a match.
 
 ### Building the Issue Map
 
@@ -314,7 +325,7 @@ EOF
 # Scan the 50 most recent comments on the main page
 /unop-import-steam-comments 50
 
-# Scan the suggestions thread, last 30 posts
+# Scan the suggestions thread, last 30 comments
 /unop-import-steam-comments 30 suggestions
 
 # Scan everything since a specific date on the suggestions thread


### PR DESCRIPTION
* Improve the `improve-steam-comments` skill to split Steam comments into logical posts that are grouped into threads independently