### PR TITLE
Fix peasant_leader trait swap when remaining landless after winning separatist uprising

### DIFF
--- a/common/casus_belli_types/07_ep3_wars.txt
+++ b/common/casus_belli_types/07_ep3_wars.txt
@@ -6052,11 +6052,17 @@ ep3_laamp_peasant_war = {
 				save_scope_as = old_title
 			}
 			show_pow_release_message_effect = yes
-			#set this to not display the event to keep playing as landless
-			set_variable = became_landed_through_separatist_uprising_var
-			#swap the peasant trait for the better one 
-			remove_trait = peasant_leader
-			add_trait = populist_leader
+			#Unop only set the variable and swap the trait when actually becoming landed
+			if = {
+				limit = {
+					NOT = { has_variable = ep3_laamp_peasant_war_remain_laamp }
+				}
+				#set this to not display the event to keep playing as landless
+				set_variable = became_landed_through_separatist_uprising_var
+				#swap the peasant trait for the better one
+				remove_trait = peasant_leader
+				add_trait = populist_leader
+			}
 			if = {
 				limit = {
 					has_variable = ep3_laamp_peasant_war_remain_laamp


### PR DESCRIPTION
Fixes #528

**fixer:** In `ep3_laamp_peasant_war`'s `on_victory`, the swap of the levelable `peasant_leader` trait for `populist_leader` ran unconditionally on the attacker. When the player chose to aid the peasants but stay landless (`ep3_laamp_peasant_war_remain_laamp` set), this still stripped `peasant_leader` — their only way to level it via these contracts — even though the rest of `on_victory` already gates landed-vs-landless behavior on that variable.

The fix wraps the two trait lines in an `if` gated on `NOT = { has_variable = ep3_laamp_peasant_war_remain_laamp }`, so the swap only happens when the player actually becomes landed.

Left `set_variable = became_landed_through_separatist_uprising_var` ungated: it only suppresses the `ep3_laamps.0800` "you became landed" event, whose trigger requires `is_landed = yes`; on a remain-landless win the player isn't landed, so that event never fires regardless — gating it would be an unnecessary change.