### PR TITLE
Gate faltering_heart xp in stress_threshold.0001 by stress level

### DIFF
--- a/events/stress_events/stress_threshold_events.txt
+++ b/events/stress_events/stress_threshold_events.txt
@@ -1,0 +1,17534 @@
+﻿namespace = stress_threshold
+
+###############
+# Hidden Stress Framework Events
+#	stress_threshold.0001 — Fired when character crosses a stress threshold. Checks if a Mental Break event can be fired and, if yes, does so.
+#	stress_threshold.0002 — As above, but for characters in prison (they get events from a different pool, for obvious reasons).
+#	stress_threshold.0005 — Fired 5 (or 8, with a perk) years from the last Mental Break a character received. Re-fires either 0001 or 0002, as appropriate.
+#	stress_threshold.0010 — Sends a toast to players when they gain a Stress Level.
+#	stress_threshold.0400 — Fired when a character reaches 400 Stress. Resets the normal 5-year cooldown for Mental Breaks and immediately fires ones.
+#
+# Level 1 Mental Breaks
+#	stress_threshold.1001 — Dark Thoughts: Suffering from overwhelming feelings of guilt.
+#	stress_threshold.1011 — Wanton Desires: Distracted by lavacious fantasies.
+#	stress_threshold.1501 —	Nothing Matters: Depression-like disinterest in everything.
+#	stress_threshold.1502 — Resentment: Increasingly frustrated and irritated with everyone.
+#	stress_threshold.1503 —	Emptiness Inside: Ennui
+#	stress_threshold.1504 —	Endless Toil: Suffering from burnout.
+#	stress_threshold.1601 — Spinning Thoughts [Generic]: Overwhelmed by the number of things to keep track of.
+#	stress_threshold.1602 —	Swirling Emotions [Generic]: Struggling to keep emotions in-check.
+#	stress_threshold.1701 — Prior Error: your personality has caused friction elsewhere.
+#	stress_threshold.1711 — Too Busy: everything just seems to pile up on you these days.
+#	stress_threshold.1721 — Impostor Syndrome: clearly you just aren't good enough for your rank!
+#	stress_threshold.1731 — No Time for Myself: your limited time to yourself is intruded on.
+#
+# Level 2 Mental Breaks
+#	stress_threshold.2001 —	Ingratitude [Generic]: Annoyed with lack of appreciation.
+#	stress_threshold.2101 —	Unwelcome [Generic]: Feels like a stranger in their own castle.
+#	stress_threshold.2201 — Boiling Anger [Generic]: Lashes out at powerful vassal.
+#	stress_threshold.2202 — Boiling Anger [Response Event]: Vassal react to liege's outburst.
+#	stress_threshold.2301 —	Growing Need: you just want to drop everything and reengage with an old passion.
+#	stress_threshold.2311 —	Haunted by the Past: you find yourself dwelling on the mistakes of yesteryear.
+#	stress_threshold.2321 — Befuddled by Court: it feels like everything you do, others take advantage of.
+#	stress_threshold.2331 —	Estranged Authority: your brevity and certainty is mistaken for ruthlessness.
+#	stress_threshold.2341 —	Shirked Duty: you half-arse your noble duties, and it shows.
+#	stress_threshold.2351 —	Improprietous Remarks: increasingly frayed, you respond to a petitioner brashly.
+#
+# Level 3 Mental Breaks
+#	stress_threshold.3001 —	The Voices [Generic]: Begin hearing voices that aren't real.
+#	stress_threshold.3101 —	Wrongdoing [Generic]: Weak grasp on reality leads to paranoia-like mania.
+#	stress_threshold.3201 —	Overload [Generic]: Shuts down from overload, vassal may offer to help.
+#	stress_threshold.3301 —	Heart Ache [Generic]: Dies from heart attack.
+#	stress_threshold.3401 —	Shooting the Messenger: you dramatically punish someone for giving you bad news.
+#	stress_threshold.3411 —	I am Unworthy: your impostor syndrome has become a full-blown complex.
+#	stress_threshold.3421 —	Domain of Debauchery: your holdings burn, but you're too ensconsed in hiding from your stress to care.
+
+#############################
+# Stress Threshold Manager	#
+# by Sean Hughes			#
+# 0001-0005					#
+#############################
+
+# For free characters, finds and runs an appropriate 'stress_threshold' event based on a character's traits and stress levels.
+stress_threshold.0001 = {
+	hidden = yes
+
+	trigger = {
+		is_imprisoned = no
+	}
+
+	immediate = {
+		if = {
+			limit = {
+				stress_level = 1
+				NOT = {
+					has_character_flag = stress_threshold_event_1_cooldown
+				}
+			}
+			if = {
+				limit = { exists = var:mental_break_deceased_character } # If the mental break was due to the death of a loved one, send special event.
+				trigger_event = { id = stress_threshold_special.1001 days = 0 }
+			}
+			else_if = {
+				limit = { # Cognitive dissonance for Rakish characters who have become Celibate
+					has_trait = rakish
+					has_trait = celibate
+				} 
+				trigger_event = { id = stress_threshold_special.2001 days = 0 }
+			}
+			else = {
+				trigger_event = { on_action = stress_threshold_level_1_event days = 0 }
+			}
+		}
+		else_if = {
+			limit = {
+				stress_level = 2
+				NOT = {
+					has_character_flag = stress_threshold_event_2_cooldown
+				}
+			}
+			if = {
+				limit = { exists = var:mental_break_deceased_character } # If the mental break was due to the death of a loved one, send special event.
+				trigger_event = { id = stress_threshold_special.1001 days = 0 }
+			}
+			else_if = {
+				limit = { # Cognitive dissonance for Rakish characters who have become Celibate
+					has_trait = rakish
+					has_trait = celibate
+				} 
+				trigger_event = { id = stress_threshold_special.2001 days = 0 }
+			}
+			else = {
+				trigger_event = { on_action = stress_threshold_level_2_event days = 0 }
+			}
+		}
+		else_if = {
+			limit = {
+				stress_level = 3
+				NOT = { has_character_flag = stress_threshold_event_3_cooldown }
+			}
+			if = {
+				limit = { exists = var:mental_break_deceased_character } # If the mental break was due to the death of a loved one, send special event.
+				trigger_event = { id = stress_threshold_special.1001 days = 0 }
+			}
+			else_if = {
+				limit = { # Cognitive dissonance for Rakish characters who have become Celibate
+					has_trait = rakish
+					has_trait = celibate
+				} 
+				trigger_event = { id = stress_threshold_special.2001 days = 0 }
+			}
+			else = {
+				trigger_event = { on_action = stress_threshold_level_3_event days = 0 } # Otherwise, send normal event.
+			}
+		}
+		else_if = {
+			limit = {
+				stress_level = 2
+				NOT = {
+					has_character_flag = stress_threshold_event_1_cooldown
+				}
+			}
+			if = {
+				limit = { exists = var:mental_break_deceased_character } # If the mental break was due to the death of a loved one, send special event.
+				trigger_event = { id = stress_threshold_special.1001 days = 0 }
+			}
+			else_if = {
+				limit = { # Cognitive dissonance for Rakish characters who have become Celibate
+					has_trait = rakish
+					has_trait = celibate
+				} 
+				trigger_event = { id = stress_threshold_special.2001 days = 0 }
+			}
+			else = {
+				trigger_event = { on_action = stress_threshold_level_1_event days = 0 }
+			}
+		}
+		else_if = {
+			limit = {
+				stress_level = 3
+				NOT = {
+					has_character_flag = stress_threshold_event_2_cooldown
+				}
+			}
+			if = {
+				limit = { exists = var:mental_break_deceased_character } # If the mental break was due to the death of a loved one, send special event.
+				trigger_event = { id = stress_threshold_special.1001 days = 0 }
+			}
+			else_if = {
+				limit = { # Cognitive dissonance for Rakish characters who have become Celibate
+					has_trait = rakish
+					has_trait = celibate
+				} 
+				trigger_event = { id = stress_threshold_special.2001 days = 0 }
+			}
+			else = {
+				trigger_event = { on_action = stress_threshold_level_2_event days = 0 }
+			}
+		}
+		else_if = {
+			limit = {
+				stress_level = 3
+				NOT = {
+					has_character_flag = stress_threshold_event_1_cooldown
+				}
+			}
+			if = {
+				limit = { exists = var:mental_break_deceased_character } # If the mental break was due to the death of a loved one, send special event.
+				trigger_event = { id = stress_threshold_special.1001 days = 0 }
+			}
+			else_if = {
+				limit = { # Cognitive dissonance for Rakish characters who have become Celibate
+					has_trait = rakish
+					has_trait = celibate
+				} 
+				trigger_event = { id = stress_threshold_special.2001 days = 0 }
+			}
+			else = {
+				trigger_event = { on_action = stress_threshold_level_1_event days = 0 }
+			}
+		}
+		else = {
+		}
+		if = {
+			limit = {
+				has_trait = faltering_heart
+				is_incapable = no
+			}
+			send_interface_message = {
+				type = msg_health_change
+				title = your_heart_beats_irregularly_feed_message_title
+				left_icon = root
+				add_trait_xp = { trait = faltering_heart track = faltering_heart value = 25 }
+			}
+			if = {
+				limit = {
+					has_trait_xp = { trait = faltering_heart track = faltering_heart value >= 100 }
+				}
+				death = { death_reason = death_heart_attack }
+			}
+		}
+	}
+}
+
+# If a character is imprisoned, we instead run this event to find an appropriate event.
+stress_threshold.0002 = {
+	hidden = yes
+
+	trigger = {
+		is_imprisoned = yes
+	}
+
+	immediate = {
+		if = {
+			limit = {
+				stress_level >= 3
+				NOT = { has_character_flag = stress_threshold_event_3_cooldown }
+			}
+			trigger_event = { on_action = stress_threshold_level_3_event_prison days = 0 }
+		}
+		else_if = {
+			limit = {
+				stress_level >= 2
+				NOR = {
+					has_character_flag = stress_threshold_event_3_cooldown
+					has_character_flag = stress_threshold_event_2_cooldown
+				}
+			}
+			trigger_event = { on_action = stress_threshold_level_2_event_prison days = 0 }
+		}
+		else_if = {
+			limit = {
+				stress_level >= 1
+				NOR = {
+					has_character_flag = stress_threshold_event_3_cooldown
+					has_character_flag = stress_threshold_event_2_cooldown
+					has_character_flag = stress_threshold_event_1_cooldown
+				}
+			}
+			trigger_event = { on_action = stress_threshold_level_1_event_prison days = 0 }
+		}
+		if = {
+			limit = {
+				has_trait = faltering_heart
+				is_incapable = no
+			}
+			if = {
+				limit = {
+					stress_level >= 3
+				}
+				send_interface_message = {
+					type = msg_health_change
+					title = your_heart_beats_irregularly_feed_message_title
+					left_icon = root
+					add_trait_xp = { trait = faltering_heart track = faltering_heart value = 25 }
+				}
+			}
+			else_if = {
+				limit = {
+					stress_level >= 2
+				}
+				send_interface_message = {
+					type = msg_health_change
+					title = your_heart_beats_irregularly_feed_message_title
+					left_icon = root
+					add_trait_xp = { trait = faltering_heart track = faltering_heart value = 15 }
+				}
+			}
+			else_if = {
+				limit = {
+					stress_level >= 1
+				}
+				send_interface_message = {
+					type = msg_health_change
+					title = your_heart_beats_irregularly_feed_message_title
+					left_icon = root
+					add_trait_xp = { trait = faltering_heart track = faltering_heart value = 5 }
+				}
+			}
+			if = {
+				limit = {
+					has_trait_xp = { trait = faltering_heart track = faltering_heart value >= 100 }
+				}
+				death = { death_reason = death_heart_attack }
+			}
+		}
+	}
+}
+
+# Cycling 5-year event for when a character is still above 100 stress, but has stabilized between stress levels ( so they still get events when not triggering new threshold events ).
+stress_threshold.0005 = {
+	hidden = yes
+
+	trigger = {
+		NOR = {
+			has_character_flag = stress_threshold_event_1_cooldown
+			has_character_flag = stress_threshold_event_2_cooldown
+			has_character_flag = stress_threshold_event_3_cooldown
+		}
+	}
+
+	immediate = {
+		if = {
+			limit = {
+				has_perk = mental_resilience_perk
+			}
+			if = {
+				limit = {
+					has_character_flag = mental_resilience_added_during_1_cooldown
+				}
+				add_character_flag = {
+					flag = stress_threshold_event_1_cooldown
+					days = 1094
+				}
+				remove_character_flag = mental_resilience_added_during_1_cooldown
+				trigger_event = {
+					id = stress_threshold.0005
+					years = 3
+				}
+			}
+			else_if = {
+				limit = {
+					has_character_flag = mental_resilience_added_during_2_cooldown
+				}
+				add_character_flag = {
+					flag = stress_threshold_event_2_cooldown
+					days = 1094
+				}
+				remove_character_flag = mental_resilience_added_during_2_cooldown
+				trigger_event = {
+					id = stress_threshold.0005
+					years = 3
+				}
+			}
+			else_if = {
+				limit = {
+					has_character_flag = mental_resilience_added_during_3_cooldown
+				}
+				add_character_flag = {
+					flag = stress_threshold_event_3_cooldown
+					days = 1094
+				}
+				remove_character_flag = mental_resilience_added_during_3_cooldown
+				trigger_event = {
+					id = stress_threshold.0005
+					years = 3
+				}
+			}
+			#Regular firing:
+			else_if = { #Should be identical to the below
+				limit = {
+					is_imprisoned = yes
+				}
+				trigger_event = {
+					id = stress_threshold.0002
+					days = 0
+				}
+			}
+			else = {
+				trigger_event = {
+					id = stress_threshold.0001
+					days = 0
+				}
+			}
+		}
+		#Regular firing:
+		else_if = { #Should be identical to the above
+			limit = {
+				is_imprisoned = yes
+			}
+			trigger_event = {
+				id = stress_threshold.0002
+				days = 0
+			}
+		}
+		else = {
+			trigger_event = {
+				id = stress_threshold.0001
+				days = 0
+			}
+		}
+	}	
+}
+
+# Sends a toast when the player gains a stress level.
+stress_threshold.0010 = {
+	hidden = yes
+
+	immediate = {
+		# Used to stop multiple stress threshold events from queuing up ontop of each other.
+		add_character_flag = {
+			flag = recently_hit_stress_threshold
+			days = 1 # Once a single day passes we remove this. This way a player's choices in a Mental Break event can still trigger another Mental Break.
+		}
+		send_interface_toast = {
+			type = msg_gained_stress_level
+			desc = stress_threshold.0010.text
+			left_icon = root
+		}
+	}
+}
+
+# Triggers when the player hits 400 stress and resets to 300.
+stress_threshold.0400 = {
+	hidden = yes
+
+	immediate = {
+		# Stop this event from firing multiple times on the same day.
+		add_character_flag = {
+			flag = recently_hit_stress_threshold
+			days = 1
+		}
+
+		send_interface_toast = {
+			type = msg_gained_stress_level
+			desc = stress_threshold.0400.toast
+			left_icon = root
+		}
+
+		remove_character_flag = stress_threshold_event_3_cooldown
+		if = {
+			limit = {
+				is_imprisoned = no
+			}
+			trigger_event = {
+				id = stress_threshold.0001
+				days = {2 3}
+			}
+		}
+		else = {
+			trigger_event = {
+				id = stress_threshold.0002
+				days = {2 3}
+			}
+		}
+		
+	}
+}
+
+# Normal Stress Events
+#	Stress Threshold events designed for when a character is free to pursue their own agendas. Most of them are heavily influenced based on personality traits.
+#	Lv1 1001-1999; Lv2 2001-2999; Lv3 3001-3999
+
+##################################################################################################################################################################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ TIER 1 STRESS EVENTS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
+##################################################################################################################################################################
+
+#############################
+# Overwhelming Guilt		#
+# by Sean Hughes			#
+# 1001						#
+#############################
+
+stress_threshold.1001 = {
+	type = character_event
+	title = stress_threshold.1001.t
+	desc = stress_threshold.1001.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain
+	}
+	left_portrait = {
+		character = root
+		animation = shame
+	}
+	
+	trigger = {
+		# Character must meet the criteria for at least two event options to qualify for this event (don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+
+			can_be_contrite = yes
+			has_trait = contrite
+			can_be_flagellant = yes
+			has_trait = flagellant
+			can_be_improvident = yes
+			has_trait = improvident
+			can_be_journaller = yes
+			has_trait = journaller
+			OR = { # While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+
+		modifier = { # Much more likely to occur if the character has a Criminal Secret they can confess.
+			AND = {
+				can_be_contrite = yes
+				any_secret = {
+					is_criminal_for = root
+				}
+			}
+			add = 50
+		}
+		modifier = { # Somewhat more likely to occur if the character can become Flagellant.
+			can_be_flagellant = yes
+			add = 10
+		}
+		modifier = { # Somewhat more likely to occur if the character can become Improvident.
+			can_be_improvident = yes
+			add = 10
+		}
+		modifier = {
+			can_be_journaller = yes
+			add = 5
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = contrite }
+				has_witnessed_stress_coping_trait = { TRAIT = flagellant }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+		# Event option set-up to determine which event options we want to offer to the player.
+		if = { # Contrite (Compelled to reveal own secrets.)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = contrite
+					can_be_contrite = yes
+				}	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { # Flagellant (Impulsively self-harms.)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = flagellant
+					can_be_flagellant = yes
+				}
+			}
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { # Improvident (Habitually over-donates to charity.)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = improvident
+					can_be_improvident = yes
+				}
+			}
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { # Journaller (Writes down thoughts in a journal as a healthy stress relief.)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = journaller
+					can_be_journaller = yes
+				}
+
+			}
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { # Substance Abuse (Alcohol or Cannabis, depending on Faith/Region.)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+				random_list = { # Which option the player gets is somewhat dependent on where they are and what their faith is.
+					50 = {
+						trigger = {
+							OR = {
+								can_be_drunkard = yes
+								has_trait = drunkard
+							}
+						}
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = {
+							OR = {
+								can_be_hashishiyah = yes
+								has_trait = hashishiyah
+							}
+						}
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# Option A: Reveal one or more secrets, major stress loss.
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_contrite
+		}
+		name = {
+			trigger = { can_be_contrite = yes }
+			text = stress_threshold.1001.contrite.gain
+		}
+		name = {
+			trigger = { has_trait = contrite }
+			text = stress_threshold.1001.contrite.effect
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = -15
+				has_trait = paranoid
+			}
+			modifier = {
+				add = 15
+				has_trait = trusting
+			}
+		}
+
+		add_trait = contrite
+		trait = contrite
+
+		contrite_get_secret_scopes_effect = yes # Get secrets before trying to reveal
+		contrite_reveal_secrets_effect = yes # Includes stress loss based on what secrets were revealed
+	}
+
+	# Option B: Wound self, medium stress loss.
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.1001.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.1001.flagellant.effect
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = -5
+				has_trait = forgiving
+			}
+			modifier = {
+				add = 15
+				has_trait = zealous
+			}
+		}
+
+		add_trait = flagellant
+		trait = flagellant
+
+		if = {
+			limit = {
+				is_ai = yes
+			}
+			random_list = { 
+				75 = {}
+				25 = { increase_wounds_effect = { REASON = whipping } }
+			}
+		}
+		else = {
+			increase_wounds_effect = { REASON = whipping }
+		}
+		add_stress = medium_stress_impact_loss
+	}
+
+	# Option C: Donate buckets of money to charity, medium stress loss.
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+			OR = {
+				is_ai = no
+				short_term_gold >= major_gold_value
+			}
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.1001.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.1001.improvident.effect
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = -15
+				has_trait = greedy
+			}
+			modifier = {
+				add = 15
+				has_trait = generous
+			}
+		}
+
+		add_trait = improvident
+		trait = improvident
+
+		remove_short_term_gold = major_gold_value
+		add_stress = medium_stress_impact_loss
+	}
+	
+	# Option D: Become drunkard, minor stress loss.
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.1001.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.1001.drunkard.effect
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 5
+				has_trait = gluttonous
+			}
+			modifier = {
+				add = 15
+				has_trait = lifestyle_reveler
+			}
+		}
+
+		trait = drunkard
+
+		if = {
+			limit = {
+				has_trait = drunkard
+			}
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}	
+		else = {
+			add_trait = drunkard
+		}
+		
+		add_stress = medium_stress_impact_loss
+	}
+
+	# Option E: Become hashishiyah, minor stress loss.
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.1001.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.1001.hashishiyah.effect
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 5
+				has_trait = gluttonous
+			}
+			modifier = {
+				add = 15
+				has_trait = lifestyle_reveler
+			}
+		}
+
+		trait = hashishiyah
+
+		if = {
+			limit = {
+				has_trait = hashishiyah
+			}
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = {
+			add_trait = hashishiyah
+		}
+
+		add_stress = medium_stress_impact_loss
+	}
+
+	# Option F: Become journaller, medium stress loss.
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1001.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1001.journaller.effect
+		}
+		ai_chance = {
+			base = 5
+			modifier = {
+				add = -15
+				has_trait = paranoid #A journal might be used as evidence against them!
+			}
+			modifier = {
+				add = 5
+				has_trait = calm
+			}
+			modifier = {
+				add = 5
+				has_trait = shy
+			}
+		}
+
+		trait = scholar
+		trait = theologian
+		
+		add_trait = journaller
+		trait = journaller
+
+		add_stress = minor_stress_impact_loss
+	}
+
+	# Option G (Always the 3rd option): Do not gain any coping traits, but major stress gain!
+	option = {
+		name = stress_threshold.1001.endure
+		add_stress = mental_break_opt_out_stress_gain
+
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 15
+				has_trait = stubborn
+			}
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+#############################
+# Desires of the Flesh		#
+# by Sean Hughes			#
+# 1011						#
+#############################
+stress_threshold.1011 = {
+	type = character_event
+	title = stress_threshold.1011.t
+	desc = stress_threshold.1011.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain
+	}
+	left_portrait = {
+		character = root
+		animation = stress
+	}
+	
+	trigger = {
+		# Character must meet the criteria for at least two event options to qualify for this event (don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+
+			can_be_rakish = yes
+			has_trait = rakish
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_do_lustful_stress_conversion = yes
+			can_be_athletic = yes
+			has_trait = athletic
+		}
+		is_adult = yes
+		NOR = {
+			has_trait = chaste
+			has_trait = celibate
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+
+		modifier = { # Much more likely if the character is Lustful
+			has_trait = lustful
+			add = 10
+		}
+		modifier = {
+			can_be_rakish = yes
+			add = 10
+		}
+		modifier = { # Somewhat more likely to occur if the character can become Reclusive.
+			can_be_reclusive = yes
+			add = 10
+		}
+		modifier = { # Somewhat more likely to occur if the character can convert to a new religion.
+			can_do_lustful_stress_conversion = yes
+			add = 10
+		}
+		modifier = {
+			can_be_athletic = yes
+			add = 5
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = athletic }
+			}
+			add = 5
+		}
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		# Event option set-up to determine which event options we want to offer to the player.
+		if = { # Rakish ( Prone to extremely wonton behavior, with the associated consequences.)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_rakish = yes
+					has_trait = rakish
+				}
+			}
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { # Reclusive ( Frequently withdrawn, risking damage to relationships.)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_reclusive = yes
+					has_trait = reclusive
+				}
+			}
+
+			add_character_flag = stress_threshold_option_reclusive
+			# Taking this option will also likely damage a relationship that the character has with someone.
+			reclusive_get_relationships_effect = yes
+
+		}
+		if = { # Religious Conversion ( No long-term consequences other than the conversion itself; that will probably be a severe enough penalty, though.)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_do_lustful_stress_conversion = yes
+			}
+
+			# Only faiths where Lustful is a sin qualify for this conversion (which is brought on by lustful thoughts).
+			hidden_effect = {
+				random_list = {
+					20 = {
+						trigger = {
+							NOT = { faith = faith:catholic }
+							NOT = { faith = faith:orthodox }
+							does_religion_exist_in_world_region_trigger = { RELIGION = faith:catholic.religion }
+						}
+						faith:catholic = { save_scope_as = new_faith }
+						add_character_flag = stress_threshold_option_conversion
+					}
+					20 = {
+						trigger = {
+							NOT = { faith = faith:orthodox }
+							NOT = { faith = faith:catholic }
+							does_religion_exist_in_world_region_trigger = { RELIGION = faith:orthodox.religion }
+						}
+						faith:orthodox = { save_scope_as = new_faith }
+						add_character_flag = stress_threshold_option_conversion
+					}
+					20 = {
+						trigger = {
+							NOT = { faith = faith:paulician }
+							does_religion_exist_in_world_region_trigger = { RELIGION = faith:paulician.religion }
+						}
+						faith:paulician = { save_scope_as = new_faith }
+						add_character_flag = stress_threshold_option_conversion
+					}
+					20 = {
+						trigger = {
+							NOT = { faith = faith:nestorian }
+							does_religion_exist_in_world_region_trigger = { RELIGION = faith:nestorian.religion }
+						}
+						faith:nestorian = { save_scope_as = new_faith }
+						add_character_flag = stress_threshold_option_conversion
+					}
+					20 = {
+						trigger = {
+							NOT = { faith = faith:karaism }
+							does_religion_exist_in_world_region_trigger = { RELIGION = faith:karaism.religion }
+						}
+						faith:karaism = { save_scope_as = new_faith }
+						add_character_flag = stress_threshold_option_conversion
+					}
+				}
+			}
+		}
+		if = {
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_athletic = yes
+					has_trait = athletic
+				}
+			}
+			add_character_flag = stress_threshold_option_athletic
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# Option A: Take a trip to the brothel, major stress loss.
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_rakish
+		}
+		name = {
+			trigger = { can_be_rakish = yes }
+			text = stress_threshold.1011.rakish.gain
+		}
+		name = {
+			trigger = { has_trait = rakish }
+			text = stress_threshold.1011.rakish.effect
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = -5
+				has_trait = shy 
+			}
+			modifier = {
+				add = -5
+				has_trait = chaste 
+			}
+			modifier = {
+				add = -15
+				has_trait = celibate 
+			}
+			modifier = {
+				add = 15
+				has_trait = lustful
+			}
+		}
+
+		trait = rakish
+		add_trait = rakish
+
+		rakish_brothel_night_effect = yes # Stress reduction is included in this effect.
+	}
+
+	option = { # Option B: Sequester yourself away and damage relationships, major stress loss.
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.1011.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.1011.reclusive.effect
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 15
+				has_trait = shy 
+			}
+			modifier = {
+				add = 5
+				has_trait = callous
+			}
+			modifier = {
+				add = -15
+				has_trait = gregarious 
+			}
+			modifier = {
+				add = -15
+				has_trait = trusting
+			}
+		}
+
+		trait = reclusive
+		add_trait = reclusive
+		reclusive_damage_relationships_effect = yes # Stress reduction is included in this effect.
+	}
+
+	option = { # Option C-1: Convert to another Faith (same Religion), medium stress loss.
+		trigger = {
+			has_character_flag = stress_threshold_option_conversion
+			faith.religion = scope:new_faith.religion
+		}
+		name = stress_threshold.1011.conversion.interfaith
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 5
+				has_trait = arbitrary 
+			}
+			modifier = {
+				add = 15
+				has_trait = fickle
+			}
+			modifier = {
+				add = -15
+				has_trait = cynical 
+			}
+			modifier = {
+				add = -15
+				has_trait = zealous
+			}
+		}
+		# Converting to a different Faith of your religion is less penalizing but also reduces less stress.
+		set_character_faith = scope:new_faith
+		if = {
+			limit = { 
+				scope:new_faith = { has_doctrine = doctrine_monotheist }
+			}
+			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
+		}
+		add_piety = medium_piety_loss
+		add_stress = medium_stress_impact_loss
+	}
+
+	option = { # Option C-2: Convert to another Faith (different Religion), massive stress loss.
+		trigger = {
+			has_character_flag = stress_threshold_option_conversion
+			faith.religion != scope:new_faith.religion
+		}
+		name = { # Special event option name if converting from an Abrahamic faith to hardline Judaism.
+			trigger = {
+				faith = {
+					has_doctrine = abrahamic_hostility_doctrine
+				}
+				scope:new_faith = faith:karaism
+			}
+			text = stress_threshold.1011.conversion.judaism
+		}		
+		name = { # Special event option name if converting from non-Christianity to Christianity.
+			trigger = {
+				faith = {
+					NOT = { religion_tag = christianity_religion }
+				}
+				scope:new_faith = {
+					religion_tag = christianity_religion
+				}
+			}
+			text = stress_threshold.1011.conversion.christianity
+		}
+		name = { # Fallback event option when converting from a non-Abrahamic faith to an Abrahamic one.
+			trigger = {
+				faith = {
+					NOT = { has_doctrine = abrahamic_hostility_doctrine }
+				}
+			}
+			text = stress_threshold.1011.conversion.intrafaith
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 5
+				has_trait = arbitrary 
+			}
+			modifier = {
+				add = 15
+				has_trait = fickle
+			}
+			modifier = {
+				add = -15
+				has_trait = cynical 
+			}
+			modifier = {
+				add = -15
+				has_trait = zealous
+			}
+		}
+
+		# Converting to a different Religion altogether is much more penalizing but also reduces stress by a lot more.
+		set_character_faith = scope:new_faith
+		if = {
+			limit = { 
+				scope:new_faith = { has_doctrine = doctrine_monotheist }
+			}
+			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
+		}
+		add_piety = major_piety_loss
+		add_piety_level = -1
+		add_stress = major_stress_impact_loss
+	}
+
+	option = { # Option D: Exercise to burn off the desire, medium stress loss.
+		trigger = {
+			has_character_flag = stress_threshold_option_athletic
+		}
+		name = {
+			trigger = { can_be_athletic = yes }
+			text = stress_threshold.1011.exercise.gain
+		}
+		name = {
+			trigger = { has_trait = athletic }
+			text = stress_threshold.1001.exercise.effect
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 5
+				has_trait = whole_of_body  
+			}
+			modifier = {
+				add = 15
+				has_trait = diligent
+			}
+			modifier = {
+				add = -15
+				has_trait = lazy 
+			}
+			modifier = {
+				add = -5
+				current_weight > overweight_value
+			}
+		}
+
+		trait = athletic
+		add_trait = athletic
+		add_stress = medium_stress_impact_loss
+	}
+
+	option = { # Option E: Endure, major stress gain.
+		name = stress_threshold.1011.endure
+		add_stress = mental_break_opt_out_stress_gain
+
+		ai_chance = {
+			base = 1
+			modifier = {
+				add = 5
+				has_trait = stubborn  
+			}
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+#############################
+# Nothing Matters			#
+# by Flavio Verna			#
+# 1501						#
+#############################
+#Base event
+stress_threshold.1501 = {
+	type = character_event
+	title = stress_threshold.1501.t
+	desc = {
+		desc = stress_threshold.1501.intro.desc
+		first_valid = {
+			#Concerned helper.
+			triggered_desc = {
+				desc = stress_threshold.1501.helper.desc
+				trigger = { exists = scope:scoped_helper }
+			}
+			desc = stress_threshold.1501.nohelper.desc
+		}
+		first_valid = { #Outro.
+			#Religious concerns.
+			triggered_desc = {
+				desc = stress_threshold.1501.faith.desc
+				trigger = {
+					exists = scope:new_faith
+					is_landless_adventurer = no
+				}
+			}
+			desc = stress_threshold.1501.fallback.desc
+		}
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = scope:scoped_ruler
+		animation = stress
+	}
+	lower_right_portrait = scope:scoped_helper
+
+	trigger = {
+		# Character must meet the criteria for at least two event options to qualify for this event.
+		calc_true_if = {
+			amount >= 2
+			can_be_reclusive = yes
+			can_be_inappetetic = yes
+			has_trait = reclusive
+			has_trait = inappetetic
+			AND = {
+				has_trait = cynical
+				faith = {
+					fervor <= medium_fervor_value
+				}
+				faith.religion = {
+					any_faith = {
+						this != root.faith
+					}
+				}
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		modifier = {
+			add = 10
+			has_trait = gregarious
+		}
+		modifier = {
+			add = 10
+			has_trait = zealous
+		}
+		modifier = {
+			add = -10
+			has_trait = shy
+		}
+		modifier = {
+			add = -10
+			has_trait = temperate
+		}
+		modifier = {
+			add = -5
+			has_trait = cynical
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = inappetetic }
+			}
+			add = 5
+		}
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+	immediate = {		
+		root = { save_scope_as = stress_character } # For stress widget
+
+		save_scope_as = scoped_ruler
+		faith = {
+			save_scope_as = scoped_faith
+		}
+		# Event option set-up to determine which event options we want to offer to the player.
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes
+			}
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_inappetetic = yes
+			}
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #
+			limit = {
+				has_trait = cynical
+				faith = {
+					fervor <= medium_fervor_value
+				}
+				faith.religion = {
+					any_faith = {
+						this != root.faith
+					}
+				}
+			}
+			add_character_flag = stress_threshold_option_conversion
+		}
+
+		if = { #Pick random friend/lover/spouse/courtier.
+			limit = {
+				any_relation = { type = lover always = yes }
+			}
+			random_relation = { type = lover
+				save_scope_as = scoped_helper
+			}
+		}
+		else_if = { #Pick random friend/lover/spouse/courtier.
+			limit = {
+				any_relation = { type = friend always = yes }
+			}
+			random_relation = { type = friend
+				save_scope_as = scoped_helper
+			}
+		}
+		else_if = { #Pick random friend/lover/spouse/courtier.
+			limit = {
+				is_married = yes
+			}
+			random_spouse = {
+				save_scope_as = scoped_helper
+			}
+		}
+		else = {
+			random_courtier = {
+				limit = {
+					is_child_of = root
+					is_available_ai_adult = yes
+				}
+				alternative_limit = {
+					dynasty ?= root.dynasty
+					is_available_ai_adult = yes
+				}
+				alternative_limit = {
+					is_available_ai_adult = yes
+				}
+				save_scope_as = scoped_helper
+			}
+		}
+		if = { #Pick random heresy in the event of special option being available.
+			limit = {
+				has_trait = cynical
+				faith = {
+					fervor <= medium_fervor_value
+				}
+				faith.religion = {
+					any_faith = {
+						this != root.faith
+					}
+				}
+			}
+			faith.religion = {
+				random_faith = {
+					limit = {
+						fervor > medium_fervor_value
+						OR = {
+							has_doctrine = tenet_human_sacrifice
+							has_doctrine = tenet_exaltation_of_pain
+							has_doctrine = tenet_sacred_shadows
+						}
+						this != root.faith
+					}
+					alternative_limit = {
+						fervor > medium_fervor_value
+						this != root.faith
+					}
+					alternative_limit = {
+						this != root.faith
+					}
+					save_scope_as = new_faith
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Option A: Effect from coping trait
+	#Option B: Gain Reclusive // Inappetetic
+	#Option C: Take stress
+	#Option D (Cynical/Faith Fervor low): Convert to other Faith.
+
+	option = { #Has Reclusive
+		name = stress_threshold.1501.a
+		trigger = { has_trait = reclusive }
+		trait = reclusive
+		if = {
+			limit = {
+				exists = scope:scoped_helper
+				scope:scoped_helper = { is_alive = yes }
+			}
+			scope:scoped_helper = {
+				add_opinion = {
+					modifier = ignored_concerns
+					target = root
+				}
+			}
+		}
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = shy
+			}
+			modifier = {
+				add = 15
+				has_trait = lazy
+			}
+			modifier = {
+				add = 15
+				has_trait = paranoid
+			}
+			modifier = {
+				add = 15
+				has_trait = just
+			}
+			modifier = {
+				add = 15
+				has_trait = craven
+			}
+		}
+	}
+	option = { #Has Inappetetic
+		name = stress_threshold.1501.b
+		trigger = { has_trait = inappetetic }
+		trait = inappetetic
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = temperate
+			}
+			modifier = {
+				add = 15
+				has_trait = arbitrary
+			}
+			modifier = {
+				add = 15
+				has_trait = content
+			}
+		}
+	}
+	option = { #Gains Reclusive
+		name = stress_threshold.1501.c
+		trigger = {
+			NOT = { has_trait = reclusive }
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		add_trait = reclusive
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = shy
+			}
+			modifier = {
+				add = 15
+				has_trait = lazy
+			}
+			modifier = {
+				add = 15
+				has_trait = paranoid
+			}
+			modifier = {
+				add = 15
+				has_trait = just
+			}
+			modifier = {
+				add = 15
+				has_trait = craven
+			}
+		}
+	}
+	option = { #Gains Inappetetic
+		name = stress_threshold.1501.d
+		trigger = {
+			NOT = { has_trait = inappetetic }
+			has_character_flag = stress_threshold_option_inappetetic
+		}
+		add_trait = inappetetic
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = temperate
+			}
+			modifier = {
+				add = 15
+				has_trait = arbitrary
+			}
+			modifier = {
+				add = 15
+				has_trait = content
+			}
+		}
+	}
+	option = { #Special option: change to heresy.
+		name = stress_threshold.1501.f
+		trigger = {
+			has_character_flag = stress_threshold_option_conversion
+			exists = scope:new_faith
+		}
+		trait = cynical
+		add_piety = medium_piety_loss
+		set_character_faith_with_conversion = scope:new_faith
+		if = {
+			limit = { 
+				scope:new_faith = { has_doctrine = doctrine_monotheist }
+			}
+			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
+		}
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 10
+			ai_value_modifier = {
+				ai_zeal = 0.2
+			}
+		}
+	}
+	option = { #Endure: Take Stress
+		name = stress_threshold.1501.e
+		 add_stress = major_stress_gain
+		ai_chance = {
+			base = 10
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+#############################
+# Insolent Fools			#
+# by Flavio Verna			#
+# 1502						#
+#############################
+#Base event
+stress_threshold.1502 = {
+	type = character_event
+	title = stress_threshold.1502.t
+	desc = {
+		desc = stress_threshold.1502.intro.desc
+		first_valid = {
+			#Annoying courtier
+			triggered_desc = {
+				desc = stress_threshold.1502.courtier.desc
+				trigger = { exists = scope:scoped_courtier }
+			}
+			desc = stress_threshold.1502.nocourtier.desc
+		}
+	}
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = no }
+		reference = throne_room
+	}
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = scope:scoped_ruler
+		animation = anger
+	}
+	right_portrait = {
+		character = scope:scoped_courtier
+		animation = flirtation_left
+	}
+
+	trigger = {
+		# Character must meet the criteria for at least two event options to qualify for this event.
+		calc_true_if = {
+			amount >= 2
+			can_be_irritable = yes
+			can_be_journaller = yes
+			can_be_drunkard = yes
+			any_prisoner = { is_ai = yes }
+			AND = {
+				has_trait = irritable
+				any_courtier = { is_available_ai_adult = yes }
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		modifier = {
+			add = 10
+			has_trait = sadistic
+		}
+		modifier = {
+			add = 10
+			has_trait = wrathful
+		}
+		modifier = {
+			add = 5
+			has_trait = callous
+		}
+		modifier = {
+			add = -10
+			has_trait = compassionate
+		}
+		modifier = {
+			add = -10
+			has_trait = patient
+		}
+		modifier = {
+			add = -5
+			has_trait = generous
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+			}
+			add = 5
+		}
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		# Event option set-up to determine which event options we want to offer to the player.
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes
+			}
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes
+			}
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_drunkard = yes
+			}
+			add_character_flag = stress_threshold_option_drunkard
+		}
+		save_scope_as = scoped_ruler
+		random_prisoner = { #Pick random prisoner.
+			limit = {
+				has_relation_rival = root
+				is_ai = yes
+			}
+			alternative_limit = {
+				reverse_opinion = {
+					target = root
+					value < low_negative_opinion
+				}
+				is_ai = yes
+			}
+			alternative_limit = {
+				reverse_opinion = {
+					target = root
+					value < 0
+				}
+				is_ai = yes
+			}
+			alternative_limit = {
+				is_ai = yes
+			}
+			save_scope_as = scoped_prisoner
+		}
+		#Pick random courtier that you might not like.
+		if = {
+			limit = { has_trait = irritable }
+			random_courtier = {
+				limit = {
+					OR = {
+						has_trait = wrathful
+						has_trait = gregarious
+						has_trait = intellect_bad
+					}
+					is_available_ai_adult = yes
+					trigger_if = {
+						limit = { exists = scope:scoped_prisoner }
+						this != scope:scoped_prisoner
+					}
+				}
+				alternative_limit = {
+					reverse_opinion = {
+						target = root
+						value < low_negative_opinion
+					}
+					is_available_ai_adult = yes
+					trigger_if = {
+						limit = { exists = scope:scoped_prisoner }
+						this != scope:scoped_prisoner
+					}
+				}
+				alternative_limit = {
+					reverse_opinion = {
+						target = root
+						value < 0
+					}
+					is_available_ai_adult = yes
+					trigger_if = {
+						limit = { exists = scope:scoped_prisoner }
+						this != scope:scoped_prisoner
+					}
+				}
+				alternative_limit = {
+					is_available_ai_adult = yes
+					trigger_if = {
+						limit = { exists = scope:scoped_prisoner }
+						this != scope:scoped_prisoner
+					}
+				}
+				save_scope_as = scoped_courtier
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Option D (High Learning/Shy): Gain journaller.
+	#Option A: Effect from coping trait
+	#Option B: Gain Irritable // Torturer // Drunkard
+	#Option C: Take stress
+
+	option = { #Special option: Gain journaller.
+		name = stress_threshold.1502.f
+		trigger = {
+			NOT = { has_trait = journaller }
+			has_character_flag = stress_threshold_option_journaller
+		}
+		trait = shy
+		add_trait = journaller
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 10
+			modifier = {
+				add = 15
+				has_trait = patient
+			}
+			modifier = {
+				add = 15
+				has_trait = calm
+			}
+			modifier = {
+				add = 15
+				has_learning_lifestyle_trait_trigger = yes
+			}
+		}
+	}
+	option = { #Has Irritable
+		name = stress_threshold.1502.a
+		trigger = {
+			has_trait = irritable
+			exists = scope:scoped_courtier
+		}
+		trait = irritable
+		scope:scoped_courtier = {
+			add_opinion = {
+				modifier = insult_opinion
+				opinion = medium_negative_opinion
+				target = root
+			}
+		}
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 30
+			modifier = {
+				add = 15
+				has_trait = wrathful
+			}
+			modifier = {
+				add = 15
+				has_trait = impatient
+			}
+			modifier = {
+				add = 15
+				has_trait = arrogant
+			}
+			modifier = {
+				add = 15
+				has_trait = stubborn
+			}
+			modifier = {
+				add = 15
+				has_trait = vengeful
+			}
+		}
+	}
+	option = { #Has Torturer
+		name = stress_threshold.1502.b
+		trigger = {
+			has_trait = torturer
+			exists = scope:scoped_prisoner
+		}
+		trait = torturer
+		scope:scoped_prisoner = {
+			increase_wounds_effect = {
+				REASON = torture
+			}
+		}
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = sadistic
+			}
+			modifier = {
+				add = 15
+				has_trait = vengeful
+			}
+			modifier = {
+				add = 15
+				has_trait = lifestyle_hunter
+			}
+			modifier = {
+				add = 15
+				has_trait = lifestyle_blademaster
+			}
+		}
+	}
+	option = { #Gains Irritable
+		name = stress_threshold.1502.c
+		trigger = {
+			NOT = { has_trait = irritable }
+			has_character_flag = stress_threshold_option_irritable
+		}
+		add_trait = irritable
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 30
+			modifier = {
+				add = 15
+				has_trait = wrathful
+			}
+			modifier = {
+				add = 15
+				has_trait = impatient
+			}
+			modifier = {
+				add = 15
+				has_trait = arrogant
+			}
+			modifier = {
+				add = 15
+				has_trait = stubborn
+			}
+			modifier = {
+				add = 15
+				has_trait = vengeful
+			}
+		}
+	}
+	option = { #Gains Drunkard
+		name = stress_threshold.1502.g
+		trigger = {
+			NOT = { has_trait = drunkard }
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		add_trait = drunkard
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 30
+			modifier = {
+				add = 15
+				has_trait = wrathful
+			}
+			modifier = {
+				add = 15
+				has_trait = impatient
+			}
+			modifier = {
+				add = 15
+				has_trait = arrogant
+			}
+			modifier = {
+				add = 15
+				has_trait = stubborn
+			}
+			modifier = {
+				add = 15
+				has_trait = vengeful
+			}
+		}
+	}
+	option = { #Endure: Take Stress
+		name = stress_threshold.1502.e
+		add_stress = major_stress_gain
+		ai_chance = {
+			base = 10
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+
+#############################
+# Emptiness Inside			#
+# by Flavio Verna			#
+# 1503						#
+#############################
+stress_threshold.1503 = {
+	type = character_event
+	title = stress_threshold.1503.t
+	desc = stress_threshold.1503.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = scope:scoped_ruler
+		animation = boredom
+	}
+
+	trigger = {
+		# Character must meet the criteria for at least two event options to qualify for this event.
+		calc_true_if = {
+			amount >= 2
+			has_trait = profligate
+			has_trait = comfort_eater
+			can_be_comfort_eater = yes
+			can_be_profligate = yes
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		modifier = {
+			add = 10
+			has_trait = generous
+		}
+		modifier = {
+			add = 10
+			has_trait = gluttonous
+		}
+		modifier = {
+			add = -10
+			has_trait = greedy
+		}
+		modifier = {
+			add = -10
+			has_trait = temperate
+		}
+		modifier = {
+			add = -5
+			has_trait = content
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = comfort_eater }
+			}
+			add = 5
+		}
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		save_scope_as = scoped_ruler
+		# Event option set-up to determine which event options we want to offer to the player.
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes
+			}
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_comfort_eater = yes
+			}
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Option A: Effect from coping trait
+	#Option B: Gain Profligate // Comfort Eater
+	#Option C: Take stress
+
+	option = { #Has Profligate
+		name = {
+			trigger = { is_landless_adventurer = no }
+			text = stress_threshold.1503.a.a
+		}
+		name = {
+			trigger = { top_liege = this }
+			text = stress_threshold.1503.a.b
+		}
+		name = {
+			trigger = {
+				NOT = {
+					faith = { has_doctrine_parameter = naked_adherents_active }
+				}
+			}
+			text = stress_threshold.1503.a.c
+		}
+		name = stress_threshold.1503.a.d
+		trigger = { has_trait = profligate }
+		trait = profligate
+		remove_short_term_gold = major_gold_value_check
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = greedy
+			}
+			modifier = {
+				add = 15
+				has_trait = ambitious
+			}
+			modifier = {
+				add = 15
+				has_trait = arbitrary
+			}
+			modifier = {
+				add = 15
+				has_trait = gregarious
+			}
+		}
+	}
+	option = { #Has Comfort Eater
+		name = stress_threshold.1503.b
+		trigger = { has_trait = comfort_eater }
+		trait = comfort_eater
+		remove_short_term_gold = minor_gold_value
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = gluttonous
+			}
+			modifier = {
+				add = 15
+				has_trait = fickle
+			}
+			modifier = {
+				add = 15
+				has_trait = arbitrary
+			}
+		}
+	}
+	option = { #Gains Profligate
+		name = {
+			trigger = { is_landless_adventurer = no }
+			text = stress_threshold.1503.a.a
+		}
+		name = {
+			trigger = { top_liege = this }
+			text = stress_threshold.1503.a.b
+		}
+		name = {
+			trigger = {
+				NOT = {
+					faith = { has_doctrine_parameter = naked_adherents_active }
+				}
+			}
+			text = stress_threshold.1503.a.c
+		}
+		name = stress_threshold.1503.a.d
+		trigger = {
+			NOT = { has_trait = profligate }
+			has_character_flag = stress_threshold_option_profligate
+		}
+		add_trait = profligate
+		remove_short_term_gold = medium_gold_value
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = greedy
+			}
+			modifier = {
+				add = 15
+				has_trait = ambitious
+			}
+			modifier = {
+				add = 15
+				has_trait = arbitrary
+			}
+			modifier = {
+				add = 15
+				has_trait = gregarious
+			}
+		}
+	}
+	option = { #Gains Comfort Eater
+		name = stress_threshold.1503.b
+		trigger = {
+			NOT = { has_trait = comfort_eater }
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		add_trait = comfort_eater
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = gluttonous
+			}
+			modifier = {
+				add = 15
+				has_trait = fickle
+			}
+			modifier = {
+				add = 15
+				has_trait = arbitrary
+			}
+		}
+	}
+	option = { #Endure: Take Stress
+		name = stress_threshold.1503.e
+		add_stress = major_stress_gain
+		ai_chance = {
+			base = 10
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+#############################
+# Endless Toil 				#
+# by Flavio Verna			#
+# 1504						#
+#############################
+stress_threshold.1504 = {
+	type = character_event
+	title = stress_threshold.1504.t
+	desc = stress_threshold.1504.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = scope:scoped_ruler
+		animation = stress
+	}
+
+	trigger = {
+		# Character must meet the criteria for at least two event options to qualify for this event.
+		calc_true_if = {
+			amount >= 2
+			has_trait = reclusive
+			can_be_reclusive = yes
+			OR = {
+				has_trait = hashishiyah
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				can_be_drunkard = yes
+			}
+			OR = {
+				can_be_burdened = yes
+				can_be_irritable = yes
+			}
+			can_be_journaller = yes
+			can_be_athletic = yes
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		modifier = {
+			add = 10
+			has_trait = shy
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		modifier = {
+			add = 10
+			has_trait = lifestyle_reveler
+		}
+		modifier = {
+			add = -10
+			has_trait = gregarious
+		}
+		modifier = {
+			add = -10
+			has_trait = temperate
+		}
+		modifier = {
+			add = -5
+			has_trait = wrathful
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = athletic }
+			}
+			add = 5
+		}
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		save_scope_as = scoped_ruler
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes
+			}
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_hashishiyah = yes
+			}
+			add_character_flag = stress_threshold_option_hashishiyah
+		}
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_drunkard = yes
+			}
+			add_character_flag = stress_threshold_option_drunkard
+		}
+		if = {
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_burdened = yes
+			}
+			add_character_flag = stress_threshold_option_burdened
+		}
+		else_if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes
+			}
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes
+			}
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_athletic = yes
+			}
+			add_character_flag = stress_threshold_option_athletic
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Lose prestige from reclusive.
+	#Lose learning from drug use.
+	#Gain Reclusive
+	#Gain hashishiyah
+	#Gain Stress
+	#Gain Burdened
+	#(Wrathful/Temperate): Gain Irritable
+	#(Learning/Diligent): Gain Journaller
+	#(Prowess/Martial Ed): Gain Athletic
+
+
+	option = { #Has Reclusive
+		name = stress_threshold.1504.a
+		trigger = { has_trait = reclusive }
+		trait = reclusive
+		add_prestige = medium_prestige_loss
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = shy
+			}
+			modifier = {
+				add = 15
+				has_trait = lazy
+			}
+			modifier = {
+				add = 15
+				has_trait = paranoid
+			}
+			modifier = {
+				add = 15
+				has_trait = just
+			}
+			modifier = {
+				add = 15
+				has_trait = craven
+			}
+		}
+	}
+	option = { #Has hashishiyah or Drunkard
+		name = stress_threshold.1504.b
+		trigger = {
+			OR = {
+				has_trait = hashishiyah
+				has_trait = drunkard
+			}
+		}
+		trait = hashishiyah
+		trait = drunkard
+		random_list = {
+			80 = {
+			}
+			20 = {
+				add_learning_skill = -1
+			}
+		}
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = impatient
+			}
+			modifier = {
+				add = 15
+				has_trait = fickle
+			}
+			modifier = {
+				add = 15
+				has_trait = diligent
+			}
+			modifier = {
+				add = 15
+				has_trait = lifestyle_reveler
+			}
+		}
+	}
+	option = { #Gains Reclusive
+		name = stress_threshold.1504.a
+		trigger = {
+			NOT = { has_trait = reclusive }
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		add_trait = reclusive
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = shy
+			}
+			modifier = {
+				add = 15
+				has_trait = lazy
+			}
+			modifier = {
+				add = 15
+				has_trait = paranoid
+			}
+			modifier = {
+				add = 15
+				has_trait = just
+			}
+			modifier = {
+				add = 15
+				has_trait = craven
+			}
+		}
+	}
+	option = { #Gains hashishiyah
+		name = stress_threshold.1504.b
+		trigger = {
+			NOR = {
+				has_trait = hashishiyah
+				has_trait = drunkard
+			}
+			OR = {
+				has_character_flag = stress_threshold_option_hashishiyah
+				has_character_flag = stress_threshold_option_drunkard
+			}
+			
+		}
+		if = {
+			limit = {
+				can_be_hashishiyah = yes
+			}
+			add_trait = hashishiyah
+		}
+		else = {
+			add_trait = drunkard
+		}
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 20
+			modifier = {
+				add = 15
+				has_trait = impatient
+			}
+			modifier = {
+				add = 15
+				has_trait = fickle
+			}
+			modifier = {
+				add = 15
+				has_trait = diligent
+			}
+			modifier = {
+				add = 15
+				has_trait = lifestyle_reveler
+			}
+		}
+	}
+	option = { #Gains Irritable
+		name = stress_threshold.1504.f
+		trigger = {
+			has_two_stress_coping_traits_trigger = no
+			NOT = { has_trait = irritable }
+			has_character_flag = stress_threshold_option_irritable
+		}
+		add_trait = irritable
+		add_stress = medium_stress_loss
+		ai_chance = {
+			base = 30
+			modifier = {
+				add = 15
+				has_trait = wrathful
+			}
+			modifier = {
+				add = 15
+				has_trait = impatient
+			}
+			modifier = {
+				add = 15
+				has_trait = arrogant
+			}
+			modifier = {
+				add = 15
+				has_trait = stubborn
+			}
+			modifier = {
+				add = 15
+				has_trait = vengeful
+			}
+		}
+	}
+	option = { #Gains Journaller
+		name = stress_threshold.1504.g
+		trigger = {
+			has_two_stress_coping_traits_trigger = no
+			NOT = { has_trait = journaller }
+			has_character_flag = stress_threshold_option_journaller
+		}
+		add_trait = journaller
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 10
+			modifier = {
+				add = 15
+				has_trait = patient
+			}
+			modifier = {
+				add = 15
+				has_trait = calm
+			}
+			modifier = {
+				add = 15
+				has_learning_lifestyle_trait_trigger = yes
+			}
+		}
+	}
+	option = { #Gains Athletic
+		name = stress_threshold.1504.h
+		trigger = {
+			NOT = { has_trait = athletic }
+			has_character_flag = stress_threshold_option_athletic
+		}
+		add_trait = athletic
+		add_stress = minor_stress_loss
+		ai_chance = {
+			base = 10
+			modifier = {
+				add = 15
+				has_trait = brave
+			}
+			modifier = {
+				add = 15
+				has_trait = diligent
+			}
+		}
+	}
+	option = { #Gains Burdened
+		name = stress_threshold.1504.i
+		trigger = {
+			has_two_stress_coping_traits_trigger = no
+			NOT = { has_trait = burdened }
+			has_character_flag = stress_threshold_option_burdened
+		}
+		add_trait = burdened
+		add_stress = major_stress_loss
+		ai_chance = {
+			base = 30
+			modifier = {
+				add = 15
+				has_trait = wrathful
+			}
+			modifier = {
+				add = 15
+				has_trait = impatient
+			}
+			modifier = {
+				add = 15
+				has_trait = arrogant
+			}
+			modifier = {
+				add = 15
+				has_trait = stubborn
+			}
+			modifier = {
+				add = 15
+				has_trait = vengeful
+			}
+			modifier = {
+				add = 15
+				has_trait = bossy
+			}
+			modifier = {
+				add = 15
+				has_trait = pensive
+			}
+			modifier = {
+				faith = { has_doctrine_parameter = children_less_likely_to_be_burdened }
+				add = -50
+			}
+		}
+	}
+	option = { #Endure: Take Stress
+		name = stress_threshold.1504.e
+		add_stress = major_stress_gain
+		ai_chance = {
+			base = 10
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+
+#########################################
+# Spinning Thoughts (fallback event)	#
+# by Linnéa Thimrén						#
+# 1601									#
+#########################################
+
+#Scripted effect so that the same script can be used for all fallback events
+scripted_effect stress_threshold_fallback_event_select_options_effect = {
+	#Event option set-up to determine which event options we want to offer to the player. First: let's see what possibilities we have!
+	if = { #Burdened (Child Stress Trait from too much pressure)
+		limit = { can_be_burdened = yes }
+		#Set the flag for enabling this event option to be chosen in the coming random list
+		add_character_flag = stress_threshold_burdened
+	}
+	if = { #Athletic (Exercises as a stress outlet)
+		limit = { can_be_athletic = yes }
+		#Set the flag for enabling this event option to be chosen in the coming random list
+		add_character_flag = stress_threshold_athletic
+	}
+	if = { #Inappetetic (Lack of appetite)
+		limit = { can_be_inappetetic = yes }
+		add_character_flag = stress_threshold_inappetetic
+	}
+	if = { #Comfort Eater (Eats as a stress release)
+		limit = { can_be_comfort_eater = yes }
+		add_character_flag = stress_threshold_comfort_eater
+	}
+	if = { #Profligate (Compulsively spends money)
+		limit = { can_be_profligate = yes }
+		add_character_flag = stress_threshold_profligate
+	}
+	if = { #Rakish (Prone to extremely wonton behavior, with the associated consequences.)
+		limit = { can_be_rakish = yes }
+		add_character_flag = stress_threshold_rakish
+	}
+	if = { #Reclusive (Secludes themselves away)
+		limit = { can_be_reclusive = yes }
+		add_character_flag = stress_threshold_reclusive
+	}
+	if = { #Irritable (Easily gets irritated)
+		limit = { can_be_irritable = yes }
+		add_character_flag = stress_threshold_irritable
+	}
+	if = { # Contrite (Compelled to reveal own secrets)
+		limit = { can_be_contrite = yes }
+		add_character_flag = stress_threshold_contrite
+	}
+	if = { #Flagellant (Impulsively self-harms)
+		limit = { can_be_flagellant = yes }
+		add_character_flag = stress_threshold_flagellant
+	}
+	if = { #Improvident (Habitually over-donates to charity)
+		limit = { can_be_improvident = yes }
+		add_character_flag = stress_threshold_improvident
+	}
+	if = { #Journaller (Writes down thoughts in a journal as a stress relief)
+		limit = { can_be_journaller = yes }
+		add_character_flag = stress_threshold_journaller
+	}
+	if = { #Confider (Has a close confidant)
+		limit = { can_be_confider = yes }
+		add_character_flag = stress_threshold_confider
+	}
+	if = { #Substance Abuse (Alcohol or Cannabis, depending on Faith/Region)
+		limit = {
+			OR = {
+				can_be_drunkard = yes
+				can_be_hashishiyah = yes
+			}
+		}
+		hidden_effect = {
+			random_list = { #Which option the player gets is somewhat dependent on where they are and what their faith is.
+				50 = {
+					trigger = { can_be_drunkard = yes }
+					add_character_flag = stress_threshold_drunkard
+				}
+				50 = {
+					trigger = { can_be_hashishiyah = yes }
+					add_character_flag = stress_threshold_hashishiyah
+				}
+			}
+		}
+	}
+
+
+	#To add possible extra options based on existent traits
+	if = {
+		limit = {
+			has_two_stress_threshold_options = no
+		}
+		if = {
+			limit = { has_trait = athletic }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:athletic
+			}
+		}
+		if = {
+			limit = { has_trait = burdened }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:burdened
+			}
+		}
+		if = {
+			limit = { has_trait = inappetetic }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:inappetetic
+			}
+		}
+		if = {
+			limit = { has_trait = comfort_eater }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:comfort_eater
+			}
+		}
+		if = {
+			limit = { has_trait = profligate }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:profligate
+			}
+		}
+		if = {
+			limit = { has_trait = rakish }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:rakish
+			}
+		}
+		if = {
+			limit = { has_trait = reclusive }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:reclusive
+			}
+		}
+		if = {
+			limit = { has_trait = irritable }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:irritable
+			}
+		}
+		if = {
+			limit = { has_trait = contrite }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:contrite
+			}
+		}
+		if = {
+			limit = { has_trait = flagellant }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:flagellant
+			}
+		}
+		if = {
+			limit = { has_trait = improvident }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:improvident
+			}
+		}
+		if = {
+			limit = { has_trait = journaller }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:journaller
+			}
+		}
+		if = {
+			limit = {
+				has_trait = confider
+				any_relation = {
+					type = friend
+				}
+			}
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:confider
+			}
+		}
+		if = {
+			limit = { has_trait = drunkard }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:drunkard
+			}
+		}
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_to_variable_list = {
+				name = extra_stress_threshold_event_option
+				target = flag:hashishiyah
+			}
+		}
+	}
+
+	#To actually choose the options shown
+	if = {
+		limit = {
+			can_be_burdened = yes
+		}
+		hidden_effect = { add_character_flag = stress_threshold_option_burdened }
+	}
+	else = {
+		hidden_effect = {
+			while = {
+				limit = { #Run until two options have been found (if two options exists)
+					has_two_stress_threshold_options = no
+					OR = {
+						has_character_flag = stress_threshold_athletic
+						has_character_flag = stress_threshold_inappetetic
+						has_character_flag = stress_threshold_comfort_eater
+						has_character_flag = stress_threshold_profligate
+						has_character_flag = stress_threshold_rakish
+						has_character_flag = stress_threshold_reclusive
+						has_character_flag = stress_threshold_irritable
+						has_character_flag = stress_threshold_contrite
+						has_character_flag = stress_threshold_flagellant
+						has_character_flag = stress_threshold_improvident
+						has_character_flag = stress_threshold_journaller
+						has_character_flag = stress_threshold_confider
+						has_character_flag = stress_threshold_drunkard
+						has_character_flag = stress_threshold_hashishiyah
+						has_character_flag = stress_threshold_burdened
+					}
+				}
+				random_list = {
+					10 = {
+						trigger = { has_character_flag = stress_threshold_burdened }
+						modifier = {
+							government_allows = merit
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_burdened
+						remove_character_flag = stress_threshold_burdened
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_athletic }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:athletic
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_athletic
+						remove_character_flag = stress_threshold_athletic
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_inappetetic }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:inappetetic
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_inappetetic
+						remove_character_flag = stress_threshold_inappetetic
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_comfort_eater }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:comfort_eater
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_comfort_eater
+						remove_character_flag = stress_threshold_comfort_eater
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_profligate }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:profligate
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_profligate
+						remove_character_flag = stress_threshold_profligate
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_rakish }
+						add_character_flag = stress_threshold_option_rakish
+						remove_character_flag = stress_threshold_rakish
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_reclusive }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:reclusive
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_reclusive
+						remove_character_flag = stress_threshold_reclusive
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_irritable }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:irritable
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_irritable
+						remove_character_flag = stress_threshold_irritable
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_contrite }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:contrite
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_contrite
+						remove_character_flag = stress_threshold_contrite
+						contrite_get_secret_scopes_effect = yes
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_flagellant }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:flagellant
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_flagellant
+						remove_character_flag = stress_threshold_flagellant
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_improvident }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:improvident
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_improvident
+						remove_character_flag = stress_threshold_improvident
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_journaller }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:journaller
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_journaller
+						remove_character_flag = stress_threshold_journaller
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_confider }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:confider
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_confider
+						remove_character_flag = stress_threshold_confider
+						if = { #To save the confidant!
+							limit = {
+								any_relation = {
+									type = friend
+									has_relation_flag = {
+										target = root
+										relation = friend
+										flag = has_been_confided_in
+									}
+								}
+							}
+							random_relation = {
+								type = friend
+								limit = {
+									has_relation_flag = {
+										target = root
+										relation = friend
+										flag = has_been_confided_in
+									}
+								}
+								save_scope_as = friend
+							}
+						}
+						else_if = {
+							limit = {
+								any_relation = {
+									type = best_friend
+									has_relation_flag = {
+										target = root
+										relation = best_friend
+										flag = has_been_confided_in
+									}
+								}
+							}
+							random_relation = {
+								type = best_friend
+								limit = {
+									has_relation_flag = {
+										target = root
+										relation = best_friend
+										flag = has_been_confided_in
+									}
+								}
+								save_scope_as = friend
+							}
+						}
+						else = {
+							random_relation = {
+								type = friend
+								save_scope_as = friend
+							}
+						}
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_drunkard }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:drunkard
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_drunkard
+						remove_character_flag = stress_threshold_drunkard
+					}
+					10 = {
+						trigger = { has_character_flag = stress_threshold_hashishiyah }
+						modifier = {
+							#One of your parents/guardian has issues
+							var:witnessed_trait ?= flag:hashishiyah
+							add = 20
+						}
+						add_character_flag = stress_threshold_option_hashishiyah
+						remove_character_flag = stress_threshold_hashishiyah
+					}
+				}
+			}
+			#To clean out the flags that weren't chosen
+			remove_character_flag = stress_threshold_athletic
+			remove_character_flag = stress_threshold_inappetetic
+			remove_character_flag = stress_threshold_comfort_eater
+			remove_character_flag = stress_threshold_profligate
+			remove_character_flag = stress_threshold_rakish
+			remove_character_flag = stress_threshold_reclusive
+			remove_character_flag = stress_threshold_irritable
+			remove_character_flag = stress_threshold_contrite
+			remove_character_flag = stress_threshold_flagellant
+			remove_character_flag = stress_threshold_improvident
+			remove_character_flag = stress_threshold_journaller
+			remove_character_flag = stress_threshold_confider
+			remove_character_flag = stress_threshold_drunkard
+			remove_character_flag = stress_threshold_hashishiyah
+		}
+	}
+
+	#To choose the extra, trait specific, options if two fun options haven't been found in the previous step
+	if = {
+		limit = {
+			can_be_burdened = no
+			has_two_stress_threshold_options = no
+			any_in_list = {
+				variable = extra_stress_threshold_event_option
+				exists = this
+			}
+			variable_list_size = {
+				name = extra_stress_threshold_event_option
+				value > 0
+			}
+		}
+		while = {
+			limit = {
+				has_two_stress_threshold_options = no
+				variable_list_size = {
+					name = extra_stress_threshold_event_option
+					value > 0
+				}
+			}
+			hidden_effect = {
+				random_list = {
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_burdened }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:burdened
+							}
+						}
+						add_character_flag = stress_threshold_option_athletic
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:burdened
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_athletic }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:athletic
+							}
+						}
+						add_character_flag = stress_threshold_option_athletic
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:athletic
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_inappetetic }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:inappetetic
+							}
+						}
+						add_character_flag = stress_threshold_option_inappetetic
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:inappetetic
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_comfort_eater }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:comfort_eater
+							}
+						}
+						add_character_flag = stress_threshold_option_comfort_eater
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:comfort_eater
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_profligate }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:profligate
+							}
+						}
+						add_character_flag = stress_threshold_option_profligate
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:profligate
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_rakish }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:rakish
+							}
+						}
+						add_character_flag = stress_threshold_option_rakish
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:rakish
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_reclusive }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:reclusive
+							}
+						}
+						add_character_flag = stress_threshold_option_reclusive
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:reclusive
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_irritable }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:irritable
+							}
+						}
+						add_character_flag = stress_threshold_option_irritable
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:irritable
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_contrite }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:contrite
+							}
+						}
+						add_character_flag = stress_threshold_option_contrite
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:contrite
+						}
+						contrite_get_secret_scopes_effect = yes
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_flagellant }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:flagellant
+							}
+						}
+						add_character_flag = stress_threshold_option_flagellant
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:flagellant
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_improvident }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:improvident
+							}
+						}
+						add_character_flag = stress_threshold_option_improvident
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:improvident
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_journaller }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:journaller
+							}
+						}
+						add_character_flag = stress_threshold_option_journaller
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:journaller
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_confider }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:confider
+							}
+						}
+						add_character_flag = stress_threshold_option_confider
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:confider
+						}
+						if = { #To save the confidant!
+							limit = {
+								any_relation = {
+									type = friend
+									has_relation_flag = {
+										target = root
+										relation = friend
+										flag = has_been_confided_in
+									}
+								}
+							}
+							random_relation = {
+								type = friend
+								limit = {
+									has_relation_flag = {
+										target = root
+										relation = friend
+										flag = has_been_confided_in
+									}
+								}
+								save_scope_as = friend
+							}
+						}
+						else_if = {
+							limit = {
+								any_relation = {
+									type = best_friend
+									has_relation_flag = {
+										target = root
+										relation = best_friend
+										flag = has_been_confided_in
+									}
+								}
+							}
+							random_relation = {
+								type = best_friend
+								limit = {
+									has_relation_flag = {
+										target = root
+										relation = best_friend
+										flag = has_been_confided_in
+									}
+								}
+								save_scope_as = friend
+							}
+						}
+						else = {
+							random_relation = {
+								type = friend
+								save_scope_as = friend
+							}
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_drunkard }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:drunkard
+							}
+						}
+						add_character_flag = stress_threshold_option_drunkard
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:drunkard
+						}
+					}
+					10 = {
+						trigger = {
+							NOT = { has_character_flag = stress_threshold_hashishiyah }
+							is_target_in_variable_list = {
+								name = extra_stress_threshold_event_option
+								target = flag:hashishiyah
+							}
+						}
+						add_character_flag = stress_threshold_option_hashishiyah
+						remove_list_variable = {
+							name = extra_stress_threshold_event_option
+							target = flag:hashishiyah
+						}
+					}
+				}
+			}
+		}
+	}
+
+	#If you still have too few options (e.g. a kid with no personality), add one of these as fallback
+	if = {
+		limit = {
+			has_two_stress_threshold_options = no
+			can_be_burdened = no
+		}
+		hidden_effect = {
+			random_list = {
+				10 = {
+					trigger = {
+						NOT = { has_character_flag = stress_threshold_option_profligate }	
+					}
+					add_character_flag = stress_threshold_option_profligate
+				}
+				10 = {
+					trigger = {
+						NOT = { has_character_flag = stress_threshold_option_irritable }	
+					}
+					add_character_flag = stress_threshold_option_irritable
+				}
+				10 = {
+					trigger = {
+						NOT = { has_character_flag = stress_threshold_option_reclusive }	
+					}
+					add_character_flag = stress_threshold_option_reclusive
+				}
+				10 = {
+					trigger = {
+						NOT = { has_character_flag = stress_threshold_option_burdened }
+						government_allows = merit
+						has_character_flag = failed_child_exam
+					}
+					add_character_flag = stress_threshold_option_burdened
+				}
+			}
+		}
+	}
+ }
+
+
+stress_threshold.1601 = {
+	type = character_event
+	title = stress_threshold.1601.t
+	desc = stress_threshold.1601.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = stress
+	}
+	lower_right_portrait = scope:friend
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		save_scope_as = stress_character #For stress widget
+
+		stress_threshold_fallback_event_select_options_effect = yes
+
+		stress_threshold_event_post_immediate = yes
+	}
+
+	option = { #Gains Profligate
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.1601.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.1601.profligate.effect
+		}
+		add_trait = profligate
+		trait = profligate
+		remove_short_term_gold = medium_gold_value
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = greedy
+					has_trait = ambitious
+					has_trait = arbitrary
+					has_trait = gregarious
+					has_trait = cynical
+				}
+			}
+		}
+	}
+
+	option = { #Gains Inappetetic
+		trigger = {
+			has_character_flag = stress_threshold_option_inappetetic
+		}
+		name = {
+			trigger = { can_be_inappetetic = yes }
+			text = stress_threshold.1601.inappetetic.gain
+		}
+		name = {
+			trigger = { has_trait = inappetetic }
+			text = stress_threshold.1601.inappetetic.effect
+		}
+		trait = inappetetic
+		if = {
+			limit = {
+				has_trait = inappetetic
+			}
+			inappetetic_advance_starvation_effect = yes
+		}
+		add_trait = inappetetic
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = temperate
+					has_trait = content
+					has_trait = arbitrary
+					has_trait = patient
+					has_trait = diligent
+				}
+			}
+		}
+	}
+
+	option = { #Gains Comfort Eater
+		trigger = {
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		name = {
+			trigger = { can_be_comfort_eater = yes }
+			text = stress_threshold.1601.comfort_eater.gain
+		}
+		name = {
+			trigger = { has_trait = comfort_eater }
+			text = stress_threshold.1601.comfort_eater.effect
+		}
+		add_trait = comfort_eater
+		trait = comfort_eater
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = gluttonous
+					has_trait = fickle
+					has_trait = arbitrary
+					has_trait = impatient
+					has_trait = calm
+				}
+			}
+		}
+	}
+
+	option = { #Gains Rakish
+		trigger = {
+			has_character_flag = stress_threshold_option_rakish
+		}
+		name = {
+			trigger = { can_be_rakish = yes }
+			text = stress_threshold.1601.rakish.gain
+		}
+		name = {
+			trigger = { has_trait = rakish }
+			text = stress_threshold.1601.rakish.effect
+		}
+
+		add_trait = rakish
+		trait = rakish
+
+		rakish_brothel_night_effect = yes # Stress reduction is included in this effect.
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = lustful
+					has_trait = arrogant
+					has_trait = deceitful
+					has_trait = gallant
+					has_trait = seducer
+				}
+			}
+		}
+	}
+
+	option = { #Gains Reclusive
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.1601.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.1601.reclusive.effect
+		}
+		add_trait = reclusive
+		trait = reclusive
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = shy
+					has_trait = lazy
+					has_trait = paranoid
+					has_trait = craven
+					has_trait = cynical
+					has_trait = just
+				}
+			}
+		}
+	}
+
+	option = { #Gains Irritable
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.1601.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.1601.irritable.effect
+		}
+		add_trait = irritable
+		trait = irritable
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = wrathful
+					has_trait = impatient
+					has_trait = arrogant
+					has_trait = stubborn
+					has_trait = vengeful
+					has_trait = callous
+				}
+			}
+		}
+	}
+
+	option = { #Gains Confider
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+			exists = scope:friend
+			scope:friend = { is_alive = yes }
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.1601.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.1601.confider.effect
+		}
+		add_trait = confider
+		trait = confider
+
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+				if = {
+					limit = {
+						has_relation_best_friend = root
+					}
+					add_relation_flag = {
+						target = root
+						relation = best_friend
+						flag = has_been_confided_in
+					}
+				}
+				else = {
+					add_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+		}
+		else = {
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 200
+			ai_value_modifier = {
+				ai_compassion = 0.5
+			}
+		}
+	}
+
+	option = { #Gains Athletic
+		trigger = {
+			has_character_flag = stress_threshold_option_athletic
+		}
+		name = {
+			trigger = { can_be_athletic = yes }
+			text = stress_threshold.1601.athletic.gain
+		}
+		name = {
+			trigger = { has_trait = athletic }
+			text = stress_threshold.1601.athletic.effect
+		}
+		add_trait = athletic
+		trait = athletic
+
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				has_trait = brave
+				has_trait = diligent
+			}
+		}
+	}
+
+	option = { #Gains Contrite
+		trigger = {
+			has_character_flag = stress_threshold_option_contrite
+		}
+		name = {
+			trigger = { can_be_contrite = yes }
+			text = stress_threshold.1601.contrite.gain
+		}
+		name = {
+			trigger = { has_trait = contrite }
+			text = stress_threshold.1601.contrite.effect
+		}
+
+		add_trait = contrite
+		trait = contrite
+
+		contrite_reveal_secrets_effect = yes # Includes stress loss based on what secrets were revealed
+		ai_chance = {
+			base = 175
+			modifier = {
+				add = 75
+				num_sinful_traits >= 1
+				any_secret = {
+					exists = this
+					can_be_exposed_by = root
+				}
+			}
+		}
+	}
+
+	option = { #Gains Flagellant
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.1601.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.1601.flagellant.effect
+		}
+
+		add_trait = flagellant
+		trait = flagellant
+
+		if = {
+			limit = {
+				is_ai = yes
+			}
+			random_list = { 
+				75 = {}
+				25 = { increase_wounds_effect = { REASON = whipping } }
+			}
+		}
+		else = {
+			increase_wounds_effect = { REASON = whipping }
+		}
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = zealous
+					has_trait = chaste
+					has_trait = temperate
+					has_trait = humble
+					has_trait = lifestyle_mystic
+				}
+			}
+		}
+	}
+
+	option = { #Gains Improvident
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+			OR = {
+				is_ai = no
+				short_term_gold >= major_gold_value
+			}
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.1601.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.1601.improvident.effect
+		}
+
+		add_trait = improvident
+		trait = improvident
+
+		remove_short_term_gold = major_gold_value
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = generous
+					has_trait = forgiving
+					has_trait = compassionate
+					has_trait = just
+					has_trait = content
+				}
+			}
+		}
+	}
+
+	option = { #Gains Journaller
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1601.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1601.journaller.effect
+		}
+		trait = scholar
+		trait = theologian
+		
+		add_trait = journaller
+		trait = journaller
+
+		add_stress = minor_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				has_trait = scholar
+				has_trait = theologian
+			}
+		}
+	}
+	
+	option = { #Gains Drunkard
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.1601.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.1601.drunkard.effect
+		}
+
+		trait = drunkard
+
+		if = {
+			limit = {
+				has_trait = drunkard
+			}
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}	
+		else = {
+			add_trait = drunkard
+		}
+		
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	option = { #Gains Hashishiyah
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.1601.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.1601.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		if = {
+			limit = {
+				has_trait = hashishiyah
+			}
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = {
+			add_trait = hashishiyah
+		}
+
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	option = { #Gains Burdened
+		trigger = {
+			has_character_flag = stress_threshold_option_burdened
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1601.burdened.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1601.burdened.effect
+		}
+
+		add_trait = burdened
+		trait = burdened
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = wrathful
+					has_trait = impatient
+					has_trait = arrogant
+					has_trait = stubborn
+					has_trait = vengeful
+					has_trait = callous
+				}
+			}
+			modifier = {
+				faith = { has_doctrine_parameter = children_less_likely_to_be_burdened }
+				add = -150
+			}
+		}
+	}
+
+	# Endure: major stress gain!
+	option = {
+		name = {
+			trigger = { has_two_stress_threshold_options = yes }
+			text = stress_threshold.1001.endure
+		}
+		name = {
+			trigger = { has_two_stress_threshold_options = no }
+			text = stress_threshold.1601.endure_no_option
+		}
+		add_stress = mental_break_opt_out_stress_gain
+
+		ai_chance = {
+			base = 0
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+
+#########################################
+# Swirling Emotions (fallback event)	#
+# by Linnéa Thimrén						#
+# 1602									#
+#########################################
+
+stress_threshold.1602 = {
+	type = character_event
+	title = stress_threshold.1602.t
+	desc = stress_threshold.1602.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = worry
+	}
+	lower_right_portrait = scope:friend
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		save_scope_as = stress_character #For stress widget
+
+		stress_threshold_fallback_event_select_options_effect = yes
+
+		stress_threshold_event_post_immediate = yes
+	}
+
+	option = { #Gains Profligate
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.1602.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.1602.profligate.effect
+		}
+		add_trait = profligate
+		trait = profligate
+		remove_short_term_gold = medium_gold_value
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = greedy
+					has_trait = ambitious
+					has_trait = arbitrary
+					has_trait = gregarious
+					has_trait = cynical
+				}
+			}
+		}
+	}
+
+	option = { #Gains Inappetetic
+		trigger = {
+			has_character_flag = stress_threshold_option_inappetetic
+		}
+		name = {
+			trigger = { can_be_inappetetic = yes }
+			text = stress_threshold.1602.inappetetic.gain
+		}
+		name = {
+			trigger = { has_trait = inappetetic }
+			text = stress_threshold.1602.inappetetic.effect
+		}
+		trait = inappetetic
+		if = {
+			limit = {
+				has_trait = inappetetic
+			}
+			inappetetic_advance_starvation_effect = yes
+		}
+		add_trait = inappetetic
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = temperate
+					has_trait = content
+					has_trait = arbitrary
+					has_trait = patient
+					has_trait = diligent
+				}
+			}
+		}
+	}
+
+	option = { #Gains Comfort Eater
+		trigger = {
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		name = {
+			trigger = { can_be_comfort_eater = yes }
+			text = stress_threshold.1602.comfort_eater.gain
+		}
+		name = {
+			trigger = { has_trait = comfort_eater }
+			text = stress_threshold.1602.comfort_eater.effect
+		}
+		add_trait = comfort_eater
+		trait = comfort_eater
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = gluttonous
+					has_trait = fickle
+					has_trait = arbitrary
+					has_trait = impatient
+					has_trait = calm
+				}
+			}
+		}
+	}
+
+	option = { #Gains Rakish
+		trigger = {
+			has_character_flag = stress_threshold_option_rakish
+		}
+		name = {
+			trigger = { can_be_rakish = yes }
+			text = stress_threshold.1602.rakish.gain
+		}
+		name = {
+			trigger = { has_trait = rakish }
+			text = stress_threshold.1602.rakish.effect
+		}
+
+		add_trait = rakish
+		trait = rakish
+
+		rakish_brothel_night_effect = yes # Stress reduction is included in this effect.
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = lustful
+					has_trait = arrogant
+					has_trait = deceitful
+					has_trait = gallant
+					has_trait = seducer
+				}
+			}
+		}
+	}
+
+	option = { #Gains Reclusive
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.1602.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.1602.reclusive.effect
+		}
+		add_trait = reclusive
+		trait = reclusive
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = shy
+					has_trait = lazy
+					has_trait = paranoid
+					has_trait = craven
+					has_trait = cynical
+					has_trait = just
+				}
+			}
+		}
+	}
+
+	option = { #Gains Irritable
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.1602.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.1602.irritable.effect
+		}
+		add_trait = irritable
+		trait = irritable
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = wrathful
+					has_trait = impatient
+					has_trait = arrogant
+					has_trait = stubborn
+					has_trait = vengeful
+					has_trait = callous
+				}
+			}
+		}
+	}
+
+	option = { #Gains Confider
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+			exists = scope:friend
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.1602.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.1602.confider.effect
+		}
+		add_trait = confider
+		trait = confider
+
+		if = {
+			limit = {
+				has_relation_friend = scope:friend
+				scope:friend = {
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			scope:friend = {
+				if = {
+					limit = {
+						has_relation_best_friend = root
+					}
+					add_relation_flag = {
+						target = root
+						relation = best_friend
+						flag = has_been_confided_in
+					}
+				}
+				else = {
+					add_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = { 
+				has_relation_friend = scope:friend 
+				scope:friend = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+			
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 200
+			ai_value_modifier = {
+				ai_compassion = 0.5
+			}
+		}
+	}
+
+	option = { #Gains Athletic
+		trigger = {
+			has_character_flag = stress_threshold_option_athletic
+		}
+		name = {
+			trigger = { can_be_athletic = yes }
+			text = stress_threshold.1602.athletic.gain
+		}
+		name = {
+			trigger = { has_trait = athletic }
+			text = stress_threshold.1602.athletic.effect
+		}
+		add_trait = athletic
+		trait = athletic
+
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				has_trait = brave
+				has_trait = diligent
+			}
+		}
+	}
+
+	option = { #Gains Contrite
+		trigger = {
+			has_character_flag = stress_threshold_option_contrite
+		}
+		name = {
+			trigger = { can_be_contrite = yes }
+			text = stress_threshold.1602.contrite.gain
+		}
+		name = {
+			trigger = { has_trait = contrite }
+			text = stress_threshold.1602.contrite.effect
+		}
+
+		add_trait = contrite
+		trait = contrite
+
+		contrite_reveal_secrets_effect = yes # Includes stress loss based on what secrets were revealed
+		ai_chance = {
+			base = 175
+			modifier = {
+				add = 75
+				num_sinful_traits >= 1
+				any_secret = {
+					exists = this
+					can_be_exposed_by = root
+				}
+			}
+		}
+	}
+
+	option = { #Gains Flagellant
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.1602.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.1602.flagellant.effect
+		}
+
+		add_trait = flagellant
+		trait = flagellant
+
+		if = {
+			limit = {
+				is_ai = yes
+			}
+			random_list = { 
+				75 = {}
+				25 = { increase_wounds_effect = { REASON = whipping } }
+			}
+		}
+		else = {
+			increase_wounds_effect = { REASON = whipping }
+		}
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = zealous
+					has_trait = chaste
+					has_trait = temperate
+					has_trait = humble
+					has_trait = lifestyle_mystic
+				}
+			}
+		}
+	}
+
+	option = { #Gains Improvident
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+			OR = {
+				is_ai = no
+				short_term_gold >= major_gold_value
+			}
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.1602.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.1602.improvident.effect
+		}
+
+		add_trait = improvident
+		trait = improvident
+
+		remove_short_term_gold = major_gold_value
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = generous
+					has_trait = forgiving
+					has_trait = compassionate
+					has_trait = just
+					has_trait = content
+				}
+			}
+		}
+	}
+
+	option = { #Gains Journaller
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1602.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1602.journaller.effect
+		}
+		trait = scholar
+		trait = theologian
+		
+		add_trait = journaller
+		trait = journaller
+
+		add_stress = minor_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				has_trait = scholar
+				has_trait = theologian
+			}
+		}
+	}
+	
+	option = { #Gains Drunkard
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.1602.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.1602.drunkard.effect
+		}
+
+		trait = drunkard
+
+		if = {
+			limit = {
+				has_trait = drunkard
+			}
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}	
+		else = {
+			add_trait = drunkard
+		}
+		
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	option = { #Gains Hashishiyah
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.1602.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.1602.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		if = {
+			limit = {
+				has_trait = hashishiyah
+			}
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = {
+			add_trait = hashishiyah
+		}
+
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	option = { #Gains Burdened
+		trigger = {
+			has_character_flag = stress_threshold_option_burdened
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1602.burdened.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1602.burdened.effect
+		}
+
+		add_trait = burdened
+		trait = burdened
+		add_stress = medium_stress_loss
+
+		ai_chance = {
+			base = 100
+			modifier = {
+				add = 75
+				calc_true_if = {
+					amount >= 2
+					has_trait = wrathful
+					has_trait = impatient
+					has_trait = arrogant
+					has_trait = stubborn
+					has_trait = vengeful
+					has_trait = callous
+				}
+			}
+		}
+	}
+
+	# Endure: major stress gain!
+	option = {
+		name = {
+			trigger = { has_two_stress_threshold_options = yes }
+			text = stress_threshold.1001.endure
+		}
+		name = {
+			trigger = { has_two_stress_threshold_options = no }
+			text = stress_threshold.1601.endure_no_option
+		}
+		add_stress = mental_break_opt_out_stress_gain
+
+		ai_chance = {
+			base = 0
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+scripted_effect jealousy_at_court_effect = {
+	every_courtier_or_guest = {
+		limit = {
+			this != scope:friend
+		}
+		custom = jealousy_at_court_effect.confider.list
+		if = {	#Players get a slap on the wrist, because they have no control.
+			limit = {
+				scope:friend = { is_ai = no }
+			}
+			add_opinion = {
+				modifier = stress_sycophant_opinion
+				opinion = -10
+				target = scope:friend
+			}
+		}
+		else = {	#NPCs, meanwhilst, become murder-bait.
+			add_opinion = {
+				modifier = stress_sycophant_opinion
+				opinion = $SYC_OPINION$
+				target = scope:friend
+			}
+			#Just for fun, put the confidant in danger with political or angry types.
+			hidden_effect = {
+				if = {
+					limit = {	#Skip straight to rivalry if appropriate.
+						calc_true_if = {
+							amount >= $TRUE_RIVAL_NUM$
+							has_trait = vengeful
+							has_trait = wrathful
+							has_trait = sadistic
+							has_trait = ambitious
+						}
+						NOR = {	#Vetoing people for whom the instant-hatred shouldn't make sense.
+							has_relation_rival = scope:friend
+							has_relation_friend = scope:friend
+							has_relation_lover = scope:friend
+							any_consort = { this = scope:friend }
+						}
+					}
+					set_relation_rival = {
+						target = scope:friend
+						reason = rival_jealousy_at_court
+					}
+				}
+				else_if = {
+					limit = {	#Otherwise, increment.
+						calc_true_if = {
+							amount >= $POTENTIAL_RIVAL_NUM$
+							has_trait = vengeful
+							has_trait = wrathful
+							has_trait = sadistic
+							has_trait = ambitious
+						}
+						NOR = {	#Continuing to veto as appropriate.
+							has_relation_rival = scope:friend
+							has_relation_friend = scope:friend
+							has_relation_lover = scope:friend
+							any_consort = { this = scope:friend }
+						}
+					}
+					progress_towards_rival_effect = {
+						REASON = rival_confider_mental_break
+						CHARACTER = scope:friend
+						OPINION = 0
+					}
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Prior Error
+# by Ewan Cowhig Croft
+# #1701
+##################################################
+
+#	Your personality has caused friction elsewhere.
+#		by Ewan Cowhig Croft
+stress_threshold.1701 = {
+	type = character_event
+	title = stress_threshold.1701.t
+	desc = {
+		desc = stress_threshold.1701.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = lazy
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_lazy }
+				}
+				desc = stress_threshold.1701.desc.lazy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = wrathful
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_wrathful }
+				}
+				desc = stress_threshold.1701.desc.wrathful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = impatient
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_impatient }
+				}
+				desc = stress_threshold.1701.desc.impatient
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = arrogant
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_arrogant }
+				}
+				desc = stress_threshold.1701.desc.arrogant
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = arbitrary
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_arbitrary }
+				}
+				desc = stress_threshold.1701.desc.arbitrary
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = trusting
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_trusting }
+				}
+				desc = stress_threshold.1701.desc.trusting
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = stubborn
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_stubborn }
+				}
+				desc = stress_threshold.1701.desc.stubborn
+			}
+			desc = stress_threshold.1701.desc.fallback
+		}
+		desc = stress_threshold.1701.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = shame
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = lazy
+			has_trait = wrathful
+			has_trait = impatient
+			has_trait = arrogant
+			has_trait = arbitrary
+			has_trait = trusting
+			has_trait = stubborn
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_rakish = yes
+			has_trait = rakish
+			can_be_irritable = yes
+			has_trait = irritable
+			can_be_flagellant = yes
+			has_trait = flagellant
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_comfort_eater = yes
+			has_trait = comfort_eater
+			can_be_inappetetic = yes
+			has_trait = inappetetic
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = rakish
+		}
+		modifier = {
+			add = 10
+			has_trait = irritable
+		}
+		modifier = {
+			add = 10
+			has_trait = flagellant
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = comfort_eater
+		}
+		modifier = {
+			add = 10
+			has_trait = inappetetic
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = flagellant }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = comfort_eater }
+				has_witnessed_stress_coping_trait = { TRAIT = inappetetic }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+		root.capital_province = { save_scope_as = capital_province } #For loc.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+
+		#Check for existing coping mechanisms first.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = rakish	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = irritable	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = flagellant	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+
+		#Then potential ones.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_rakish = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_flagellant = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Rakish: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_rakish
+		}
+		name = {
+			trigger = { can_be_rakish = yes }
+			text = stress_threshold.1701.a.rakish.gain
+		}
+		name = {
+			trigger = { has_trait = rakish }
+			text = stress_threshold.1701.a.rakish.effect
+		}
+
+		add_trait = rakish
+		trait = rakish
+
+		rakish_brothel_night_effect = yes # Stress reduction is included in this effect.
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = rakish
+			}
+		}
+	}
+
+	#Irritable: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.1701.b.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.1701.b.irritable.effect
+		}
+		
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+
+	#Flagellant: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.1701.c.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.1701.c.flagellant.effect
+		}
+		
+		add_trait = flagellant
+		trait = flagellant
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		increase_wounds_effect = { REASON = whipping }
+		if = {
+			limit = {
+				faith = { has_doctrine_parameter = self_mutilation_active }
+			}
+			add_piety = minor_piety_value
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_zeal = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = flagellant
+			}
+		}
+	}
+
+	#Profligate: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.1701.d.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.1701.d.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		remove_short_term_gold = major_gold_value
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+
+	#Journaller: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1701.g.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1701.g.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+
+	#Confider: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.1701.h.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.1701.h.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+				}
+				if = {
+					limit = {
+						this = { has_relation_best_friend = root }
+					}
+					add_relation_flag = {
+						target = root
+						relation = best_friend
+						flag = has_been_confided_in
+					}
+				}
+				else = {
+					add_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+
+	#Drunkard: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.1701.i.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.1701.i.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+
+	#Hashishiyah: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.1701.j.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.1701.j.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.1701.k
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = lazy
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_lazy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1701_desc_lazy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = wrathful
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_wrathful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1701_desc_wrathful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = impatient
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_impatient }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1701_desc_impatient
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = arrogant
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_arrogant }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1701_desc_arrogant
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = arbitrary
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_arbitrary }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1701_desc_arbitrary
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = trusting
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_trusting }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1701_desc_trusting
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = stubborn
+					NOT = { has_character_flag = had_stress_threshold_1701_desc_stubborn }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1701_desc_stubborn
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Too Busy
+# by Ewan Cowhig Croft
+# #1711
+##################################################
+
+#	Everything just seems to pile up on you these days.
+#		by Ewan Cowhig Croft
+stress_threshold.1711 = {
+	type = character_event
+	title = stress_threshold.1711.t
+	desc = {
+		desc = stress_threshold.1711.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = greedy
+					NOT = { has_character_flag = had_stress_threshold_1711_greedy }
+				}
+				desc = stress_threshold.1711.desc.greedy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = diligent
+					NOT = { has_character_flag = had_stress_threshold_1711_diligent }
+				}
+				desc = stress_threshold.1711.desc.diligent
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = patient
+					NOT = { has_character_flag = had_stress_threshold_1711_patient }
+				}
+				desc = stress_threshold.1711.desc.patient
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = deceitful
+					NOT = { has_character_flag = had_stress_threshold_1711_deceitful }
+				}
+				desc = stress_threshold.1711.desc.deceitful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = ambitious
+					NOT = { has_character_flag = had_stress_threshold_1711_ambitious }
+				}
+				desc = stress_threshold.1711.desc.ambitious
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = just
+					NOT = { has_character_flag = had_stress_threshold_1711_just }
+				}
+				desc = stress_threshold.1711.desc.just
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = zealous
+					NOT = { has_character_flag = had_stress_threshold_1711_zealous }
+				}
+				desc = stress_threshold.1711.desc.zealous
+			}
+			desc = stress_threshold.1711.desc.fallback
+		}
+		desc = stress_threshold.1711.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = stress
+	}
+	right_portrait = {
+		character = scope:courtier
+		animation = stunned
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		any_courtier = {
+			is_available_adult = yes
+		}
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = greedy
+			has_trait = diligent
+			has_trait = patient
+			has_trait = deceitful
+			has_trait = ambitious
+			has_trait = just
+			has_trait = zealous
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_flagellant = yes
+			has_trait = flagellant
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_improvident = yes
+			has_trait = improvident
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_athletic = yes
+			has_trait = athletic
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = flagellant
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = improvident
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = athletic
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = flagellant }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = improvident }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = athletic }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+		random_courtier = {
+			limit = { is_available_adult = yes }
+			save_scope_as = courtier
+			add_opinion = {
+				target = root
+				modifier = insulted_opinion
+				opinion = -15
+			}
+		}
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = flagellant	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = improvident	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = athletic	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+
+		#Then potential ones.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_flagellant = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_improvident = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_athletic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Reclusive: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.1711.a.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.1711.a.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Flagellant: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.1711.b.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.1711.b.flagellant.effect
+		}
+		
+		add_trait = flagellant
+		trait = flagellant
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		increase_wounds_effect = { REASON = whipping }
+		if = {
+			limit = {
+				faith = { has_doctrine_parameter = self_mutilation_active }
+			}
+			add_piety = minor_piety_value
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_zeal = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = flagellant
+			}
+		}
+	}
+	
+	#Profligate: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.1711.c.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.1711.c.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		remove_short_term_gold = major_gold_value
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+	
+	#Improvident: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.1711.d.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.1711.d.improvident.effect
+		}
+		
+		add_trait = improvident
+		trait = improvident
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		remove_short_term_gold = major_gold_value
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_greed = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = improvident
+			}
+		}
+	}
+	
+	#Journaller: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1711.e.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1711.e.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Athletic: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_athletic
+		}
+		name = {
+			trigger = { can_be_athletic = yes }
+			text = stress_threshold.1711.f.athletic.gain
+		}
+		name = {
+			trigger = { has_trait = athletic }
+			text = stress_threshold.1711.f.athletic.effect
+		}
+		
+		add_trait = athletic
+		trait = athletic
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.5
+				ai_boldness = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = athletic
+			}
+		}
+	}
+	
+	#Drunkard: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.1711.g.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.1711.g.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.1711.h.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.1711.h.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.1711.i
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = greedy
+					NOT = { has_character_flag = had_stress_threshold_1711_greedy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1711_greedy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = diligent
+					NOT = { has_character_flag = had_stress_threshold_1711_diligent }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1711_diligent
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = patient
+					NOT = { has_character_flag = had_stress_threshold_1711_patient }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1711_patient
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = deceitful
+					NOT = { has_character_flag = had_stress_threshold_1711_deceitful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1711_deceitful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = ambitious
+					NOT = { has_character_flag = had_stress_threshold_1711_ambitious }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1711_ambitious
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = just
+					NOT = { has_character_flag = had_stress_threshold_1711_just }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1711_just
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = zealous
+					NOT = { has_character_flag = had_stress_threshold_1711_zealous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1711_zealous
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Impostor Syndrome
+# by Ewan Cowhig Croft
+# #1721
+##################################################
+
+#	Clearly you just aren't good enough for your rank!
+#		by Ewan Cowhig Croft
+stress_threshold.1721 = {
+	type = character_event
+	title = stress_threshold.1721.t
+	desc = {
+		desc = stress_threshold.1721.desc.intro
+		first_valid = {
+			triggered_desc = {	#Temperate is slightly out of order so that the easter egg final option works.
+				trigger = {
+					has_trait = temperate
+					NOT = { has_character_flag = had_stress_threshold_1721_temperate }
+				}
+				desc = stress_threshold.1721.desc.temperate
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = chaste
+					NOT = { has_character_flag = had_stress_threshold_1721_chaste }
+				}
+				desc = stress_threshold.1721.desc.chaste
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = generous
+					NOT = { has_character_flag = had_stress_threshold_1721_generous }
+				}
+				desc = stress_threshold.1721.desc.generous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = calm
+					NOT = { has_character_flag = had_stress_threshold_1721_calm }
+				}
+				desc = stress_threshold.1721.desc.calm
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = humble
+					NOT = { has_character_flag = had_stress_threshold_1721_humble }
+				}
+				desc = stress_threshold.1721.desc.humble
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = honest
+					NOT = { has_character_flag = had_stress_threshold_1721_honest }
+				}
+				desc = stress_threshold.1721.desc.honest
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = craven
+					NOT = { has_character_flag = had_stress_threshold_1721_craven }
+				}
+				desc = stress_threshold.1721.desc.craven
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = content
+					NOT = { has_character_flag = had_stress_threshold_1721_content }
+				}
+				desc = stress_threshold.1721.desc.content
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = cynical
+					NOT = { has_character_flag = had_stress_threshold_1721_cynical }
+				}
+				# Would collide with duke_female_polish before
+				desc = stress_threshold.1721.desc.cynical_no_collide
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = paranoid
+					NOT = { has_character_flag = had_stress_threshold_1721_paranoid }
+				}
+				desc = stress_threshold.1721.desc.paranoid
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = callous
+					NOT = { has_character_flag = had_stress_threshold_1721_callous }
+				}
+				desc = stress_threshold.1721.desc.callous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = compassionate
+					NOT = { has_character_flag = had_stress_threshold_1721_compassionate }
+				}
+				desc = stress_threshold.1721.desc.compassionate
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = fickle
+					NOT = { has_character_flag = had_stress_threshold_1721_fickle }
+				}
+				desc = stress_threshold.1721.desc.fickle
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = vengeful
+					NOT = { has_character_flag = had_stress_threshold_1721_vengeful }
+				}
+				desc = stress_threshold.1721.desc.vengeful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = forgiving
+					NOT = { has_character_flag = had_stress_threshold_1721_forgiving }
+				}
+				desc = stress_threshold.1721.desc.forgiving
+			}
+			desc = stress_threshold.1721.desc.fallback
+		}
+		desc = stress_threshold.1721.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = worry
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = chaste
+			has_trait = temperate
+			has_trait = generous
+			has_trait = calm
+			has_trait = humble
+			has_trait = honest
+			has_trait = craven
+			has_trait = content
+			has_trait = cynical
+			has_trait = paranoid
+			has_trait = callous
+			has_trait = compassionate
+			has_trait = fickle
+			has_trait = vengeful
+			has_trait = forgiving
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_irritable = yes
+			has_trait = irritable
+			can_be_flagellant = yes
+			has_trait = flagellant
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_improvident = yes
+			has_trait = improvident
+			can_be_contrite = yes
+			has_trait = contrite
+			can_be_comfort_eater = yes
+			has_trait = comfort_eater
+			can_be_inappetetic = yes
+			has_trait = inappetetic
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = irritable
+		}
+		modifier = {
+			add = 10
+			has_trait = flagellant
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = improvident
+		}
+		modifier = {
+			add = 10
+			has_trait = contrite
+		}
+		modifier = {
+			add = 10
+			has_trait = comfort_eater
+		}
+		modifier = {
+			add = 10
+			has_trait = inappetetic
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = flagellant }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = improvident }
+				has_witnessed_stress_coping_trait = { TRAIT = contrite }
+				has_witnessed_stress_coping_trait = { TRAIT = comfort_eater }
+				has_witnessed_stress_coping_trait = { TRAIT = inappetetic }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = irritable	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = flagellant	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = improvident	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Contrite (compelled to reveal own secrets)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = contrite	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = comfort_eater	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Inappetetic (lack of appetite)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = inappetetic	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_flagellant = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_improvident = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Contrite (compelled to reveal own secrets)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_contrite = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_comfort_eater = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Inappetetic (lack of appetite)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_inappetetic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Reclusive: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.1721.a.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.1721.a.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Irritable: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.1721.b.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.1721.b.irritable.effect
+		}
+		
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+	
+	#Flagellant: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.1721.c.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.1721.c.flagellant.effect
+		}
+		
+		add_trait = flagellant
+		trait = flagellant
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		increase_wounds_effect = { REASON = whipping }
+		if = {
+			limit = {
+				faith = { has_doctrine_parameter = self_mutilation_active }
+			}
+			add_piety = minor_piety_value
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_zeal = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = flagellant
+			}
+		}
+	}
+	
+	#Profligate: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.1721.d.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.1721.d.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		remove_short_term_gold = major_gold_value
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+	
+	#Improvident: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.1721.e.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.1721.e.improvident.effect
+		}
+		
+		add_trait = improvident
+		trait = improvident
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		remove_short_term_gold = major_gold_value
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_greed = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = improvident
+			}
+		}
+	}
+	
+	#Contrite: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_contrite
+		}
+		name = {
+			trigger = { can_be_contrite = yes }
+			text = stress_threshold.1721.f.contrite.gain
+		}
+		name = {
+			trigger = { has_trait = contrite }
+			text = stress_threshold.1721.f.contrite.effect
+		}
+		
+		add_trait = contrite
+		trait = contrite
+
+		contrite_reveal_secrets_effect = yes # Includes stress loss based on what secrets were revealed
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_honor = 0.5
+				ai_compassion = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = contrite
+			}
+		}
+	}
+	
+	#Comfort Eater: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		name = {
+			trigger = { can_be_comfort_eater = yes }
+			text = stress_threshold.1721.g.comfort_eater.gain
+		}
+		name = {
+			trigger = { has_trait = comfort_eater }
+			text = stress_threshold.1721.g.comfort_eater.effect
+		}
+		
+		add_trait = comfort_eater
+		trait = comfort_eater
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = comfort_eater
+			}
+		}
+	}
+	
+	#Inappetetic: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_inappetetic
+		}
+		name = {
+			trigger = { can_be_inappetetic = yes }
+			text = stress_threshold.1721.h.inappetetic.gain
+		}
+		name = {
+			trigger = { has_trait = inappetetic }
+			text = stress_threshold.1721.h.inappetetic.effect
+		}
+		
+		add_trait = inappetetic
+		trait = inappetetic
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				has_trait = inappetetic
+			}
+			inappetetic_advance_starvation_effect = yes
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = -0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = inappetetic
+			}
+		}
+	}
+	
+	#Journaller: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1721.i.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1721.i.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Confider: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.1721.j.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.1721.j.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+				}
+				add_relation_flag = {
+					target = root
+					relation = friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+	
+	#Drunkard: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.1721.k.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.1721.k.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.1721.l.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.1721.l.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.1721.m
+
+		trigger = {	#Always appear, unless the cannibal option is available.
+			NAND = {
+				has_trait = temperate
+				NOT = { has_character_flag = had_stress_threshold_1721_temperate }
+				is_cannibal_trigger = yes
+			}
+		}
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	#Eat someone till you feel better.
+	option = {
+		name = stress_threshold.1721.n
+
+		trigger = {
+			has_trait = temperate
+			NOT = { has_character_flag = had_stress_threshold_1721_temperate }
+			is_cannibal_trigger = yes
+		}
+
+		trait = cannibal
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = chaste
+					NOT = { has_character_flag = had_stress_threshold_1721_chaste }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_chaste
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = temperate
+					NOT = { has_character_flag = had_stress_threshold_1721_temperate }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_temperate
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = generous
+					NOT = { has_character_flag = had_stress_threshold_1721_generous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_generous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = calm
+					NOT = { has_character_flag = had_stress_threshold_1721_calm }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_calm
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = humble
+					NOT = { has_character_flag = had_stress_threshold_1721_humble }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_humble
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = honest
+					NOT = { has_character_flag = had_stress_threshold_1721_honest }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_honest
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = craven
+					NOT = { has_character_flag = had_stress_threshold_1721_craven }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_craven
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = content
+					NOT = { has_character_flag = had_stress_threshold_1721_content }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_content
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = cynical
+					NOT = { has_character_flag = had_stress_threshold_1721_cynical }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_cynical
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = paranoid
+					NOT = { has_character_flag = had_stress_threshold_1721_paranoid }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_paranoid
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = callous
+					NOT = { has_character_flag = had_stress_threshold_1721_callous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_callous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = compassionate
+					NOT = { has_character_flag = had_stress_threshold_1721_compassionate }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_compassionate
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = fickle
+					NOT = { has_character_flag = had_stress_threshold_1721_fickle }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_fickle
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = vengeful
+					NOT = { has_character_flag = had_stress_threshold_1721_vengeful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_vengeful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = forgiving
+					NOT = { has_character_flag = had_stress_threshold_1721_forgiving }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1721_forgiving
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# No Time for Myself
+# by Ewan Cowhig Croft
+# #1731
+##################################################
+
+#	Your limited time to yourself is intruded on.
+#		by Ewan Cowhig Croft
+stress_threshold.1731 = {
+	type = character_event
+	title = stress_threshold.1731.t
+	desc = {
+		desc = stress_threshold.1731.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = lustful
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_lustful }
+				}
+				desc = stress_threshold.1731.desc.lustful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = gluttonous
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_gluttonous }
+				}
+				desc = stress_threshold.1731.desc.gluttonous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = brave
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_brave }
+				}
+				desc = stress_threshold.1731.desc.brave
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = shy
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_shy }
+				}
+				desc = stress_threshold.1731.desc.shy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = gregarious
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_gregarious }
+				}
+				desc = stress_threshold.1731.desc.gregarious
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = sadistic
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_sadistic }
+				}
+				desc = stress_threshold.1731.desc.sadistic
+			}
+			desc = stress_threshold.1731.desc.fallback
+		}
+		desc = stress_threshold.1731.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain
+	}
+	left_portrait = {
+		character = root
+		animation = disapproval
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = lustful
+			has_trait = gluttonous
+			has_trait = brave
+			has_trait = shy
+			has_trait = gregarious
+			has_trait = sadistic
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+
+			can_be_rakish = yes
+			has_trait = rakish
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_comfort_eater = yes
+			has_trait = comfort_eater
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			can_be_athletic = yes
+			has_trait = athletic
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = rakish
+		}
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = comfort_eater
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			has_trait = athletic
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = improvident }
+				has_witnessed_stress_coping_trait = { TRAIT = comfort_eater }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = athletic }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+		root.capital_province = { save_scope_as = capital_province }
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = rakish	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = comfort_eater	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider
+				any_relation = {
+					type = friend
+					count >= 1
+				}
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = athletic
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_rakish = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_comfort_eater = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+				any_relation = {
+					type = friend
+					count >= 1
+				}
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_athletic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Rakish: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_rakish
+		}
+		name = {
+			trigger = { can_be_rakish = yes }
+			text = stress_threshold.1731.a.rakish.gain
+		}
+		name = {
+			trigger = { has_trait = rakish }
+			text = stress_threshold.1731.a.rakish.effect
+		}
+		
+		add_trait = rakish
+		trait = rakish
+
+		rakish_brothel_night_effect = yes # Stress reduction is included in this effect.
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = rakish
+			}
+		}
+	}
+	
+	#Reclusive: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.1731.b.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.1731.b.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Profligate: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.1731.c.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.1731.c.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		remove_short_term_gold = major_gold_value
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+
+	#Comfort Eater: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		name = {
+			trigger = { can_be_comfort_eater = yes }
+			text = stress_threshold.1731.d.comfort_eater.gain
+		}
+		name = {
+			trigger = { has_trait = comfort_eater }
+			text = stress_threshold.1731.d.comfort_eater.effect
+		}
+		
+		add_trait = comfort_eater
+		trait = comfort_eater
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = comfort_eater
+			}
+		}
+	}
+
+	#Journaller: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.1731.e.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.1731.e.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Confider: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.1731.f.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.1731.f.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+				}
+				if = {
+					limit = {
+						has_relation_best_friend = root
+					}
+					add_relation_flag = {
+						target = root
+						relation = best_friend
+						flag = has_been_confided_in
+					}
+				}
+				else = {
+					add_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+	
+	#Athletic: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_athletic
+		}
+		name = {
+			trigger = { can_be_athletic = yes }
+			text = stress_threshold.1731.g.athletic.gain
+		}
+		name = {
+			trigger = { has_trait = athletic }
+			text = stress_threshold.1731.g.athletic.effect
+		}
+		
+		add_trait = athletic
+		trait = athletic
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.5
+				ai_boldness = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = athletic
+			}
+		}
+	}
+	
+	#Drunkard: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.1731.h.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.1731.h.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: minor stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.1731.i.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.1731.i.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = minor_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.1731.g
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = lustful
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_lustful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1731_desc_lustful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = gluttonous
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_gluttonous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1731_desc_gluttonous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = brave
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_brave }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1731_desc_brave
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = shy
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_shy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1731_desc_shy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = gregarious
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_gregarious }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1731_desc_gregarious
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = sadistic
+					NOT = { has_character_flag = had_stress_threshold_1731_desc_sadistic }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_1731_desc_sadistic
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################################################################################################################################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ TIER 2 STRESS EVENTS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
+##################################################################################################################################################################
+
+#############################
+# Taken for Granted			#
+# by Sean Hughes			#
+# 2001						#
+#############################
+stress_threshold.2001 = {
+	type = character_event
+	title = stress_threshold.2001.t
+	desc = stress_threshold.2001.desc
+	
+	theme = mental_break
+	left_portrait = {
+		character = root
+		animation = anger
+	}
+	right_portrait = {
+		character = scope:victim
+		animation = dismissal
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	trigger = {
+		is_travelling = no
+		any_courtier = { is_imprisoned = no }
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		stress_get_victim_in_court_effect = yes # Find a good courtier to be our possible victim, heavily weighted towards our own children.
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# Option A: Become arbitrary/lose diplomacy, major stress loss.
+	option = {
+		name = {
+			trigger = { NOT = { has_trait = arbitrary} }
+			text = stress_threshold.2001.arbitrary.gain
+		}
+		name = {
+			trigger = { has_trait = arbitrary }
+			text = stress_threshold.2001.arbitrary.effect
+		}
+
+		trait = arbitrary
+
+		if = {
+			limit = {
+				has_trait = arbitrary
+			}
+			if = {
+				limit = {
+					diplomacy > 0
+				}
+				add_diplomacy_skill = -1
+			}
+			else = {
+				add_prestige = medium_prestige_loss
+			}
+		}
+		else = {
+			stress_replace_personality_trait_with_opposite_effect = { TRAIT = arbitrary }
+		}
+
+		add_stress = major_stress_impact_loss
+	}
+
+	# Option B: Imprison a random courtier, medium stress loss, but you will (probably) suffer Tyranny penalties.
+	option = {
+		trigger = { exists = scope:victim  }
+		name = stress_threshold.2001.imprison_victim
+
+		imprison_character_effect = {
+			TARGET = scope:victim
+			IMPRISONER = root
+		}
+
+		add_stress = medium_stress_impact_loss
+
+	}
+	
+	# Option C: Just try to work through it, gain stress.
+	option = {
+		name = stress_threshold.2001.endure
+
+		add_stress = mental_break_opt_out_stress_gain
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+#############################
+# Unwelcome Home			#
+# by Sean Hughes			#
+# 2101						#
+#############################
+
+stress_threshold.2101 = {
+	type = character_event
+	title = stress_threshold.2101.t
+	desc = stress_threshold.2101.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = worry
+	}
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	trigger = {
+		NOT = {	
+			faith = {
+				has_doctrine_parameter = witchcraft_accepted
+			}
+		}
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# Option A: Turn to dark magic, medium stress loss, gain witch secret.
+	option = {
+		name = {
+			trigger = {
+				NOR = {
+					has_trait = witch
+					any_secret = { type = secret_witch }
+				}
+			}
+			text = stress_threshold.2101.witch.gain
+		}
+		name = {
+			trigger = {
+				OR = {
+					has_trait = witch
+					any_secret = { type = secret_witch }
+				}
+			}
+			text = stress_threshold.2101.witch.effect
+		}
+
+		if = {
+			limit = {
+				NOR = {
+					has_trait = witch
+					any_secret = { type = secret_witch }
+				}
+			}
+			if = {
+				limit = {
+					NOT = {	
+						faith = {
+							has_doctrine_parameter = witchcraft_accepted
+						}
+					}
+				}
+				add_secret = {
+					type = secret_witch
+				}
+				# If you have a legend maybe we change it?
+				if = {
+					limit = {
+						has_legend_chapter_trigger = { CHAPTER = opening }
+					}
+					random = {
+						chance = 75
+						send_interface_toast = {
+							title = legend_chapter_change_toast
+							left_icon = root
+							promoted_legend = {
+								set_legend_chapter = {
+									name = opening
+									localization_key = legend_chapter_opening_witch
+								}
+							}
+						}
+					}
+				}
+			}
+			else = {
+				add_trait = witch
+				add_piety_level = -1
+				# If you have a legend maybe we change it?
+				if = {
+					limit = {
+						has_legend_chapter_trigger = { CHAPTER = opening }
+					}
+					random = {
+						chance = 75
+						send_interface_toast = {
+							title = legend_chapter_change_toast
+							left_icon = root
+							promoted_legend = {
+								set_legend_chapter = {
+									name = opening
+									localization_key = legend_chapter_opening_witch
+								}
+							}
+						}
+					}
+				}
+			}
+			
+		}
+		
+		add_stress = medium_stress_impact_loss
+	}
+
+	# Option B-1: Become drunkard, go on drinking spree, medium stress loss.
+	option = {
+		trigger = {
+			OR = {
+				can_be_drunkard = yes
+				has_trait = drunkard
+			}
+		}
+		name = stress_threshold.2101.drunkard.effect
+
+		trait = drunkard
+
+		if = {
+			limit = {
+				NOT = { has_trait = drunkard }
+			}
+			add_trait = drunkard
+		}	
+		add_character_modifier = {
+			modifier = stress_drinking_binge
+			years = 3
+		}
+		
+		add_stress = medium_stress_impact_loss
+
+	}
+
+	# Option B-2: Become hashishiyah, go on hashish spree, medium stress loss.
+	option = {
+		trigger = {
+			OR = {
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+		name = stress_threshold.2101.hashishiyah.effect
+
+
+		trait = hashishiyah
+
+		if = {
+			limit = {
+				NOT = { has_trait = hashishiyah }
+			}
+			add_trait = hashishiyah
+		}	
+		
+		add_character_modifier = {
+			modifier = stress_hashish_stupor
+			years = 3
+		}
+
+		add_stress = medium_stress_impact_loss
+	}
+
+	# Option C: Try to endure it.
+	option = {
+		name = stress_threshold.2101.endure
+		add_stress = mental_break_opt_out_stress_gain
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+
+#############################
+# Boiling Anger				#
+# by Linnéa Thimrén			#
+# 2201						#
+#############################
+stress_threshold.2201 = {
+	type = character_event
+	title = stress_threshold.2201.t
+	desc = {
+		triggered_desc = {
+			trigger = { has_government = landless_adventurer_government }
+			desc = stress_threshold.2201.desc.insult_adventurer
+		}
+		desc = stress_threshold.2201.desc
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						liege = scope:character_to_yell_at
+					}
+					desc = stress_threshold.2201.desc_liege
+				}
+				desc = stress_threshold.2201.desc_vassal
+			}
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					OR = {
+						has_trait = calm
+						has_trait = craven
+						has_trait = shy
+					}
+				}
+				desc = stress_threshold.2201.desc.calm
+			}
+			desc = stress_threshold.2201.desc.ending
+		}
+	}
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = no }
+		reference = throne_room
+	}
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = rage
+	}
+	right_portrait = {
+		character = scope:character_to_yell_at
+		animation = anger
+		triggered_animation = {
+			trigger = {
+				root = {
+					dread_modified_ai_boldness = {
+						dreaded_character = scope:character_to_yell_at
+						value <= low_positive_ai_value
+					}
+				}
+			}
+			animation = fear
+		}
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	trigger = {
+		OR = {
+			AND = {
+				exists = liege
+				liege != root
+				NOT = { has_relation_rival = liege }
+			}
+			any_vassal = {
+				is_powerful_vassal = yes
+				NOT = { has_relation_rival = root }
+			}
+			AND = {
+				has_government = landless_adventurer_government
+				any_courtier = {
+					NOT = { has_relation_rival = root }
+				}
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+
+		modifier = { #More likely if you're angry!
+			add = 2
+			OR = {
+				has_trait = wrathful
+				has_trait = irritable
+				has_trait = burdened
+			}
+		}
+
+		modifier = { #Scared characters are less likely to get this
+			add = -0.75
+			OR = {
+				AND = {
+					exists = liege
+					liege != root
+					NOT = { has_relation_rival = liege }
+					is_ai = yes
+					liege = {
+						dread_modified_ai_boldness = {
+							dreaded_character = root
+							value <= low_positive_ai_value
+						}
+					}
+				}
+				any_vassal = {
+					is_powerful_vassal = yes
+					NOT = { has_relation_rival = root }
+					is_ai = yes
+					dread_modified_ai_boldness = {
+						dreaded_character = root
+						value <= low_positive_ai_value
+					}
+				}
+				AND = {
+					has_government = landless_adventurer_government
+					any_courtier = {
+						NOT = { has_relation_rival = root }
+					}
+					dread_modified_ai_boldness = {
+						dreaded_character = root
+						value <= low_positive_ai_value
+					}
+				}
+			}
+		}
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		#Let's find your liege or a powerful vassal!
+		if = {
+			limit = {
+				exists = liege
+				liege != root
+				NOT = { has_relation_rival = liege }
+			}
+			liege = {
+				save_scope_as = character_to_yell_at
+			}
+		}
+		else_if = {
+			limit = {
+				any_vassal = {
+					is_powerful_vassal = yes
+					NOT = { has_relation_rival = root }
+				}
+			}
+			random_vassal = {
+				limit = {
+					is_powerful_vassal = yes
+					NOT = { has_relation_rival = root }
+					has_relation_potential_rival = root
+				}
+				alternative_limit = {
+					is_powerful_vassal = yes
+					NOT = { has_relation_rival = root }
+				}
+				weight = {
+					base = 1
+					is_of_minor_interest_to_weight_up_modifier = { CHARACTER = root }
+					is_of_major_interest_to_weight_up_modifier = { CHARACTER = root }
+				}
+				save_scope_as = character_to_yell_at
+			}
+		}
+		else = {
+			random_courtier = {
+				limit = {
+					NOT = { has_relation_rival = root }
+				}
+				weight = {
+					base = 1
+					is_of_minor_interest_to_weight_up_modifier = { CHARACTER = root }
+					is_of_major_interest_to_weight_up_modifier = { CHARACTER = root }
+				}
+				save_scope_as = character_to_yell_at
+			}
+		}
+		scope:character_to_yell_at = {
+			add_opinion = {
+				target = root
+				modifier = insulted_opinion
+				opinion = -40
+			}
+		}
+
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# Double down on the insults!
+	option = {
+		name = stress_threshold.2201.a
+
+		if = {
+			limit = {
+				NOT = { has_trait = irritable }
+			}
+			add_trait = irritable
+		}
+
+		add_character_modifier = {
+			modifier = angry_at_everyone_modifier
+			years = 5
+		}
+
+		add_stress = medium_stress_impact_loss
+
+		if = {
+			limit = {
+				has_relation_potential_rival = scope:character_to_yell_at
+				NOT = { has_relation_rival = scope:character_to_yell_at }
+			}
+			show_as_tooltip = {
+				set_relation_rival = {
+					target = scope:character_to_yell_at
+					reason = rival_lashed_out_against
+				}
+			}
+			save_scope_value_as = {
+				name = rival
+				value = yes
+			}
+		}
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_rival_trigger = { CHARACTER = scope:character_to_yell_at }
+				}
+				set_relation_potential_rival = scope:character_to_yell_at
+			}
+		}
+
+		ai_chance = {
+			base = 100
+
+			modifier = {
+				add = 50
+				has_trait = wrathful
+			}
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+			}
+		}
+	}
+
+	# Save face - because of gregarious trait
+	option = {
+		name = stress_threshold.2201.save
+		trigger = {
+			has_trait = gregarious
+			diplomacy < high_skill_rating
+		}
+		trait = gregarious
+		flavor = stress_threshold.2201.save_tt
+
+		scope:character_to_yell_at = {
+			add_opinion = {
+				target = root
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+
+		add_stress = medium_stress_impact_loss
+
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_rival_trigger = { CHARACTER = scope:character_to_yell_at }
+				}
+				set_relation_potential_rival = scope:character_to_yell_at
+			}
+		}
+
+		ai_chance = {
+			base = 500
+		}
+	}
+
+	#Save face - because of diplo skill
+	option = {
+		name = stress_threshold.2201.save
+		trigger = {
+			diplomacy >= high_skill_rating
+		}
+		skill = diplomacy
+		flavor = stress_threshold.2201.save_tt
+
+		scope:character_to_yell_at = {
+			add_opinion = {
+				target = root
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+
+		add_stress = medium_stress_impact_loss
+
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_rival_trigger = { CHARACTER = scope:character_to_yell_at }
+				}
+				set_relation_potential_rival = scope:character_to_yell_at
+			}
+		}
+
+		ai_chance = {
+			base = 500
+		}
+	}
+	
+	# Say sorry and repress your feelings, gain stress.
+	option = {
+		name = {
+			trigger = { scope:character_to_yell_at = root.liege }
+			text = stress_threshold.2201.liege
+		}
+		name = {
+			trigger = { scope:character_to_yell_at != root.liege }
+			text = stress_threshold.2201.c
+		}
+
+		scope:character_to_yell_at = {
+			add_opinion = {
+				target = root
+				modifier = friendliness_opinion
+				opinion = 10
+			}
+		}
+
+		add_stress = mental_break_opt_out_stress_gain
+
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_rival_trigger = { CHARACTER = scope:character_to_yell_at }
+				}
+				set_relation_potential_rival = scope:character_to_yell_at
+			}
+		}
+
+		ai_chance = {
+			base = 0
+		}
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+		scope:character_to_yell_at = { trigger_event = stress_threshold.2202 }
+	}
+}
+
+
+#Response event for character_to_yell_at
+stress_threshold.2202 = {
+	type = character_event
+	title = stress_threshold.2202.t
+	desc = {
+		desc = {
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						scope:stress_character = { has_government = landless_adventurer_government }
+					}
+					desc = stress_threshold.2201.desc.insult_adventurer
+				}
+				desc = stress_threshold.2201.desc.insult
+			}
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:stress_character = liege
+				}
+				desc = stress_threshold.2202.desc.liege
+			}
+			triggered_desc = {
+				trigger = {
+					scope:stress_character = { is_landed = yes }
+					target_is_vassal_or_below = scope:stress_character
+				}
+				desc = stress_threshold.2202.desc.vassal
+			}
+			desc = stress_threshold.2202.desc.other_relationship
+		}
+		desc = stress_threshold.2202.desc
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					exists = scope:rival
+				}
+				desc = stress_threshold.2202.desc.rival
+			}
+			desc = stress_threshold.2202.desc.other
+		}
+	}
+	theme = unfriendly
+	left_portrait = {
+		character = root
+		triggered_animation = {
+			trigger = {
+				root = {
+					dread_modified_ai_boldness = {
+						dreaded_character = scope:character_to_yell_at
+						value <= low_positive_ai_value
+					}
+				}
+			}
+			animation = fear
+		}
+		animation = dismissal
+	}
+	right_portrait = {
+		character = scope:stress_character
+		animation = rage
+	}
+
+	immediate = {
+		if = {
+			limit = {
+				exists = scope:rival
+			}
+			set_relation_rival = {
+				target = scope:stress_character
+				reason = rival_lashed_out_against
+			}
+		}
+	}
+
+	option = { #They're now my rival!
+		name = stress_threshold.2202.a
+		trigger = {
+			exists = scope:rival
+		}
+	}
+
+	option = { #They're so rude.
+		name = stress_threshold.2202.b
+		trigger = {
+			NOT = { exists = scope:rival }
+		}
+		add_stress = medium_stress_loss
+	}
+}
+
+
+##################################################
+# Growing Need
+# by Ewan Cowhig Croft
+# #2301
+##################################################
+
+#	You just want to drop everything and re-engage with an old passion.
+#		by Ewan Cowhig Croft
+stress_threshold.2301 = {
+	type = character_event
+	title = stress_threshold.2301.t
+	desc = {
+		desc = stress_threshold.2301.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = lustful
+					NOT = { has_character_flag = had_stress_threshold_2301_desc_lustful }
+				}
+				desc = stress_threshold.2301.desc.lustful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = gluttonous
+					NOT = { has_character_flag = had_stress_threshold_2301_desc_gluttonous }
+				}
+				desc = stress_threshold.2301.desc.gluttonous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = greedy
+					NOT = { has_character_flag = had_stress_threshold_2301_desc_greedy }
+				}
+				desc = stress_threshold.2301.desc.greedy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = gregarious
+					NOT = { has_character_flag = had_stress_threshold_2301_desc_gregarious }
+				}
+				desc = stress_threshold.2301.desc.gregarious
+			}
+			desc = stress_threshold.2301.desc.fallback
+		}
+		desc = stress_threshold.2301.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = sadness
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = lustful
+			has_trait = gluttonous
+			has_trait = greedy
+			has_trait = gregarious
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_rakish = yes
+			has_trait = rakish
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_comfort_eater = yes
+			has_trait = comfort_eater
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = rakish
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = comfort_eater
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = comfort_eater }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = rakish	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = comfort_eater	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_rakish = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_comfort_eater = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Rakish: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_rakish
+		}
+		name = {
+			trigger = { can_be_rakish = yes }
+			text = stress_threshold.2301.a.rakish.gain
+		}
+		name = {
+			trigger = { has_trait = rakish }
+			text = stress_threshold.2301.a.rakish.effect
+		}
+		
+		add_trait = rakish
+		trait = rakish
+
+		rakish_brothel_night_effect = yes # Stress reduction is included in this effect.
+		
+		if = {
+			limit = {
+				faith = { trait_is_virtue = lustful }
+			}
+			add_piety = miniscule_piety_gain
+		}
+		else_if = {
+			limit = {
+				faith = { trait_is_sin = lustful }
+			}
+			add_piety = medium_piety_loss
+		}
+		else = { add_piety = minor_piety_loss }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = rakish
+			}
+		}
+	}
+
+	#Profligate: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.2301.b.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.2301.b.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		#You buy a veritable glut of furniture.
+		add_character_modifier = {
+			modifier = glut_of_furniture_modifier
+			years = 10
+		}
+		add_prestige = minor_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+	
+	#Comfort Eater: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		name = {
+			trigger = { can_be_comfort_eater = yes }
+			text = stress_threshold.2301.c.comfort_eater.gain
+		}
+		name = {
+			trigger = { has_trait = comfort_eater }
+			text = stress_threshold.2301.c.comfort_eater.effect
+		}
+		
+		add_trait = comfort_eater
+		trait = comfort_eater
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Your constant feasts drain the local area of game.
+		capital_province.county = {
+			add_county_modifier = {
+				modifier = deplenished_forests_and_fields_modifier
+				years = 10
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = comfort_eater
+			}
+		}
+	}
+	
+	#Drunkard: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.2301.d.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.2301.d.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#You seem less scary, or at least less noble.
+		if = {
+			limit = { dread >= major_dread_loss }
+			add_dread = major_dread_loss
+			add_prestige = miniscule_prestige_loss
+		}
+		else = { add_prestige = medium_prestige_loss }
+
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.2301.e.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.2301.e.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#You seem less scary, or at least less noble.
+		if = {
+			limit = { dread >= major_dread_loss }
+			add_dread = major_dread_loss
+			add_prestige = miniscule_prestige_loss
+		}
+		else = { add_prestige = medium_prestige_loss }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.2301.f
+
+		#Account for stress; chance to gain non-genetic depression.
+		if = {
+			limit = {
+				has_trait_rank = {
+					trait = depressed
+					rank <= 0
+				}
+			}
+			random_list = {
+				80 = { add_stress = medium_stress_impact_gain }
+				20 = { add_trait = depressed_1 }
+			}
+		}
+		else = { add_stress = medium_stress_impact_gain }
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = lustful
+					NOT = { has_character_flag = had_stress_threshold_2301_desc_lustful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2301_desc_lustful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = gluttonous
+					NOT = { has_character_flag = had_stress_threshold_2301_desc_gluttonous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2301_desc_gluttonous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = greedy
+					NOT = { has_character_flag = had_stress_threshold_2301_desc_greedy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2301_desc_greedy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = gregarious
+					NOT = { has_character_flag = had_stress_threshold_2301_desc_gregarious }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2301_desc_gregarious
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Haunted by the Past
+# by Ewan Cowhig Croft
+# #2311
+##################################################
+
+#	You find yourself dwelling on the mistakes of yesteryear.
+#		by Ewan Cowhig Croft
+stress_threshold.2311 = {
+	type = character_event
+	title = stress_threshold.2311.t
+	desc = {
+		desc = stress_threshold.2311.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = generous
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_generous }
+				}
+				desc = stress_threshold.2311.desc.generous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = diligent
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_diligent }
+				}
+				desc = stress_threshold.2311.desc.diligent
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = wrathful
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_wrathful }
+				}
+				desc = stress_threshold.2311.desc.wrathful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = patient
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_patient }
+				}
+				desc = stress_threshold.2311.desc.patient
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = arrogant
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_arrogant }
+				}
+				desc = stress_threshold.2311.desc.arrogant
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = humble
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_humble }
+				}
+				desc = stress_threshold.2311.desc.humble
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = deceitful
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_deceitful }
+				}
+				desc = stress_threshold.2311.desc.deceitful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = zealous
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_zealous }
+				}
+				desc = stress_threshold.2311.desc.zealous
+			}
+			desc = stress_threshold.2311.desc.fallback
+		}
+		desc = stress_threshold.2311.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = shame
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = generous
+			has_trait = diligent
+			has_trait = wrathful
+			has_trait = patient
+			has_trait = arrogant
+			has_trait = humble
+			has_trait = deceitful
+			has_trait = zealous
+		}
+		#Copy is quite religious in flavour.
+		NOT = { has_trait = cynical }
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_rakish = yes
+			has_trait = rakish
+			can_be_irritable = yes
+			has_trait = irritable
+			can_be_flagellant = yes
+			has_trait = flagellant
+			can_be_improvident = yes
+			has_trait = improvident
+			can_be_contrite = yes
+			has_trait = contrite
+			can_be_inappetetic = yes
+			has_trait = inappetetic
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			can_be_athletic = yes
+			has_trait = athletic
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = rakish
+		}
+		modifier = {
+			add = 10
+			has_trait = irritable
+		}
+		modifier = {
+			add = 10
+			has_trait = flagellant
+		}
+		modifier = {
+			add = 10
+			has_trait = improvident
+		}
+		modifier = {
+			add = 10
+			has_trait = contrite
+		}
+		modifier = {
+			add = 10
+			has_trait = inappetetic
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			has_trait = athletic
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = flagellant }
+				has_witnessed_stress_coping_trait = { TRAIT = improvident }
+				has_witnessed_stress_coping_trait = { TRAIT = contrite }
+				has_witnessed_stress_coping_trait = { TRAIT = inappetetic }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = athletic }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = rakish	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = irritable	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = flagellant	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = improvident	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Contrite (compelled to reveal own secrets)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = contrite	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { #Inappetetic (lack of appetite)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = inappetetic	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = athletic
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_rakish = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_flagellant = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_improvident = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Contrite (compelled to reveal own secrets)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_contrite = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { #Inappetetic (lack of appetite)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_inappetetic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_athletic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Rakish: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_rakish
+		}
+		name = {
+			trigger = { can_be_rakish = yes }
+			text = stress_threshold.2311.a.rakish.gain
+		}
+		name = {
+			trigger = { has_trait = rakish }
+			text = stress_threshold.2311.a.rakish.effect
+		}
+		
+		add_trait = rakish
+		trait = rakish
+
+		rakish_brothel_night_effect = yes # Stress reduction is included in this effect.
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = lost_in_lust_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = rakish
+			}
+		}
+	}
+
+	#Irritable: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.2311.b.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.2311.b.irritable.effect
+		}
+		
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = agonising_irritations_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+	
+	#Flagellant: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.2311.c.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.2311.c.flagellant.effect
+		}
+		
+		add_trait = flagellant
+		trait = flagellant
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		increase_wounds_effect = { REASON = whipping }
+		if = {
+			limit = {
+				faith = { has_doctrine_parameter = self_mutilation_active }
+			}
+			add_piety = minor_piety_value
+		}
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = scars_over_scars_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_zeal = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = flagellant
+			}
+		}
+	}
+	
+	#Improvident: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.2311.d.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.2311.d.improvident.effect
+		}
+		
+		add_trait = improvident
+		trait = improvident
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = trying_to_buy_happiness_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_greed = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = improvident
+			}
+		}
+	}
+	
+	#Contrite: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_contrite
+		}
+		name = {
+			trigger = { can_be_contrite = yes }
+			text = stress_threshold.2311.e.contrite.gain
+		}
+		name = {
+			trigger = { has_trait = contrite }
+			text = stress_threshold.2311.e.contrite.effect
+		}
+		
+		add_trait = contrite
+		trait = contrite
+
+		contrite_reveal_secrets_effect = yes # Includes stress loss based on what secrets were revealed
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = outer_monologue_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_honor = 0.5
+				ai_compassion = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = contrite
+			}
+		}
+	}
+	
+	#Inappetetic: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_inappetetic
+		}
+		name = {
+			trigger = { can_be_inappetetic = yes }
+			text = stress_threshold.2311.f.inappetetic.gain
+		}
+		name = {
+			trigger = { has_trait = inappetetic }
+			text = stress_threshold.2311.f.inappetetic.effect
+		}
+		
+		add_trait = inappetetic
+		trait = inappetetic
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				has_trait = inappetetic
+			}
+			inappetetic_advance_starvation_effect = yes
+		}
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = sated_by_mistakes_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = -0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = inappetetic
+			}
+		}
+	}
+	
+	#Journaller: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.2311.g.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.2311.g.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = refuge_in_words_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Confider: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.2311.h.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.2311.h.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+				}
+				add_relation_flag = {
+					target = root
+					relation = friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = sorely_needed_confidant_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+	
+	#Athletic: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_athletic
+		}
+		name = {
+			trigger = { can_be_athletic = yes }
+			text = stress_threshold.2311.i.athletic.gain
+		}
+		name = {
+			trigger = { has_trait = athletic }
+			text = stress_threshold.2311.i.athletic.effect
+		}
+		
+		add_trait = athletic
+		trait = athletic
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = long_walks_of_the_mind_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.5
+				ai_boldness = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = athletic
+			}
+		}
+	}
+	
+	#Drunkard: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.2311.j.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.2311.j.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = bottom_of_a_bottle_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.2311.k.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.2311.k.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#Add regret coping modifier.
+		add_character_modifier = {
+			modifier = fogging_hard_memories_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.2311.l
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = generous
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_generous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2311_desc_generous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = diligent
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_diligent }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2311_desc_diligent
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = wrathful
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_wrathful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2311_desc_wrathful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = patient
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_patient }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2311_desc_patient
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = arrogant
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_arrogant }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2311_desc_arrogant
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = humble
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_humble }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2311_desc_humble
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = deceitful
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_deceitful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2311_desc_deceitful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = zealous
+					NOT = { has_character_flag = had_stress_threshold_2311_desc_zealous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2311_desc_zealous
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Befuddled by Court
+# by Ewan Cowhig Croft
+# #2321
+##################################################
+
+#Coping mechanisms themselves are deliberately excluded from the accepting traits in this event's options: whilst everyone has coping mechanisms, a mental break is especially egregious. Someone with the drunkard trait who never suffers from enough stress to have a mental break does not automatically commiserate with someone who has the drunkard trait and snaps.
+
+#	It feels like everything you do, others take advantage of.
+#		by Ewan Cowhig Croft
+stress_threshold.2321 = {
+	type = character_event
+	title = stress_threshold.2321.t
+	desc = {
+		desc = stress_threshold.2321.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = impatient
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_impatient }
+				}
+				desc = stress_threshold.2321.desc.impatient
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = honest
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_honest }
+				}
+				desc = stress_threshold.2321.desc.honest
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = trusting
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_trusting }
+				}
+				desc = stress_threshold.2321.desc.trusting
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = compassionate
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_compassionate }
+				}
+				desc = stress_threshold.2321.desc.compassionate
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = forgiving
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_forgiving }
+				}
+				desc = stress_threshold.2321.desc.forgiving
+			}
+			desc = stress_threshold.2321.desc.fallback
+		}
+		desc = stress_threshold.2321.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = no }
+		reference = throne_room
+	}
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = anger
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = impatient
+			has_trait = honest
+			has_trait = trusting
+			has_trait = compassionate
+			has_trait = forgiving
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_irritable = yes
+			has_trait = irritable
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_improvident = yes
+			has_trait = improvident
+			can_be_contrite = yes
+			has_trait = contrite
+			can_be_comfort_eater = yes
+			has_trait = comfort_eater
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = irritable
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = improvident
+		}
+		modifier = {
+			add = 10
+			has_trait = contrite
+		}
+		modifier = {
+			add = 10
+			has_trait = comfort_eater
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = improvident }
+				has_witnessed_stress_coping_trait = { TRAIT = contrite }
+				has_witnessed_stress_coping_trait = { TRAIT = comfort_eater }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		every_courtier = { add_to_list = affected_by_outburst }
+		every_vassal = { add_to_list = affected_by_outburst }
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				is_alive = yes
+				has_trait = irritable	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = improvident	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Contrite (compelled to reveal own secrets)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = contrite	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = comfort_eater	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_improvident = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Contrite (compelled to reveal own secrets)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_contrite = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_comfort_eater = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Irritable: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.2321.a.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.2321.a.irritable.effect
+		}
+		
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Court reacts to your little upset.
+		if = {
+			limit = {
+ 				any_in_list = {
+ 					list = affected_by_outburst
+   					count >= 1
+  				}
+  			}
+			every_in_list = {
+				list = affected_by_outburst
+				limit = {
+					is_alive = yes
+					NOR = {
+						has_trait = wrathful
+						has_trait = callous
+						has_trait = sadistic
+					}
+				}
+				custom = stress_threshold.2321.a.irritable.list
+				add_opinion = {
+					modifier = cruelty_opinion
+					opinion = -20
+					target = root
+				}
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+
+	#Profligate: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.2321.b.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.2321.b.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		#Court reacts to your little upset.
+		if = {
+			limit = {
+ 				any_in_list = {
+ 					list = affected_by_outburst
+   					count >= 1
+   					NOR = {
+						has_trait = fickle
+						has_trait = forgiving
+						has_trait = trusting
+					}
+					is_alive = yes
+  				}
+  			}
+			every_in_list = {
+				list = affected_by_outburst
+				limit = {
+					NOR = {
+						has_trait = fickle
+						has_trait = forgiving
+						has_trait = trusting
+					}
+					is_alive = yes
+				}
+				custom = stress_threshold.2321.b.profligate.list
+				add_opinion = {
+					modifier = respect_opinion
+					opinion = -20
+					target = root
+				}
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+	
+	#Improvident: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.2321.c.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.2321.c.improvident.effect
+		}
+		
+		add_trait = improvident
+		trait = improvident
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		#Court reacts to your little upset.
+		if = {
+			limit = {
+ 				any_in_list = {
+ 					list = affected_by_outburst
+   					count >= 1
+   					NOR = {
+						has_trait = generous
+						has_trait = compassionate
+						has_trait = humble
+					}
+					is_alive = yes
+				}
+			}
+			every_in_list = {
+				list = affected_by_outburst
+				limit = {
+					NOR = {
+						has_trait = generous
+						has_trait = compassionate
+						has_trait = humble
+					}
+					is_alive = yes
+				}
+				custom = stress_threshold.2321.c.improvident.list
+				add_opinion = {
+					modifier = weak_opinion
+					opinion = -20
+					target = root
+				}
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_greed = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = improvident
+			}
+		}
+	}
+	
+	#Contrite: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_contrite
+		}
+		name = {
+			trigger = { can_be_contrite = yes }
+			text = stress_threshold.2321.d.contrite.gain
+		}
+		name = {
+			trigger = { has_trait = contrite }
+			text = stress_threshold.2321.d.contrite.effect
+		}
+		
+		add_trait = contrite
+		trait = contrite
+
+		contrite_reveal_secrets_effect = yes # Includes stress loss based on what secrets were revealed
+		
+		#Court reacts to your little upset.
+		if = {
+			limit = {
+ 				any_in_list = {
+ 					list = affected_by_outburst
+   					count >= 1
+   					NOR = {
+						has_trait = honest
+						has_trait = just
+						has_trait = compassionate
+					}
+					is_alive = yes
+   				}
+   			}
+			every_in_list = {
+				list = affected_by_outburst
+				limit = {
+					NOR = {
+						has_trait = honest
+						has_trait = just
+						has_trait = compassionate
+					}
+					is_alive = yes
+				}
+				custom = stress_threshold.2321.d.contrite.list
+				add_opinion = {
+					modifier = disgusted_opinion
+					opinion = -20
+					target = root
+				}
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_honor = 0.5
+				ai_compassion = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = contrite
+			}
+		}
+	}
+	
+	#Comfort Eater: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		name = {
+			trigger = { can_be_comfort_eater = yes }
+			text = stress_threshold.2321.e.comfort_eater.gain
+		}
+		name = {
+			trigger = { has_trait = comfort_eater }
+			text = stress_threshold.2321.e.comfort_eater.effect
+		}
+		
+		add_trait = comfort_eater
+		trait = comfort_eater
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Court reacts to your little upset.
+		if = {
+			limit = {
+				list_size = {
+					name = affected_by_outburst
+					value > 0
+				}
+			}
+			every_in_list = {
+				list = affected_by_outburst
+				limit = {
+					NOR = {
+						has_trait = gluttonous
+						has_trait = arbitrary
+						has_trait = calm
+					}
+					is_alive = yes
+				}
+				custom = stress_threshold.2321.e.comfort_eater.list
+				add_opinion = {
+					modifier = pity_opinion
+					opinion = -20
+					target = root
+				}
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = comfort_eater
+			}
+		}
+	}
+	
+	#Journaller: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.2321.f.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.2321.f.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Court reacts to your little upset.
+		every_in_list = {
+			list = affected_by_outburst
+			limit = {
+				NOR = {
+					has_trait = patient
+					has_trait = scholar
+					has_trait = theologian
+				}
+				is_alive = yes
+			}
+			custom = stress_threshold.2321.f.journaller.list
+			add_opinion = {
+				modifier = suspicion_opinion
+				opinion = -10
+				target = root
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Confider: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.2321.g.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.2321.g.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+				}
+				add_relation_flag = {
+					target = root
+					relation = friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+		
+		#Court reacts to your little upset.
+		every_in_list = {
+			list = affected_by_outburst
+			limit = {
+				NOR = {
+					has_trait = gregarious
+					has_trait = shy
+					has_trait = trusting
+				}
+				is_alive = yes
+			}
+			custom = stress_threshold.2321.g.confider.list
+			add_opinion = {
+				modifier = suspicion_opinion
+				opinion = -20
+				target = root
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+	
+	#Drunkard: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.2321.h.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.2321.h.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#Court reacts to your little upset.
+		every_in_list = {
+			list = affected_by_outburst
+			limit = {
+				NOR = {
+					has_trait = gluttonous
+					has_trait = forgiving
+					has_trait = compassionate
+				}
+				is_alive = yes
+			}
+			custom = stress_threshold.2321.h.drunkard.list
+			add_opinion = {
+				modifier = disgusted_opinion
+				opinion = -20
+				target = root
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.2321.i.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.2321.i.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#Court reacts to your little upset.
+		every_in_list = {
+			list = affected_by_outburst
+			limit = {
+				NOR = {
+					has_trait = gluttonous
+					has_trait = forgiving
+					has_trait = compassionate
+				}
+				is_alive = yes
+			}
+			custom = stress_threshold.2321.i.hashishiyah.list
+			add_opinion = {
+				modifier = disgusted_opinion
+				opinion = -20
+				target = root
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.2321.j
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+		
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = impatient
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_impatient }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2321_desc_impatient
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = honest
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_honest }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2321_desc_honest
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = trusting
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_trusting }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2321_desc_trusting
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = compassionate
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_compassionate }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2321_desc_compassionate
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = forgiving
+					NOT = { has_character_flag = had_stress_threshold_2321_desc_forgiving }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2321_desc_forgiving
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Estranged Authority
+# by Ewan Cowhig Croft
+# #2331
+##################################################
+
+#	Your brevity and certainty is mistaken for ruthlessness.
+#		by Ewan Cowhig Croft
+stress_threshold.2331 = {
+	type = character_event
+	title = stress_threshold.2331.t
+	desc = {
+		desc = stress_threshold.2331.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = calm
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_calm }
+				}
+				desc = stress_threshold.2331.desc.calm
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = brave
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_brave }
+				}
+				desc = stress_threshold.2331.desc.brave
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = ambitious
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_ambitious }
+				}
+				desc = stress_threshold.2331.desc.ambitious
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = just
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_just }
+				}
+				desc = stress_threshold.2331.desc.just
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = callous
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_callous }
+				}
+				desc = stress_threshold.2331.desc.callous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = stubborn
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_stubborn }
+				}
+				desc = stress_threshold.2331.desc.stubborn
+			}
+			desc = stress_threshold.2331.desc.fallback
+		}
+		desc = stress_threshold.2331.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = shame
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = calm
+			has_trait = brave
+			has_trait = ambitious
+			has_trait = just
+			has_trait = callous
+			has_trait = stubborn
+		}
+		#For tonal reasons, must not *actually* be a dick.
+		NOR = {
+			has_trait = callous
+			has_trait = sadistic
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_irritable = yes
+			has_trait = irritable
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_improvident = yes
+			has_trait = improvident
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			can_be_athletic = yes
+			has_trait = athletic
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = irritable
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = improvident
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			has_trait = athletic
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = improvident }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = athletic }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = irritable	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = improvident	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = athletic
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_improvident = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_athletic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Reclusive: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.2331.a.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.2331.a.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#You banish them from your presence for a few days.
+		every_courtier_or_guest = {
+			custom = stress_threshold.2331.a.reclusive.opinion_list
+			add_opinion = {
+				modifier = scared_opinion
+				opinion = -30
+				target = root
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Irritable: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.2331.b.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.2331.b.irritable.effect
+		}
+		
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Your blood pressure goes up.
+		add_character_modifier = {
+			modifier = high_blood_pressure_modifier
+			years = 5
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+
+	#Profligate: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.2331.c.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.2331.c.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		#This excess spending is unbecoming of you.
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+	
+	#Improvident: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.2331.d.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.2331.d.improvident.effect
+		}
+		
+		add_trait = improvident
+		trait = improvident
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		capital_province.county = {
+			add_county_modifier = {
+				modifier = an_influx_of_eager_beggars_modifier
+				years = 10
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_greed = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = improvident
+			}
+		}
+	}
+	
+	#Journaller: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.2331.e.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.2331.e.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#You shut yourself away with your journals.
+		add_character_modifier = {
+			modifier = refuge_in_words_modifier
+			years = 5
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Confider: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.2331.f.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.2331.f.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+				add_relation_flag = {
+					target = root
+					relation = friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+		
+		if = {
+			limit = { exists = scope:friend }
+			jealousy_at_court_effect = {
+				SYC_OPINION = -60
+				TRUE_RIVAL_NUM = 2
+				POTENTIAL_RIVAL_NUM = 1
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+	
+	#Athletic: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_athletic
+		}
+		name = {
+			trigger = { can_be_athletic = yes }
+			text = stress_threshold.2331.g.athletic.gain
+		}
+		name = {
+			trigger = { has_trait = athletic }
+			text = stress_threshold.2331.g.athletic.effect
+		}
+		
+		add_trait = athletic
+		trait = athletic
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Your regular walks give ample opportunity to ambush you.
+		add_character_modifier = {
+			modifier = regular_walking_routes_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.5
+				ai_boldness = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = athletic
+			}
+		}
+	}
+	
+	#Drunkard: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.2331.h.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.2331.h.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#Not a great look for anyone.
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.2331.i.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.2331.i.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#Not a great look for anyone.
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.2331.j
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = calm
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_calm }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2331_desc_calm
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = brave
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_brave }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2331_desc_brave
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = ambitious
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_ambitious }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2331_desc_ambitious
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = just
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_just }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2331_desc_just
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = callous
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_callous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2331_desc_callous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = stubborn
+					NOT = { has_character_flag = had_stress_threshold_2331_desc_stubborn }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2331_desc_stubborn
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Shirked Duty
+# by Ewan Cowhig Croft
+# #2341
+##################################################
+
+#	You half-arse your noble duties, and it shows.
+#		by Ewan Cowhig Croft
+stress_threshold.2341 = {
+	type = character_event
+	title = stress_threshold.2341.t
+	desc = {
+		desc = stress_threshold.2341.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = lazy
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_lazy }
+				}
+				desc = stress_threshold.2341.desc.lazy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = craven
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_craven }
+				}
+				desc = stress_threshold.2341.desc.craven
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = shy
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_shy }
+				}
+				desc = stress_threshold.2341.desc.shy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = arbitrary
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_arbitrary }
+				}
+				desc = stress_threshold.2341.desc.arbitrary
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = fickle
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_fickle }
+				}
+				desc = stress_threshold.2341.desc.fickle
+			}
+			desc = stress_threshold.2341.desc.fallback
+		}
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = disapproval
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = lazy
+			has_trait = craven
+			has_trait = shy
+			has_trait = arbitrary
+			has_trait = fickle
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_comfort_eater = yes
+			has_trait = comfort_eater
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = comfort_eater
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = comfort_eater }
+				has_witnessed_stress_coping_trait = { TRAIT = inappetetic }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = comfort_eater	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_comfort_eater = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Reclusive: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.2341.a.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.2341.a.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#You lose mild opinion with all courtiers, and all guests are immediately made to leave.
+		every_courtier = {
+			custom = stress_threshold.2341.a.reclusive.list_courtier
+			add_opinion = {
+				modifier = respect_opinion
+				opinion = -15
+				target = root
+			}
+		}
+		every_pool_guest = {
+			custom = stress_threshold.2341.a.reclusive.list_guest
+			hidden_effect = {
+				move_to_pool = yes
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Profligate: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.2341.b.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.2341.b.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		#Your new cloak becomes a symbol of your shirked duty.
+		add_character_modifier = {
+			modifier = symbol_of_folly_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+
+	#Comfort Eater: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		name = {
+			trigger = { can_be_comfort_eater = yes }
+			text = stress_threshold.2341.c.comfort_eater.gain
+		}
+		name = {
+			trigger = { has_trait = comfort_eater }
+			text = stress_threshold.2341.c.comfort_eater.effect
+		}
+		
+		add_trait = comfort_eater
+		trait = comfort_eater
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Your feast gives you a poor nickname.
+		if = {
+			limit = { has_any_nickname = no }
+			custom_tooltip = stress_threshold.2341.c.comfort_eater.tt
+			hidden_effect = {
+				random_list = {	#nick_the_fat excluded from the list, as it feels a little too mean-spirited.
+					13 = { give_nickname = nick_the_greedy }
+					13 = { give_nickname = nick_the_unworthy }
+					13 = { give_nickname = nick_the_selfish }
+					12 = { give_nickname = nick_the_wicked }
+					13 = { give_nickname = nick_the_terrible }
+					12 = { give_nickname = nick_the_plump }
+					12 = { give_nickname = nick_the_little } #Ironically.
+					12 = { give_nickname = nick_the_wicked }
+				}
+			}
+		}
+		#... Or else just lost prestige.
+		else = { add_prestige = medium_prestige_loss }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = comfort_eater
+			}
+		}
+	}
+
+	#Journaller: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.2341.d.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.2341.d.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#You shut yourself away with your journals.
+		add_character_modifier = {
+			modifier = refuge_in_words_modifier
+			years = 15
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Confider: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+			exists = scope:friend
+			scope:friend = { is_alive = yes }
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.2341.e.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.2341.e.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+				}
+				add_relation_flag = {
+					target = root
+					relation = friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = best_friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = best_friend
+				limit = {
+					this = scope:friend
+				}
+				add_relation_flag = {
+					target = root
+					relation = best_friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = best_friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = best_friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+		
+		if = {
+			limit = { exists = scope:friend }
+			jealousy_at_court_effect = {
+				SYC_OPINION = -40
+				TRUE_RIVAL_NUM = 3
+				POTENTIAL_RIVAL_NUM = 2
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+
+	#Drunkard: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.2341.f.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.2341.f.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#Doesn't look great, even on a landed ruler.
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+
+	#Hashishiyah: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.2341.g.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.2341.g.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#Doesn't look great, even on a landed ruler.
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.2341.h
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+		
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = lazy
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_lazy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2341_desc_lazy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = craven
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_craven }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2341_desc_craven
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = shy
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_shy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2341_desc_shy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = arbitrary
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_arbitrary }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2341_desc_arbitrary
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = fickle
+					NOT = { has_character_flag = had_stress_threshold_2341_desc_fickle }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2341_desc_fickle
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Improprietous Remarks
+# by Ewan Cowhig Croft
+# #2351
+##################################################
+
+#	Increasingly frayed, you respond to a petitioner brashly.
+#		by Ewan Cowhig Croft
+stress_threshold.2351 = {
+	type = character_event
+	title = stress_threshold.2351.t
+	desc = {
+		desc = stress_threshold.2351.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = content
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_content }
+				}
+				desc = stress_threshold.2351.desc.content
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = cynical
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_cynical }
+				}
+				desc = stress_threshold.2351.desc.cynical
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = paranoid
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_paranoid }
+				}
+				desc = stress_threshold.2351.desc.paranoid
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = sadistic
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_sadistic }
+				}
+				desc = stress_threshold.2351.desc.sadistic
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = vengeful
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_vengeful }
+				}
+				desc = stress_threshold.2351.desc.vengeful
+			}
+			desc = stress_threshold.2351.desc.fallback
+		}
+		desc = stress_threshold.2351.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = no }
+		reference = throne_room
+	}
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = anger
+	}
+
+	trigger = {
+		#Barons don't need fancy events.
+		is_playable_character = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = content
+			has_trait = cynical
+			has_trait = paranoid
+			has_trait = sadistic
+			has_trait = vengeful
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_irritable = yes
+			has_trait = irritable
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_improvident = yes
+			has_trait = improvident
+			can_be_inappetetic = yes
+			has_trait = inappetetic
+			can_be_journaller = yes
+			has_trait = journaller
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = irritable
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = improvident
+		}
+		modifier = {
+			add = 10
+			has_trait = inappetetic
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = improvident }
+				has_witnessed_stress_coping_trait = { TRAIT = inappetetic }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = irritable	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = improvident	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Inappetetic (lack of appetite)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = inappetetic	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_improvident = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Inappetetic (lack of appetite)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_inappetetic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+	
+	#Reclusive: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.2351.a.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.2351.a.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#You gain a reputation as reclusive and strange.
+		add_character_modifier = {
+			modifier = strange_recluse_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Irritable: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.2351.b.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.2351.b.irritable.effect
+		}
+		
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#You get a reputation as a grouch.
+		add_character_modifier = {
+			modifier = grouchy_ruler_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+	
+	#Profligate: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.2351.c.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.2351.c.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		#You try to buy your way to feeling better.
+		add_character_modifier = {
+			modifier = trying_to_buy_happiness_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+	
+	#Improvident: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.2351.d.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.2351.d.improvident.effect
+		}
+		
+		add_trait = improvident
+		trait = improvident
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		remove_short_term_gold = massive_gold_value
+		
+		#Giving everyone who needs it access to the treasury is generally bad practice for feudal societies.
+		add_stewardship_skill = -1
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_greed = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = improvident
+			}
+		}
+	}
+	
+	#Inappetetic: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_inappetetic
+		}
+		name = {
+			trigger = { can_be_inappetetic = yes }
+			text = stress_threshold.2351.e.inappetetic.gain
+		}
+		name = {
+			trigger = { has_trait = inappetetic }
+			text = stress_threshold.2351.e.inappetetic.effect
+		}
+		
+		add_trait = inappetetic
+		trait = inappetetic
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		if = {
+			limit = {
+				has_trait = inappetetic
+			}
+			inappetetic_advance_starvation_effect = yes
+		}
+		
+		#A ruler should have might feasts, after all.
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = -0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = inappetetic
+			}
+		}
+	}
+	
+	#Journaller: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.2351.f.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.2351.f.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#People grow suspicious of your journal constantly being in your lap.
+		add_character_modifier = {
+			modifier = suspicious_sketcher_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Drunkard: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.2351.g.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.2351.g.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#Tsk, drinking on the job.
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: medium stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.2351.h.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.2351.h.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#Tsk, indulging on the job.
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.2351.i
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+		
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = content
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_content }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2351_desc_content
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = cynical
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_cynical }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2351_desc_cynical
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = paranoid
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_paranoid }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2351_desc_paranoid
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = sadistic
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_sadistic }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2351_desc_sadistic
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = vengeful
+					NOT = { has_character_flag = had_stress_threshold_2351_desc_vengeful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_2351_desc_vengeful
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+
+##################################################
+# Eccentric stress break
+# by James Beaumont
+# #2360
+##################################################
+stress_threshold.2360 = {
+	type = character_event
+	title = stress_threshold.2360.t
+	desc = stress_threshold.2360.desc
+	theme = mental_break
+	override_background = {
+		reference = bedchamber
+	}
+	left_portrait = {
+		character = root
+		animation = anger
+	}
+
+	trigger = {
+		is_ai = no # We want the eccentric trait to be rare
+		is_travelling = no
+		number_of_personality_traits < personality_trait_limit
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+	}
+	
+	#Become eccentric, big stress loss
+	option = {
+		name = {
+			trigger = { NOT = { has_trait = eccentric } }
+			text = stress_threshold.2360.a.eccentric.gain
+		}
+		name = {
+			trigger = { has_trait = eccentric }
+			text = stress_threshold.2360.a.eccentric.effect
+		}
+		if = {
+			limit = {
+				has_trait = fickle
+			}
+			remove_trait = fickle
+		}
+		if = {
+			limit = {
+				has_trait = stubborn
+			}
+			remove_trait = stubborn
+		}
+		add_trait_force_tooltip = eccentric
+		trait = eccentric
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#You gain a reputation as eccentric and strange.
+		add_character_modifier = {
+			modifier = erratic_behaviour
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_rationality = -1
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = eccentric
+			}
+		}
+	}
+	
+	#Become irritable, stress loss
+	option = {
+		trigger = {
+			OR = {
+				can_be_irritable = yes
+				has_trait = irritable
+			}
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.2360.b.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.2360.b.irritable.effect
+		}
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+		
+		#You're smashing birds and that's weird
+		add_character_modifier = {
+			modifier = bird_cruelty
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+	#Opt out, get another stress event
+	option = {
+		name = stress_threshold.2360.c
+		add_stress = minor_stress_impact_gain
+		ai_chance = { base = 300 }	#AI shouldn't become eccentric through stress
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes
+	}
+}
+
+##################################################################################################################################################################
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ TIER 3 STRESS EVENTS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
+##################################################################################################################################################################
+
+#############################
+# The Voices In My Head		#
+# by Sean Hughes			#
+# 3001						#
+#############################
+
+stress_threshold.3001 = {
+	type = character_event
+	title = stress_threshold.3001.t
+	desc = stress_threshold.3001.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = paranoia
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# Option A: Hearing voices, if already lunatic lose random skills.
+	option = {
+		name = {
+			trigger = { NOT = { has_trait = lunatic} }
+			text = stress_threshold.3001.possessed.gain
+		}
+		name = {
+			trigger = { has_trait = lunatic }
+			text = stress_threshold.3001.possessed.effect
+		}
+
+		trait = lunatic_1
+		trait = lunatic_genetic
+
+		if = {
+			limit = {
+				has_trait = lunatic
+			}
+			random_list = {
+				33 = {
+					trigger = {
+						diplomacy > 0
+					}
+					add_diplomacy_skill = -1
+				}
+				33 = {
+					trigger = {
+						stewardship > 0
+					}
+					add_stewardship_skill = -1
+				}
+				33 = {
+					trigger = {
+						learning > 0
+					}
+					add_learning_skill = -1
+				}
+			}
+		}
+		else = {
+			add_trait = lunatic_1
+		}
+
+		add_stress = major_stress_impact_loss
+	}
+
+	# Option B: Go for a naked run, feel better but suffer a massive hit to prestige/prestige level.
+	option = {
+		name = stress_threshold.3001.naked_run
+
+		add_prestige = major_prestige_loss
+		add_prestige_level = -1
+		add_stress = major_stress_impact_loss
+	}	
+	
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+#############################
+# Who Is To Blame?			#
+# by Sean Hughes			#
+# 3101						#
+#############################
+
+stress_threshold.3101 = {
+	type = character_event
+	title = stress_threshold.3101.t
+	desc = stress_threshold.3101.desc
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = no }
+		reference = throne_room
+	}
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = rage
+	}
+	right_portrait = {
+		character = scope:victim
+		animation = worry
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		stress_get_victim_in_court_effect = yes
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# Option A: Kill a random courtier (preference for your heir or other children).
+	option = {
+		trigger = {
+			exists = scope:victim
+		}
+		name = stress_threshold.3101.kill_victim
+
+		known_murder_effect = {
+			VICTIM = scope:victim
+			MURDERER = root
+			EXPOSER = root.host
+		}
+
+		add_stress = major_stress_impact_loss
+
+	}
+
+	# Option B: Lunacy, stress is no longer an issue but at what cost?
+	option = {
+		name = {
+			trigger = { NOT = { has_trait = lunatic} }
+			text = stress_threshold.3101.lunatic.gain
+		}
+		name = {
+			trigger = { has_trait = lunatic }
+			text = stress_threshold.3101.lunatic.effect
+		}
+
+		trait = lunatic_1
+		trait = lunatic_genetic
+
+		flavor = stress_threshold.3101.lunatic.tt
+
+		if = {
+			limit = {
+				has_trait = lunatic
+			}
+			add_prestige = medium_prestige_loss
+		}
+		else = {
+			add_trait = lunatic_1
+		}
+		add_stress = major_stress_impact_loss
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+
+#############################
+# Overload					#
+# by Linnéa Thimrén			#
+# 3201						#
+#############################
+
+stress_threshold.3201 = {
+	type = character_event
+	title = stress_threshold.3201.t
+	desc = stress_threshold.3201.desc
+	
+	theme = mental_break
+	override_background = {
+		reference = feast
+	}
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = grief
+	}
+	right_portrait = {
+		character = scope:vassal
+		animation = worry
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	trigger = {
+		OR = {
+			any_vassal = {
+				NOT = { has_relation_rival = root }
+			}
+			AND = {
+				has_government = landless_adventurer_government
+				any_courtier = {
+					NOT = { has_relation_rival = root }
+				}
+			}
+		}
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		random_vassal = {
+			limit = {
+				has_relation_friend = root
+			}
+			alternative_limit = {
+				has_relation_potential_friend = root
+			}
+			alternative_limit = {
+				is_powerful_vassal_of = root
+				NOT = { has_relation_rival = root }
+			}
+			alternative_limit = {
+				NOT = { has_relation_rival = root }
+			}
+			weight = {
+				base = 100
+				opinion_modifier = {
+					opinion_target = root
+				}
+				ai_value_modifier = {
+					ai_compassion = 2 # +100 at 50, -100 at -50
+				}
+				is_of_minor_interest_to_weight_up_modifier = { CHARACTER = root }
+				is_of_major_interest_to_weight_up_modifier = { CHARACTER = root }
+			}
+			save_scope_as = vassal
+		}
+
+		if = {
+			limit = {
+				NOT = { exists = scope:vassal }
+			}
+			random_courtier = {
+				limit = {
+					has_relation_friend = root
+				}
+				alternative_limit = {
+					has_relation_potential_friend = root
+				}
+				alternative_limit = {
+					NOT = { has_relation_rival = root }
+				}
+				weight = {
+					base = 100
+					opinion_modifier = {
+						opinion_target = root
+					}
+					ai_value_modifier = {
+						ai_compassion = 2 # +100 at 50, -100 at -50
+					}
+					is_of_minor_interest_to_weight_up_modifier = { CHARACTER = root }
+ 					is_of_major_interest_to_weight_up_modifier = { CHARACTER = root }
+				}
+				save_scope_as = vassal
+			}
+		}
+
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# I give up...
+	option = {
+		name = {
+			trigger = { NOT = { has_trait = depressed} }
+			text = stress_threshold.3201.depressed.gain
+		}
+		name = {
+			trigger = { has_trait = depressed }
+			text = stress_threshold.3201.depressed.effect
+		}
+
+		trait = depressed_1
+		trait = depressed_genetic
+
+		if = {
+			limit = {
+				has_trait = depressed
+			}
+			random_list = {
+				33 = {
+					trigger = {
+						diplomacy > 0
+					}
+					add_diplomacy_skill = -1
+				}
+				33 = {
+					trigger = {
+						stewardship > 0
+					}
+					add_stewardship_skill = -1
+				}
+				33 = {
+					trigger = {
+						learning > 0
+					}
+					add_learning_skill = -1
+				}
+			}
+		}
+		else = {
+			add_trait = depressed_1
+		}
+
+		add_stress = major_stress_impact_loss
+
+		ai_chance = {
+			base = 100
+
+			modifier = {
+				add = -50
+				has_trait = stubborn
+			}
+			ai_value_modifier = {
+				ai_energy = -0.5
+			}
+		}
+	}
+
+	# I need help. Now. (Not meant to shame people that reach out for help, meant to frame it as a more public debacle)
+	option = {
+		name = stress_threshold.3201.help
+
+		add_prestige = major_prestige_loss
+		add_prestige_level = -1
+		add_stress = medium_stress_impact_loss
+
+		#If the vassal is your friend already they can become your confidant
+		if = {
+			limit = {
+				NOT = { has_trait = confider }
+				any_relation = {
+					type = friend
+					this = scope:vassal
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			add_trait = confider
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:vassal
+				}
+				add_relation_flag = {
+					target = root
+					relation = friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+
+		#To nudge the relationship towards, or to, friendship
+		if = {
+			limit = {
+				has_relation_potential_rival = scope:vassal
+			}
+			remove_relation_potential_rival = scope:vassal
+		}
+		progress_towards_friend_effect = { CHARACTER = scope:vassal REASON = friend_confide_opposite OPINION = 0 }
+
+		ai_chance = {
+			base = 50
+
+			modifier = {
+				add = 100
+				any_relation = {
+					type = friend
+					this = scope:vassal
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+		}
+	}	
+
+	# Lash out.
+	option = {
+		name = {
+			trigger = { NOT = { has_trait = wrathful} }
+			text = stress_threshold.3201.wrathful.gain
+		}
+		name = {
+			trigger = { has_trait = wrathful }
+			text = stress_threshold.3201.wrathful.effect
+		}
+		trait = wrathful
+
+		if = {
+			limit = {
+				NOT = { has_trait = wrathful}
+			}
+			stress_impact = {
+				base = major_stress_impact_loss
+				compassionate = medium_stress_impact_gain
+				calm = medium_stress_impact_gain
+			}
+
+			stress_replace_personality_trait_with_opposite_effect = { TRAIT = wrathful }
+			scope:vassal = {
+				add_opinion = {
+					modifier = insult_opinion
+					target = root
+					opinion = -30
+				}
+			}
+		}
+		else = {
+			duel = {
+				skill = prowess
+				target = scope:vassal
+
+				50 = {
+					desc = stress_threshold.3201.wrathful.effect.success
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = 3.5
+						min = -49
+					}
+					scope:vassal = {
+						increase_wounds_effect = { REASON = fight }
+						add_prestige = minor_prestige_loss
+					}
+					
+				}
+				50 = {
+					desc = stress_threshold.3201.wrathful.effect.failure
+					compare_modifier = {
+						value = scope:duel_value
+						multiplier = -3.5
+						min = -49
+					}
+					increase_wounds_effect = { REASON = fight }
+					add_prestige = medium_prestige_loss
+				}
+
+
+			}
+			scope:vassal = {
+				add_opinion = {
+					modifier = angry_opinion
+					target = root
+					opinion = -50
+				}
+			}
+			stress_impact = {
+				base = major_stress_impact_loss
+				compassionate = medium_stress_impact_gain
+			}
+		}
+
+
+		
+		ai_chance = {
+			base = 50
+
+			ai_value_modifier = {
+				ai_compassion = -5
+			}
+		}		
+	}
+	
+	after = {
+		stress_threshold_event_aftereffects = yes # Perform stress threshold event clean-up and preparation for future stress threshold events.
+	}
+}
+
+
+#############################
+# Heart Ache				#
+# by Linnéa Thimrén			#
+# 3301						#
+#############################
+
+stress_threshold.3301 = {
+	type = character_event
+	title = stress_threshold.3301.t
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					is_female = yes
+				}
+				desc = stress_threshold.3301.desc_woman
+			}
+			desc = stress_threshold.3301.desc_man
+		}
+	}
+	
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain_travel
+	}
+	left_portrait = {
+		character = root
+		animation = pain
+	}
+
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	weight_multiplier = {
+		base = 1
+
+		modifier = { #More likely if you're older
+			add = 0.5
+			age > 50
+		}
+
+		modifier = { #More likely if you're overweight
+			add = 0.5
+			current_weight > overweight_value
+		}
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } # For stress widget
+
+		stress_threshold_event_post_immediate = yes
+	}
+
+	# Ugh...!
+	option = {
+		name = stress_threshold.3301.a
+
+		death = {
+			death_reason = death_stress
+		}
+	}
+}
+
+
+##################################################
+# Shooting the Messenger
+# by Ewan Cowhig Croft
+# #3401
+##################################################
+
+#	You dramatically punish someone for giving you bad news.
+#		by Ewan Cowhig Croft
+stress_threshold.3401 = {
+	type = character_event
+	title = stress_threshold.3401.t
+	desc = {
+		desc = stress_threshold.3401.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = vengeful
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_vengeful }
+				}
+				desc = stress_threshold.3401.desc.vengeful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = wrathful
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_wrathful }
+				}
+				desc = stress_threshold.3401.desc.wrathful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = impatient
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_impatient }
+				}
+				desc = stress_threshold.3401.desc.impatient
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = arbitrary
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_arbitrary }
+				}
+				desc = stress_threshold.3401.desc.arbitrary
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = paranoid
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_paranoid }
+				}
+				desc = stress_threshold.3401.desc.paranoid
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = callous
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_callous }
+				}
+				desc = stress_threshold.3401.desc.callous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = sadistic
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_sadistic }
+				}
+				desc = stress_threshold.3401.desc.sadistic
+			}
+			desc = stress_threshold.3401.desc.fallback
+		}
+		desc = stress_threshold.3401.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = no }
+		reference = throne_room
+	}
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain
+	}
+	left_portrait = {
+		character = root
+		animation = rage
+	}
+	right_portrait = {
+		character = scope:unlucky_sod
+		animation = shock
+	}
+
+	trigger = {
+		#Landless characters & barons don't need fancy events.
+		is_landed = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = vengeful
+			has_trait = wrathful
+			has_trait = impatient
+			has_trait = arbitrary
+			has_trait = paranoid
+			has_trait = callous
+			has_trait = sadistic
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_irritable = yes
+			has_trait = irritable
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+		#There must also be 3 potential victims 
+		any_courtier_or_guest = {
+			NOR = {
+				dynasty = root.dynasty
+				has_relation_lover = root
+				has_relation_friend = root
+				any_consort = { this = root }
+			}
+			age >= 8
+			is_ai = yes
+			is_available = yes
+			count >= 3
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = irritable
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		#Grab three random people for the irritable execution option.
+		every_courtier_or_guest = {
+			limit = {
+				NOR = {
+					dynasty = root.dynasty
+					has_relation_lover = root
+					has_relation_friend = root
+					any_consort = { this = root }
+				}
+				age >= 8
+				is_ai = yes
+				is_available = yes
+			}
+			add_to_list = random_victims
+		}
+		#And pick a poor sod.
+		random_in_list = {
+			list = random_victims
+			save_scope_as = unlucky_sod
+			weight = {
+				base = 1
+				
+				modifier = {	#Powerful potential foes!
+					add = 30
+					any_close_family_member = { highest_held_title_tier = tier_empire }
+				}
+				modifier = {	#Powerful potential foes!
+					add = 25
+					any_close_family_member = { highest_held_title_tier = tier_kingdom }
+				}
+				modifier = {	#Potential foes.
+					add = 20
+					any_close_family_member = { highest_held_title_tier = tier_duchy }
+				}
+				modifier = {	#Potential foes.
+					add = 15
+					any_close_family_member = { highest_held_title_tier = tier_county }
+				}
+				modifier = {	#Potential annoyances.
+					add = 10
+					any_close_family_member = { highest_held_title_tier = tier_barony }
+				}
+				modifier = {	#Abuse of own resources.
+					add = 20
+					is_claimant = yes
+				}
+				modifier = {	#Abuse of *different* own-resources.
+					add = 10
+					OR = {
+						diplomacy >= high_skill_rating
+						martial >= high_skill_rating
+						stewardship >= high_skill_rating
+						intrigue >= high_skill_rating
+						learning >= high_skill_rating
+						prowess >= high_skill_rating
+					}
+				}
+				modifier = {	#Aaaaaaand set up some good-old fashioned tensions by prioritising the relatives of your vassals.
+					add = 20
+					save_temporary_scope_as = murder_bait
+					root = {
+						any_vassal = {
+							any_close_family_member = { this = scope:murder_bait }
+						}
+					}
+				}
+			}
+		}
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = irritable	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { is_available_ai_adult = yes }
+				save_scope_as = friend
+			}
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+	
+	#Reclusive: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.3401.a.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.3401.a.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#You banish everyone you can from your court.
+		every_courtier_or_guest = {
+			limit = {
+				NOR = {
+					is_close_family_of = root
+					any_consort = {
+						OR = {
+							is_close_family_of = root
+							this = root
+						}
+					}
+					any_parent = { is_close_family_of = root }
+					has_relation_guardian = root
+					is_foreign_court_guest = yes
+					has_relation_friend = root
+					has_relation_lover= root
+				}
+			}
+			custom = stress_threshold.3401.a.reclusive.list
+			move_to_pool = yes
+		}
+		add_character_modifier = {
+			modifier = deserted_halls_modifier
+			years = 20
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Irritable: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.3401.b.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.3401.b.irritable.effect
+		}
+		
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#If available, execute a courtier/guest.
+		if = {
+			limit = { exists = scope:unlucky_sod }
+			execute_prisoner_effect = {
+				VICTIM = scope:unlucky_sod
+				EXECUTIONER = root
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+	
+	#Journaller: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.3401.c.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.3401.c.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#In a fit of insanity, you have the corpse drained and the resulting fluids made into ink. Just like other normal human writers do.
+		add_character_modifier = {
+			modifier = carrion_writer_modifier
+			#Indefinite: assuming you squeeze at least 40kg of pulp out, especially if you dilute it, and aren't writing constantly, one reasonably-sized body should last for decades or longer.
+		}
+		add_piety = major_piety_loss
+		random = {
+			chance = 35
+			add_trait = lunatic_1
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Confider: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.3401.d.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.3401.d.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					is_available_ai_adult = yes
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+					is_available_ai_adult = yes
+				}
+				add_relation_flag = {
+					target = root
+					relation = friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+		
+		#Your confidant is blamed for the death.
+		if = {
+			limit = { exists = scope:friend }
+			jealousy_at_court_effect = {
+				SYC_OPINION = -60
+				TRUE_RIVAL_NUM = 2
+				POTENTIAL_RIVAL_NUM = 1
+			}
+		}
+		#And no one likes an axe-happy monarch.
+		add_piety = medium_piety_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+
+	#Drunkard: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.3401.e.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.3401.e.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#Your behaviour is unbecoming.
+		add_prestige_level = -1
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.3401.f.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.3401.f.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#Your behaviour is unbecoming.
+		add_prestige_level = -1
+		add_prestige = medium_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.3401.g
+
+		#Account for stress.
+		add_stress = medium_stress_impact_loss
+
+		#You have the messenger's pickled head for a footstool.
+		add_character_modifier = {
+			modifier = pickled_human_head_footstool
+		}
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = vengeful
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_vengeful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3401_desc_vengeful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = wrathful
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_wrathful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3401_desc_wrathful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = impatient
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_impatient }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3401_desc_impatient
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = arbitrary
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_arbitrary }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3401_desc_arbitrary
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = paranoid
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_paranoid }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3401_desc_paranoid
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = callous
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_callous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3401_desc_callous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = sadistic
+					NOT = { has_character_flag = had_stress_threshold_3401_desc_sadistic }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3401_desc_sadistic
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# I am Unworthy
+# by Ewan Cowhig Croft
+# 3411
+##################################################
+
+#	Your impostor syndrome has become a full-blown complex.
+#		by Ewan Cowhig Croft
+stress_threshold.3411 = {
+	type = character_event
+	title = stress_threshold.3411.t
+	desc = {
+		desc = stress_threshold.3411.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = generous
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_generous }
+				}
+				desc = stress_threshold.3411.desc.generous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = diligent
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_diligent }
+				}
+				desc = stress_threshold.3411.desc.diligent
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = patient
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_patient }
+				}
+				desc = stress_threshold.3411.desc.patient
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = humble
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_humble }
+				}
+				desc = stress_threshold.3411.desc.humble
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = shy
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_shy }
+				}
+				desc = stress_threshold.3411.desc.shy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = just
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_just }
+				}
+				desc = stress_threshold.3411.desc.just
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = trusting
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_trusting }
+				}
+				desc = stress_threshold.3411.desc.trusting
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = compassionate
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_compassionate }
+				}
+				desc = stress_threshold.3411.desc.compassionate
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = forgiving
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_forgiving }
+				}
+				desc = stress_threshold.3411.desc.forgiving
+			}
+			desc = stress_threshold.3411.desc.fallback
+		}
+		desc = stress_threshold.3411.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain
+	}
+	left_portrait = {
+		character = root
+		animation = shame
+	}
+
+	trigger = {
+		#Landless characters & barons don't need fancy events.
+		is_landed = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = generous
+			has_trait = diligent
+			has_trait = patient
+			has_trait = humble
+			has_trait = shy
+			has_trait = just
+			has_trait = trusting
+			has_trait = compassionate
+			has_trait = forgiving
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_flagellant = yes
+			has_trait = flagellant
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_improvident = yes
+			has_trait = improvident
+			can_be_contrite = yes
+			has_trait = contrite
+			can_be_inappetetic = yes
+			has_trait = inappetetic
+			can_be_journaller = yes
+			has_trait = journaller
+			can_be_confider = yes
+			has_trait = confider
+			can_be_athletic = yes
+			has_trait = athletic
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = flagellant
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = improvident
+		}
+		modifier = {
+			add = 10
+			has_trait = contrite
+		}
+		modifier = {
+			add = 10
+			has_trait = inappetetic
+		}
+		modifier = {
+			add = 10
+			has_trait = journaller
+		}
+		modifier = {
+			add = 10
+			has_trait = confider
+		}
+		modifier = {
+			add = 10
+			has_trait = athletic
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = flagellant }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = improvident }
+				has_witnessed_stress_coping_trait = { TRAIT = contrite }
+				has_witnessed_stress_coping_trait = { TRAIT = inappetetic }
+				has_witnessed_stress_coping_trait = { TRAIT = journaller }
+				has_witnessed_stress_coping_trait = { TRAIT = confider }
+				has_witnessed_stress_coping_trait = { TRAIT = athletic }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = flagellant	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = improvident	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Contrite (compelled to reveal own secrets)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = contrite	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { #Inappetetic (lack of appetite)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = inappetetic	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = journaller	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = confider	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = athletic	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_flagellant = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Improvident (habitually over-donates to charity)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_improvident = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_improvident
+		}
+		if = { #Contrite (compelled to reveal own secrets)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_contrite = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_contrite
+			contrite_get_secret_scopes_effect = yes
+		}
+		if = { #Inappetetic (lack of appetite)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_inappetetic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_inappetetic
+		}
+		if = { #Journaller (writes down thoughts in a journal as a healthy stress relief)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_journaller = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_journaller
+		}
+		if = { #Confider (has a close confidant)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_confider = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_confider
+			random_relation = {
+				type = friend
+				limit = {
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+					is_available_ai_adult = yes
+				}
+				alternative_limit = { exists = this }
+				save_scope_as = friend
+			}
+		}
+		if = { #Athletic (exercises as a stress outlet)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_athletic = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_athletic
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Reclusive: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.3411.a.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.3411.a.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#You develop a phobia of being observed that will take years to overcome.
+		add_character_modifier = {
+			modifier = scopophobic_modifier
+			years = 20
+		}
+		add_prestige = major_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Flagellant: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.3411.b.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.3411.b.flagellant.effect
+		}
+		
+		add_trait = flagellant
+		trait = flagellant
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		increase_wounds_effect = { REASON = whipping }
+		if = {
+			limit = {
+				faith = { has_doctrine_parameter = self_mutilation_active }
+			}
+			add_piety = minor_piety_value
+		}
+		
+		#You do yourself permanent harm to compensate for your inadequacies.
+		if = {
+			limit = {
+				NOT = { has_trait = one_eyed }
+			}
+			add_trait = one_eyed
+		}
+		else_if = {
+			limit = {
+				NOT = { has_trait = disfigured }
+			}
+			add_trait = disfigured
+		}
+		else_if = {
+			limit = {
+				NOT = { has_trait = one_legged }
+			}
+			add_trait = one_legged
+		}
+		else_if = {
+			limit = {
+				NOT = { has_trait = maimed }
+			}
+			apply_maimed_trait_and_modifier_effect = yes
+		}
+		else_if = {
+			limit = {
+				NOT = { has_trait = wounded_3 }
+			}
+			hidden_effect = {
+				remove_trait = wounded_1
+				remove_trait = wounded_2
+			}
+			add_trait = wounded_3
+		}
+		else = { add_prestige = major_prestige_loss }
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_zeal = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = flagellant
+			}
+		}
+	}
+	
+	#Profligate: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.3411.c.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.3411.c.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		remove_short_term_gold = monumental_gold_value
+		
+		#You begin work on a series of self-aggrandising monuments, attempting to fool others.
+		add_character_modifier = {
+			modifier = ostentatious_follies_modifier
+			years = 20
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+	
+	#Improvident: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_improvident
+		}
+		name = {
+			trigger = { can_be_improvident = yes }
+			text = stress_threshold.3411.d.improvident.gain
+		}
+		name = {
+			trigger = { has_trait = improvident }
+			text = stress_threshold.3411.d.improvident.effect
+		}
+		
+		add_trait = improvident
+		trait = improvident
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		remove_short_term_gold = monumental_gold_value
+		
+		#You declare that literally anyone can take whatever they want from the treasury.
+		add_character_modifier = {
+			modifier = extreme_tax_rebates_modifier
+			years = 20
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_greed = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = improvident
+			}
+		}
+	}
+	
+	#Contrite: massive stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_contrite
+		}
+		name = {
+			trigger = { can_be_contrite = yes }
+			text = stress_threshold.3411.e.contrite.gain
+		}
+		name = {
+			trigger = { has_trait = contrite }
+			text = stress_threshold.3411.e.contrite.effect
+		}
+		
+		add_trait = contrite
+		trait = contrite
+
+		contrite_reveal_secrets_effect = yes # Includes stress loss based on what secrets were revealed
+		
+		#Not a great look for any ruler.
+		add_prestige = massive_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_honor = 0.5
+				ai_compassion = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = contrite
+			}
+		}
+	}
+	
+	#Inappetetic: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_inappetetic
+		}
+		name = {
+			trigger = { can_be_inappetetic = yes }
+			text = stress_threshold.3411.f.inappetetic.gain
+		}
+		name = {
+			trigger = { has_trait = inappetetic }
+			text = stress_threshold.3411.f.inappetetic.effect
+		}
+		
+		add_trait = inappetetic
+		trait = inappetetic
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		if = {
+			limit = {
+				has_trait = inappetetic
+			}
+			inappetetic_advance_starvation_effect = yes
+		}
+		
+		#Your dumping of the larders causes everyone else in the castle to experience the ill-effects of your self-enforced famine.
+		every_courtier_or_guest = {
+			custom = stress_threshold.3411.f.inappetetic.list
+			inappetetic_advance_starvation_effect = yes
+			add_opinion = {
+				target = root
+				modifier = stress_denied_food_opinion
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = -0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = inappetetic
+			}
+		}
+	}
+	
+	#Journaller: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_journaller
+		}
+		name = {
+			trigger = { can_be_journaller = yes }
+			text = stress_threshold.3411.g.journaller.gain
+		}
+		name = {
+			trigger = { has_trait = journaller }
+			text = stress_threshold.3411.g.journaller.effect
+		}
+		
+		add_trait = journaller
+		trait = journaller
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Obsessed with discovering where you went wrong, you compulsively read and re-read old journals.
+		add_character_modifier = {
+			modifier = obsessed_autobiographer_modifier
+			years = 20
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.25
+				ai_rationality = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = journaller
+			}
+		}
+	}
+	
+	#Confider: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_confider
+		}
+		name = {
+			trigger = { can_be_confider = yes }
+			text = stress_threshold.3411.h.confider.gain
+		}
+		name = {
+			trigger = { has_trait = confider }
+			text = stress_threshold.3411.h.confider.effect
+		}
+		
+		add_trait = confider
+		trait = confider
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					NOT = {
+						has_relation_flag = {
+							target = root
+							relation = friend
+							flag = has_been_confided_in
+						}
+					}
+				}
+			}
+			random_relation = {
+				type = friend
+				limit = {
+					this = scope:friend
+				}
+				add_relation_flag = {
+					target = root
+					relation = friend
+					flag = has_been_confided_in
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				any_relation = {
+					type = friend
+					this = scope:friend
+					has_relation_flag = {
+						target = root
+						relation = friend
+						flag = has_been_confided_in
+					}
+				}
+			}
+			reverse_add_opinion = {
+				target = scope:friend
+				modifier = friendliness_opinion
+				opinion = 20
+			}
+		}
+		
+		#Accusations of sycophancy & general disapproval ensue.
+		add_prestige = major_prestige_loss
+		if = {
+			limit = { exists = scope:friend }
+			jealousy_at_court_effect = {
+				SYC_OPINION = -40
+				TRUE_RIVAL_NUM = 2
+				POTENTIAL_RIVAL_NUM = 1
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = confider
+			}
+		}
+	}
+	
+	#Athletic: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_athletic
+		}
+		name = {
+			trigger = { can_be_athletic = yes }
+			text = stress_threshold.3411.i.athletic.gain
+		}
+		name = {
+			trigger = { has_trait = athletic }
+			text = stress_threshold.3411.i.athletic.effect
+		}
+		
+		add_trait = athletic
+		trait = athletic
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#You attempt to, quite literally, run from your problems.
+		add_character_modifier = {
+			modifier = running_from_responsibilities_modifier
+			years = 20
+		}
+		add_prestige = major_prestige_loss
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_energy = 0.5
+				ai_boldness = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = athletic
+			}
+		}
+	}
+	
+	#Drunkard: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.3411.j.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.3411.j.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#You commit fully to pickling yourself in booze.
+		add_character_modifier = {
+			modifier = tragic_drunk_modifier
+			years = 10
+		}
+		add_prestige_level = -1
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.3411.k.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.3411.k.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#You attempt to obliterate your brain with hashish.
+		add_character_modifier = {
+			modifier = tragic_stoner_modifier
+			years = 10
+		}
+		add_prestige_level = -1
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Grit your teeth and push through.
+	option = {
+		name = stress_threshold.3411.l
+
+		#Account for stress.
+		add_stress = medium_stress_impact_gain
+
+		#You abdicate.
+		every_vassal = {
+			limit = {
+				opinion = {	#They've gotta not completely hate you to be annoyed by this.
+					target = root
+					value >= medium_negative_opinion
+				}
+				NOR = {	#Various relations either support you or already hated you.
+					has_relation_rival = root
+					has_relation_friend = root
+					has_relation_lover = root
+					has_trait = ambitious	#Ambitious peeps are actually ok with a change of leader.
+				}
+			}
+			custom = stress_threshold.3411.l.list
+			add_opinion = {
+				modifier = stress_abdicated_opinion
+				opinion = -80
+				target = root
+			}
+		}
+		add_character_flag = {
+			flag = abdicated_from_throne
+			days = 30
+		}
+		
+		hidden_effect = {	#Make all weak claims on your titles into strong claims.
+			every_held_title = {
+				save_temporary_scope_as = abdicator_title
+				every_claimant = {
+					limit = { has_weak_claim_on = scope:abdicator_title }
+					make_claim_strong = scope:abdicator_title
+				}
+			}
+		}
+		custom_tooltip = stress_threshold.3411.l.tt
+		depose = yes # depose_effect not used for opted abdication
+
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = generous
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_generous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_generous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = diligent
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_diligent }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_diligent
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = patient
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_patient }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_patient
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = humble
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_humble }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_humble
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = shy
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_shy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_shy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = just
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_just }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_just
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = trusting
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_trusting }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_trusting
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = compassionate
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_compassionate }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_compassionate
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = forgiving
+					NOT = { has_character_flag = had_stress_threshold_3411_desc_forgiving }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3411_desc_forgiving
+					years = 10
+				}
+			}
+		}
+	}
+}
+
+##################################################
+# Domain of Debauchery
+# by Ewan Cowhig Croft
+# #3421
+##################################################
+
+#	Your holdings burn, but you're too ensconsed in hiding from your stress to care.
+#		by Ewan Cowhig Croft
+stress_threshold.3421 = {
+	type = character_event
+	title = stress_threshold.3421.t
+	desc = {
+		desc = stress_threshold.3421.desc.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					has_trait = lustful
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_lustful }
+				}
+				desc = stress_threshold.3421.desc.lustful
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = gluttonous
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_gluttonous }
+				}
+				desc = stress_threshold.3421.desc.gluttonous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = greedy
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_greedy }
+				}
+				desc = stress_threshold.3421.desc.greedy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = lazy
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_lazy }
+				}
+				desc = stress_threshold.3421.desc.lazy
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = arrogant
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_arrogant }
+				}
+				desc = stress_threshold.3421.desc.arrogant
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = craven
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_craven }
+				}
+				desc = stress_threshold.3421.desc.craven
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = gregarious
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_gregarious }
+				}
+				desc = stress_threshold.3421.desc.gregarious
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = cynical
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_cynical }
+				}
+				desc = stress_threshold.3421.desc.cynical
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = zealous
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_zealous }
+				}
+				desc = stress_threshold.3421.desc.zealous
+			}
+			triggered_desc = {
+				trigger = {
+					has_trait = stubborn
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_stubborn }
+				}
+				desc = stress_threshold.3421.desc.stubborn
+			}
+			desc = stress_threshold.3421.desc.fallback
+		}
+		desc = stress_threshold.3421.desc.rump
+	}
+	theme = mental_break
+	override_background = {
+		reference = bedchamber
+	}
+	override_background = {
+		trigger = { is_travelling = yes }
+		reference = terrain
+	}
+	left_portrait = {
+		character = root
+		animation = happiness
+	}
+
+	trigger = {
+		#Landless characters & barons don't need fancy events.
+		is_landed = yes
+		primary_title.tier >= tier_county
+		#Must match at least one appropriate personality trait.
+		OR = {
+			has_trait = lustful
+			has_trait = gluttonous
+			has_trait = greedy
+			has_trait = lazy
+			has_trait = arrogant
+			has_trait = craven
+			has_trait = gregarious
+			has_trait = cynical
+			has_trait = zealous
+			has_trait = stubborn
+		}
+		#Characters must meet the criteria for at least two event options to qualify for this event (we don't want to fire the event if the player has no choices!).
+		calc_true_if = {
+			amount >= 2
+			
+			can_be_rakish = yes
+			has_trait = rakish
+			can_be_reclusive = yes
+			has_trait = reclusive
+			can_be_irritable = yes
+			has_trait = irritable
+			can_be_flagellant = yes
+			has_trait = flagellant
+			can_be_profligate = yes
+			has_trait = profligate
+			can_be_comfort_eater = yes
+			has_trait = comfort_eater
+			OR = { #While picking either of these is fine, we don't want to have the player chose between only these two.
+				can_be_drunkard = yes
+				has_trait = drunkard
+				can_be_hashishiyah = yes
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	weight_multiplier = {
+		base = 1
+		#Weight up if the character has any relevant coping method from the event.
+		modifier = {
+			add = 10
+			has_trait = rakish
+		}
+		modifier = {
+			add = 10
+			has_trait = reclusive
+		}
+		modifier = {
+			add = 10
+			has_trait = irritable
+		}
+		modifier = {
+			add = 10
+			has_trait = flagellant
+		}
+		modifier = {
+			add = 10
+			has_trait = profligate
+		}
+		modifier = {
+			add = 10
+			has_trait = comfort_eater
+		}
+		modifier = {
+			add = 10
+			OR = {
+				has_trait = drunkard
+				has_trait = hashishiyah
+			}
+		}
+		#One of your parents/guardian has issues
+		modifier = {
+			OR = {
+				has_witnessed_stress_coping_trait = { TRAIT = reclusive }
+				has_witnessed_stress_coping_trait = { TRAIT = irritable }
+				has_witnessed_stress_coping_trait = { TRAIT = flagellant }
+				has_witnessed_stress_coping_trait = { TRAIT = profligate }
+				has_witnessed_stress_coping_trait = { TRAIT = contrite }
+				has_witnessed_stress_coping_trait = { TRAIT = comfort_eater }
+				has_witnessed_stress_coping_trait = { TRAIT = drunkard }
+				has_witnessed_stress_coping_trait = { TRAIT = hashishiyah }
+			}
+			add = 5
+		}
+	}
+	
+	widget = {
+		gui = "event_window_widget_stress"
+		container = "custom_widgets_container"
+	}
+
+	immediate = {
+		root = { save_scope_as = stress_character } #For stress widget.
+		capital_province = { save_scope_as = capital_holding }	#For loc.
+		random_directly_owned_province = {
+			limit = {
+				barony.county = { county_control >= massive_county_control_loss }
+			}
+			alternative_limit = { always = yes }
+			barony.county = { save_scope_as = burning_holding }
+		}	#For loc.
+
+		#Event option set-up to determine which event options we want to offer to the player.
+		#Check for existing coping mechanisms first.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = rakish	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = reclusive	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = irritable	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = flagellant	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = profligate	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				has_trait = comfort_eater	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					has_trait = drunkard
+					has_trait = hashishiyah
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { has_trait = drunkard }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { has_trait = hashishiyah }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		
+		#Then potential ones.
+		if = { #Rakish (prone to extremely wonton behavior, with the associated consequences)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_rakish = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_rakish
+		}
+		if = { #Reclusive (frequently withdrawn, risking damage to relationships)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_reclusive = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_reclusive
+		}
+		if = { #Irritable (tends to lash out at random)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_irritable = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_irritable
+		}
+		if = { #Flagellant (impulsively self-harms)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_flagellant = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_flagellant
+		}
+		if = { #Profligate (compulsively spends money)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_profligate = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_profligate
+		}
+		if = { #Comfort Eater (eats as a stress release)
+			limit = {
+				has_two_stress_threshold_options = no
+				can_be_comfort_eater = yes	
+			}
+			# Set the flag for enabling this event option.
+			add_character_flag = stress_threshold_option_comfort_eater
+		}
+		if = { #Substance Abuse (alcohol or cannabis, depending on faith/region)
+			limit = {
+				has_two_stress_threshold_options = no
+				OR = {
+					can_be_drunkard = yes
+					can_be_hashishiyah = yes
+				}
+			}
+			hidden_effect = {
+					random_list = { #Which option the player gets is somewhat dependent on wherethey are and what their faith is.
+					50 = {
+						trigger = { can_be_drunkard = yes }
+						add_character_flag = stress_threshold_option_drunkard
+					}
+					50 = {
+						trigger = { can_be_hashishiyah = yes }
+						add_character_flag = stress_threshold_option_hashishiyah
+					}
+				}
+			}
+		}
+		stress_threshold_event_post_immediate = yes
+	}
+
+	#Rakish: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_rakish
+		}
+		name = {
+			trigger = { can_be_rakish = yes }
+			text = stress_threshold.3421.a.rakish.gain
+		}
+		name = {
+			trigger = { has_trait = rakish }
+			text = stress_threshold.3421.a.rakish.effect
+		}
+		
+		add_trait = rakish
+		trait = rakish
+
+		rakish_brothel_night_effect = yes # Stress reduction is included in this effect.
+		
+		#Other effects: the county suffers minor damage and your delay disgusts everyone.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = managed_urban_fires_modifier
+				years = 20
+			}
+			change_county_control = major_county_control_loss
+		}
+		add_prestige_level = -1
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = rakish
+			}
+		}
+	}
+	
+	#Reclusive: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_reclusive
+		}
+		name = {
+			trigger = { can_be_reclusive = yes }
+			text = stress_threshold.3421.b.reclusive.gain
+		}
+		name = {
+			trigger = { has_trait = reclusive }
+			text = stress_threshold.3421.b.reclusive.effect
+		}
+		
+		add_trait = reclusive
+		trait = reclusive
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Other effects: everything burns, everyone burns, everyone *else* is disgusted with you for refusing to even give a response.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = uncontrolled_urban_fires_modifier
+				years = 20
+			}
+			change_county_control = massive_county_control_loss
+		}
+
+		every_vassal = {
+			limit = {
+				NOR = {
+					has_trait = sadistic
+					has_trait = callous
+				}
+			}
+			custom = stress_threshold.3421.b.reclusive.list
+			add_opinion = {
+				modifier = disgusted_opinion
+				opinion = -30
+				target = root
+			}
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_sociability = 0.5
+				ai_energy = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = reclusive
+			}
+		}
+	}
+
+	#Irritable: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_irritable
+		}
+		name = {
+			trigger = { can_be_irritable = yes }
+			text = stress_threshold.3421.c.irritable.gain
+		}
+		name = {
+			trigger = { has_trait = irritable }
+			text = stress_threshold.3421.c.irritable.effect
+		}
+		
+		add_trait = irritable
+		trait = irritable
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Other effects: the county suffers minor damage and your delay disgusts everyone.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = controlled_urban_fires_modifier
+				years = 10
+			}
+			change_county_control = minor_county_control_loss
+		}
+		add_character_modifier = {
+			modifier = lashing_out_at_victims_modifier
+			years = 10
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_vengefulness = 0.5
+				ai_compassion = -0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = irritable
+			}
+		}
+	}
+	
+	#Flagellant: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_flagellant
+		}
+		name = {
+			trigger = { can_be_flagellant = yes }
+			text = stress_threshold.3421.d.flagellant.gain
+		}
+		name = {
+			trigger = { has_trait = flagellant }
+			text = stress_threshold.3421.d.flagellant.effect
+		}
+		
+		add_trait = flagellant
+		trait = flagellant
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		increase_wounds_effect = { REASON = whipping }
+		if = {
+			limit = {
+				faith = { has_doctrine_parameter = self_mutilation_active }
+			}
+			add_piety = minor_piety_value
+		}
+		
+		#Other effects: the county suffers minor damage and your delay disgusts everyone.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = managed_urban_fires_modifier
+				years = 20
+			}
+			change_county_control = major_county_control_loss
+		}
+		add_prestige_level = -1
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_zeal = 0.5
+				ai_energy = 0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = flagellant
+			}
+		}
+	}
+	
+	#Profligate: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_profligate
+		}
+		name = {
+			trigger = { can_be_profligate = yes }
+			text = stress_threshold.3421.e.profligate.gain
+		}
+		name = {
+			trigger = { has_trait = profligate }
+			text = stress_threshold.3421.e.profligate.effect
+		}
+		
+		add_trait = profligate
+		trait = profligate
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		remove_short_term_gold = monumental_gold_value
+		
+		#Other effects: the fires are doused successfully at huge cost but with minimal damage.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = controlled_urban_fires_modifier
+				years = 10
+			}
+			change_county_control = minor_county_control_loss
+		}
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.5
+				ai_sociability = 0.5
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = profligate
+			}
+		}
+	}
+	
+	#Comfort Eater: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_comfort_eater
+		}
+		name = {
+			trigger = { can_be_comfort_eater = yes }
+			text = stress_threshold.3421.f.comfort_eater.gain
+		}
+		name = {
+			trigger = { has_trait = comfort_eater }
+			text = stress_threshold.3421.f.comfort_eater.effect
+		}
+		
+		add_trait = comfort_eater
+		trait = comfort_eater
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Other effects: the county suffers minor damage and your delay disgusts everyone.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = managed_urban_fires_modifier
+				years = 20
+			}
+			change_county_control = major_county_control_loss
+		}
+		add_prestige_level = -1
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = comfort_eater
+			}
+		}
+	}
+	
+	#Drunkard: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_drunkard
+		}
+		name = {
+			trigger = { can_be_drunkard = yes }
+			text = stress_threshold.3421.g.drunkard.gain
+		}
+		name = {
+			trigger = { has_trait = drunkard }
+			text = stress_threshold.3421.g.drunkard.effect
+		}
+		
+		trait = drunkard
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Make habitual binge drinker, or go on a tear.
+		if = {
+			limit = { has_trait = drunkard }
+			add_character_modifier = {
+				modifier = stress_drinking_binge
+				years = 3
+			}
+		}
+		else = { add_trait = drunkard }
+		
+		#Other effects: the county suffers minor damage and your delay disgusts everyone.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = managed_urban_fires_modifier
+				years = 20
+			}
+			change_county_control = major_county_control_loss
+		}
+		add_prestige_level = -1
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = drunkard
+			}
+		}
+	}
+	
+	#Hashishiyah: major stress loss
+	option = {
+		trigger = {
+			has_character_flag = stress_threshold_option_hashishiyah
+		}
+		name = {
+			trigger = { can_be_hashishiyah = yes }
+			text = stress_threshold.3421.h.hashishiyah.gain
+		}
+		name = {
+			trigger = { has_trait = hashishiyah }
+			text = stress_threshold.3421.h.hashishiyah.effect
+		}
+
+		trait = hashishiyah
+
+		#Account for stress.
+		add_stress = major_stress_impact_loss
+		
+		#Make habitual hashish consumer, or go on a notable binge.
+		if = {
+			limit = { has_trait = hashishiyah }
+			add_character_modifier = {
+				modifier = stress_hashish_stupor
+				years = 3
+			}
+		}	
+		else = { add_trait = hashishiyah }
+		
+		#Other effects: the county suffers minor damage and your delay disgusts everyone.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = managed_urban_fires_modifier
+				years = 20
+			}
+			change_county_control = major_county_control_loss
+		}
+		add_prestige_level = -1
+
+		ai_chance = {
+			base = 25
+			ai_value_modifier = {
+				ai_greed = 0.25
+				ai_energy = -0.25
+			}
+			modifier = {	#Pick this option if you have the relevant coping mechanism.
+				add = 200
+				has_trait = hashishiyah
+			}
+		}
+	}
+
+	#Sounds like a them-problem.
+	option = {
+		name = stress_threshold.3421.i
+
+		#Account for stress.
+		add_stress = massive_stress_impact_loss
+
+		#Other effects: everything burns, everyone burns.
+		scope:burning_holding.county = {
+			add_county_modifier = {
+				modifier = uncontrolled_urban_fires_modifier
+				years = 20
+			}
+			change_county_control = massive_county_control_loss
+		}
+		add_character_modifier = {
+			modifier = encouraged_city_burn_modifier
+			years = 10
+		}
+		
+		ai_chance = { base = 0 }	#AI should never opt for stress.
+	}
+
+	after = {
+		stress_threshold_event_aftereffects = yes #Perform stress threshold event clean-up and preparation for future stress threshold events.
+
+		if = {
+			limit = {
+				is_alive = yes
+			}
+
+			# Add blocker to prevent us from getting the same event option multiple times in short succession.
+			if = {
+				limit = {
+					has_trait = lustful
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_lustful }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_lustful
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = gluttonous
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_gluttonous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_gluttonous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = greedy
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_greedy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_greedy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = lazy
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_lazy }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_lazy
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = arrogant
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_arrogant }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_arrogant
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = craven
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_craven }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_craven
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = gregarious
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_gregarious }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_gregarious
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = cynical
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_cynical }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_cynical
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = zealous
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_zealous }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_zealous
+					years = 10
+				}
+			}
+			else_if = {
+				limit = {
+					has_trait = stubborn
+					NOT = { has_character_flag = had_stress_threshold_3421_desc_stubborn }
+				}
+				add_character_flag = {
+					flag = had_stress_threshold_3421_desc_stubborn
+					years = 10
+				}
+			}
+		}
+	}
+}

--- a/events/stress_events/stress_threshold_events.txt
+++ b/events/stress_events/stress_threshold_events.txt
@@ -195,11 +195,39 @@ stress_threshold.0001 = {
 				has_trait = faltering_heart
 				is_incapable = no
 			}
-			send_interface_message = {
-				type = msg_health_change
-				title = your_heart_beats_irregularly_feed_message_title
-				left_icon = root
-				add_trait_xp = { trait = faltering_heart track = faltering_heart value = 25 }
+			#Unop gate the faltering_heart xp by stress level (and tier it) like the imprisoned path does, so it no longer progresses at stress level 0
+			if = {
+				limit = {
+					stress_level >= 3
+				}
+				send_interface_message = {
+					type = msg_health_change
+					title = your_heart_beats_irregularly_feed_message_title
+					left_icon = root
+					add_trait_xp = { trait = faltering_heart track = faltering_heart value = 25 }
+				}
+			}
+			else_if = {
+				limit = {
+					stress_level >= 2
+				}
+				send_interface_message = {
+					type = msg_health_change
+					title = your_heart_beats_irregularly_feed_message_title
+					left_icon = root
+					add_trait_xp = { trait = faltering_heart track = faltering_heart value = 15 }
+				}
+			}
+			else_if = {
+				limit = {
+					stress_level >= 1
+				}
+				send_interface_message = {
+					type = msg_health_change
+					title = your_heart_beats_irregularly_feed_message_title
+					left_icon = root
+					add_trait_xp = { trait = faltering_heart track = faltering_heart value = 5 }
+				}
 			}
 			if = {
 				limit = {


### PR DESCRIPTION
Fixes #537

**fixer:** In `stress_threshold.0001` (the non-imprisoned periodic stress event), the Faltering Heart xp block had no stress gate — it always added a flat 25 track xp whenever the event fired, including at stress level 0. Since `stress_threshold.0005` fires `.0001` on cooldown regardless of stress, the trait progressed (and could reach the heart-attack death at xp ≥ 100) with zero stress, contradicting the trait's "progresses for every mental break" design.

Mirrored the imprisoned path (`stress_threshold.0002`), which already tiers the xp by stress level: 25 at `stress_level >= 3`, 15 at `>= 2`, 5 at `>= 1`, and nothing at level 0. The ungated death check is left unchanged. This also resolves the flat-vs-tiered inconsistency between the two paths.

The vanilla file is added unmodified in the first commit, the fix in the second. In-game verification needed: at stress 0 the trait should no longer gain xp.