### PR TITLE
Change coronation law before equipping crown/regalia

### DIFF
--- a/events/activities/coronation_activity/coronation_events_6.txt
+++ b/events/activities/coronation_activity/coronation_events_6.txt
@@ -5312,6 +5312,7 @@ coronation_events.6100 = {
 			limit = {
 				this = scope:host
 			}
+			coronation_change_law_effect = yes #Unop Change the law first, so the crown/regalia can be equipped
 			if = {
 				limit = {
 					scope:crowning_artifact ?= { is_equipped = no }
@@ -5319,11 +5320,11 @@ coronation_events.6100 = {
 				}
 				scope:crowning_artifact = { equip_artifact_to_owner = yes }
 			}
-			coronation_change_law_effect = yes
 		}
 		else = {
 			show_as_tooltip = {
 				scope:host = {
+					coronation_change_law_effect = yes #Unop Change the law first, so the crown/regalia can be equipped
 					if = {
 						limit = {
 							scope:crowning_artifact ?= { is_equipped = no }
@@ -5331,7 +5332,6 @@ coronation_events.6100 = {
 						}
 						scope:crowning_artifact = { equip_artifact_to_owner = yes }
 					}
-					coronation_change_law_effect = yes
 				}
 			}
 		}
@@ -5946,6 +5946,7 @@ coronation_events.6101 = {
 					this = root
 				}
 				coronation_ceremony_opinion_effect = yes
+				coronation_change_law_effect = yes #Unop Change the law first, so the crown/regalia can be equipped
 				if = {
 					limit = {
 						scope:crowning_artifact ?= { is_equipped = no }
@@ -5953,11 +5954,11 @@ coronation_events.6101 = {
 					}
 					scope:crowning_artifact = { equip_artifact_to_owner = yes }
 				}
-				coronation_change_law_effect = yes
 			}
 			else = {
 				show_as_tooltip = {
 					coronation_ceremony_opinion_effect = yes
+					coronation_change_law_effect = yes #Unop Change the law first, so the crown/regalia can be equipped
 					if = {
 						limit = {
 							scope:crowning_artifact ?= { is_equipped = no }
@@ -5965,7 +5966,6 @@ coronation_events.6101 = {
 						}
 						scope:crowning_artifact = { equip_artifact_to_owner = yes }
 					}
-					coronation_change_law_effect = yes
 				}
 			}
 		}
@@ -6623,6 +6623,7 @@ coronation_events.6102 = {
 					this = root
 				}
 				coronation_ceremony_opinion_effect = yes
+				coronation_change_law_effect = yes #Unop Change the law first, so the crown/regalia can be equipped
 				if = {
 					limit = {
 						scope:crowning_artifact ?= { is_equipped = no }
@@ -6630,11 +6631,11 @@ coronation_events.6102 = {
 					}
 					scope:crowning_artifact = { equip_artifact_to_owner = yes }
 				}
-				coronation_change_law_effect = yes
 			}
 			else = {
 				show_as_tooltip = {
 					coronation_ceremony_opinion_effect = yes
+					coronation_change_law_effect = yes #Unop Change the law first, so the crown/regalia can be equipped
 					if = {
 						limit = {
 							scope:crowning_artifact ?= { is_equipped = no }
@@ -6642,7 +6643,6 @@ coronation_events.6102 = {
 						}
 						scope:crowning_artifact = { equip_artifact_to_owner = yes }
 					}
-					coronation_change_law_effect = yes
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #538

**fixer:** During coronation the crown/regalia auto-equip ran `can_equip_artifact` *before* `coronation_change_law_effect = yes`. While the ruler still holds the `uncrowned` law, the crown/regalia templates' `can_equip` (`NOT = { has_realm_law = uncrowned }`) fails, so the equip `if` is skipped and the artifact is never equipped automatically.

Reordered so `coronation_change_law_effect = yes` runs first at all six sites in `coronation_events_6.txt` (the king/emperor/anointment effect blocks and their `show_as_tooltip` mirrors), so the law no longer blocks the equip and the tooltip matches the executed effect.