### PR TITLE
Fix ep3_contract_event.0007 city buy assigning bought artifact to merchant

### DIFF
--- a/events/dlc/ep3/ep3_contract_events.txt
+++ b/events/dlc/ep3/ep3_contract_events.txt
@@ -1957,7 +1957,7 @@ ep3_contract_event.0007 = {
 		}
 		change_treasure_type = yes
 		scope:newly_created_artifact = {
-			set_owner = scope:local_1
+			set_owner = root #Unop the player bought the artifact, so it should go to them, not back to the merchant
 		}
 
 		stress_impact = {


### PR DESCRIPTION
Fixes #404

**fixer:** In the treasure-hunt contract resolution event `ep3_contract_event.0007`, the city branch reveals a second artifact that the merchant offers to sell, and the "I'll take everything" option (`city_city`) has the player pay for it. But after `change_treasure_type` correctly transfers it to the player, the option re-assigned it back to the merchant with `set_owner = scope:local_1`, so the player paid and got nothing. Changed that to `set_owner = root` so the bought artifact ends up with the player.