### PR TITLE
Remove Siberian permafrost modifier when conquering the North via Expand the Steppe

### DIFF
--- a/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
+++ b/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
@@ -6247,22 +6247,12 @@ expanding_steppe_effect = {
 				REGION = dlc_mpo_steppe_siberia_further_expansion
 			}
 			#Unop the permafrost modifier loc promises it is removed by conquering the whole North via this decision, but the removal was never implemented
-			#Unop the permafrost modifier loc promises it is removed by conquering the whole North via this decision, but the removal was never implemented
+			custom_tooltip = {
+				text = unop_remove_permafrost_modifiers
+			}
 			hidden_effect = {
 				every_county_in_region = {
 					region = mpo_region_permafrost
-					if = {
-						limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
-						remove_county_modifier = mpo_siberian_permafrost_modifier
-					}
-					else_if = {
-						limit = { has_county_modifier = mpo_siberian_permafrost_modifier_bad }
-						remove_county_modifier = mpo_siberian_permafrost_modifier_bad
-					}
-				}
-			}
-				region = mpo_region_permafrost
-				hidden_effect = {
 					if = {
 						limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
 						remove_county_modifier = mpo_siberian_permafrost_modifier

--- a/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
+++ b/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
@@ -6246,6 +6246,18 @@ expanding_steppe_effect = {
 				SUB_REGION = central
 				REGION = dlc_mpo_steppe_siberia_further_expansion
 			}
+			#Unop the permafrost modifier loc promises it is removed by conquering the whole North via this decision, but the removal was never implemented
+			every_county_in_region = {
+				region = mpo_region_permafrost
+				if = {
+					limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
+					remove_county_modifier = mpo_siberian_permafrost_modifier
+				}
+				else_if = {
+					limit = { has_county_modifier = mpo_siberian_permafrost_modifier_bad }
+					remove_county_modifier = mpo_siberian_permafrost_modifier_bad
+				}
+			}
 		}
 		# East
 		scope:dlc_mpo_steppe_hexi_tarim_expansion = {

--- a/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
+++ b/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
@@ -6249,13 +6249,15 @@ expanding_steppe_effect = {
 			#Unop the permafrost modifier loc promises it is removed by conquering the whole North via this decision, but the removal was never implemented
 			every_county_in_region = {
 				region = mpo_region_permafrost
-				if = {
-					limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
-					remove_county_modifier = mpo_siberian_permafrost_modifier
-				}
-				else_if = {
-					limit = { has_county_modifier = mpo_siberian_permafrost_modifier_bad }
-					remove_county_modifier = mpo_siberian_permafrost_modifier_bad
+				hidden_effect = {
+					if = {
+						limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
+						remove_county_modifier = mpo_siberian_permafrost_modifier
+					}
+					else_if = {
+						limit = { has_county_modifier = mpo_siberian_permafrost_modifier_bad }
+						remove_county_modifier = mpo_siberian_permafrost_modifier_bad
+					}
 				}
 			}
 		}

--- a/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
+++ b/common/scripted_effects/09_dlc_mpo_scripted_effects.txt
@@ -6247,7 +6247,20 @@ expanding_steppe_effect = {
 				REGION = dlc_mpo_steppe_siberia_further_expansion
 			}
 			#Unop the permafrost modifier loc promises it is removed by conquering the whole North via this decision, but the removal was never implemented
-			every_county_in_region = {
+			#Unop the permafrost modifier loc promises it is removed by conquering the whole North via this decision, but the removal was never implemented
+			hidden_effect = {
+				every_county_in_region = {
+					region = mpo_region_permafrost
+					if = {
+						limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
+						remove_county_modifier = mpo_siberian_permafrost_modifier
+					}
+					else_if = {
+						limit = { has_county_modifier = mpo_siberian_permafrost_modifier_bad }
+						remove_county_modifier = mpo_siberian_permafrost_modifier_bad
+					}
+				}
+			}
 				region = mpo_region_permafrost
 				hidden_effect = {
 					if = {

--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -303,3 +303,8 @@
  domicile_building_parameter_domicile_increased_wet_nurse_aptitude_4: "[GetCourtPositionType('wet_nurse_court_position').GetName()] [aptitude|E]: #P +[EmptyScope.ScriptValue('domicile_increased_wet_nurse_aptitude_4_value')|0]#!"
  domicile_building_parameter_domicile_increased_wet_nurse_aptitude_5: "[GetCourtPositionType('wet_nurse_court_position').GetName()] [aptitude|E]: #P +[EmptyScope.ScriptValue('domicile_increased_wet_nurse_aptitude_5_value')|0]#!"
  domicile_building_parameter_domicile_increased_wet_nurse_aptitude_6: "[GetCourtPositionType('wet_nurse_court_position').GetName()] [aptitude|E]: #P +[EmptyScope.ScriptValue('domicile_increased_wet_nurse_aptitude_6_value')|0]#!"
+ # This region doesn't have a name in game currently, but as we want to highligth the region to the player we need to link it and have a proper name
+ mpo_region_permafrost: "Permafrost"
+ # Based on all_permafrost_will_clear
+ unop_remove_permafrost_modifiers: "All [counties|E] in the [GetGeographicalRegion('mpo_region_permafrost').GetName] [region|E]#! will lose [GetModifier('mpo_siberian_permafrost_modifier').GetNameWithTooltip] and [GetModifier('mpo_siberian_permafrost_modifier_bad').GetNameWithTooltip] [modifiers|E]"
+


### PR DESCRIPTION
Fixes #534

**fixer:** The `mpo_siberian_permafrost_modifier(_bad)` loc states the penalty is removed "after conquering the whole North by the expand_the_steppe_decision for the dlc_mpo_steppe_siberia_further_expansion region", but the Siberia branch of `expanding_steppe_effect` only added the region to the steppe situation and never removed the modifier.

Added the removal in that branch: iterate `every_county_in_region = { region = mpo_region_permafrost }` (the same region the modifier is added to at game start) and remove whichever variant (`mpo_siberian_permafrost_modifier` or `_bad`) is present, mirroring the existing removal idiom in vanilla `00_decisions_effects.txt`.

In-game verification needed: complete the Siberia expansion (`completely_controls_region = dlc_mpo_steppe_siberia_further_expansion`) and confirm the permafrost modifiers are removed from the permafrost counties.