### PR TITLE
Stop hold_court church/city events building in baronies that can't have holdings

### DIFF
--- a/common/scripted_triggers/02_ep1_scripted_triggers.txt
+++ b/common/scripted_triggers/02_ep1_scripted_triggers.txt
@@ -311,6 +311,7 @@ target_of_powerful_faction_trigger = {
 province_has_no_holding_trigger = { # province has no holding
 	has_ongoing_construction = no
 	has_holding = no
+	barony_cannot_construct_holding = no #Unop also require that a holding is actually allowed here (excludes e.g. Sahara corridor baronies)
 }
 
 county_has_all_holding_types = { # county has all three holding types

--- a/events/activities/pilgrimage_activity/pilgrimage_events_seasia.txt
+++ b/events/activities/pilgrimage_activity/pilgrimage_events_seasia.txt
@@ -1,0 +1,2758 @@
+﻿# Events for Pilgrimages in South-East Asia
+
+namespace = pilgrimage_seasia
+
+# The Pearl Diver
+pilgrimage_seasia.100 = {
+	type = character_event
+	title = pilgrimage_seasia.100.t
+	desc = pilgrimage_seasia.100.desc
+	theme = travel_pilgrimage
+	override_background = { reference = bp3_coast }
+	left_portrait = {
+		character = root
+		animation = interested
+	}
+	right_portrait = {
+		character = scope:pearl_diver_child
+		animation = storyteller
+		camera = camera_event_right_pointing_right
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		has_tgp_dlc_trigger = yes
+		is_travelling = yes
+		OR = {
+			government_has_flag = government_is_mandala
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		is_adult = yes
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+				is_coastal = yes
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		location = {
+			random_neighboring_province = {
+				limit = {
+					exists = county
+					OR = {
+						geographical_region = world_asia_southeast_mainland
+						geographical_region = world_asia_southeast_islands
+					}
+					is_coastal = yes
+				}
+				save_scope_as = background_terrain_scope
+			}
+		}
+		create_character = {
+			location = scope:background_terrain_scope
+			template = peasant_child_character
+			age = { 8 11 }
+			gender_female_chance = root_faith_dominant_gender_adjusted_female_chance
+			faith = scope:background_terrain_scope.faith
+			culture = scope:background_terrain_scope.culture
+			save_scope_as = pearl_diver_child
+		}
+	}
+
+	option = { # Adopt child
+		name = pilgrimage_seasia.100.a
+		
+		trigger = {
+			can_be_parent_of = scope:pearl_diver_child
+			has_activity_intent = altruism_intent
+		}
+		
+		reason = activity_intent
+		
+		very_pious_type_option_effect = yes
+		
+		scope:pearl_diver_child = {
+			add_piety_level = 4
+		}
+		
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:pearl_diver_child 
+			NEW_COURT_OWNER = root 
+		}
+		
+		if = {
+			limit = {
+				is_male = yes
+			}
+			scope:pearl_diver_child = { set_father = root }
+		}
+		else = {
+			scope:pearl_diver_child = { set_mother = root }
+		}
+		if = {
+			limit = { exists = house }
+			scope:pearl_diver_child = { set_house = root.house }
+		}
+		set_relation_friend = {
+			reason = friend_adopted
+			target = scope:pearl_diver_child
+		}
+		
+		stress_impact = {
+			sadistic = massive_stress_impact_gain
+			cynical = massive_stress_impact_gain
+			compassionate = massive_stress_impact_loss
+			zealous = medium_stress_impact_loss
+		}
+		ai_chance = {
+			base = 5
+			modifier = {
+				OR = {
+					has_trait = cynical
+					has_trait = sadistic
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Accept pearl as an omen
+		name = pilgrimage_seasia.100.b
+		
+		add_piety = minor_piety_gain
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+			zealous = minor_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Accept pearl as trinket
+		name = pilgrimage_seasia.100.c
+		
+		add_gold = tiny_gold_value_static_max
+		worldly_type_option_effect = yes
+		
+		stress_impact = {
+			generous = medium_stress_impact_gain
+			zealous = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				OR = {
+					has_trait = generous
+					has_trait = zealous
+				}
+				factor = 0
+			}
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:pearl_diver_child = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# Mangrove Spirits
+pilgrimage_seasia.200 = {
+	type = character_event
+	title = pilgrimage_seasia.200.t
+	desc = pilgrimage_seasia.200.desc
+	theme = travel_pilgrimage
+	override_background = { reference = wilderness_wetlands }
+	left_portrait = {
+		character = root
+		animation = interested
+		camera = camera_event_very_right_pointing_very_left
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = bribing
+		camera = camera_event_left_away_3_4
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		has_tgp_dlc_trigger = yes
+		is_travelling = yes
+		OR = {
+			government_has_flag = government_is_mandala
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		is_adult = yes
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+				is_coastal = yes
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		location = {
+			random_neighboring_province = {
+				limit = {
+					exists = county
+					OR = {
+						geographical_region = world_asia_southeast_mainland
+						geographical_region = world_asia_southeast_islands
+					}
+					is_coastal = yes
+				}
+				save_scope_as = background_terrain_scope
+			}
+		}
+		if = {
+			limit = {
+				any_pool_character = {
+					province = scope:background_terrain_scope
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+				}
+			}
+			random_pool_character = {
+				province = scope:background_terrain_scope
+				limit = {
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+				}
+				save_scope_as = local_character
+			}
+		}
+		else = {
+			create_character = {
+				template = generic_peasant_character
+				location = scope:background_terrain_scope
+				culture = scope:background_terrain_scope.culture
+				faith = scope:background_terrain_scope.faith
+				save_scope_as = local_character
+			}
+		}
+		hidden_effect = {
+			scope:local_character = {
+				assign_random_nickname_effect = yes
+			}
+		}
+	}
+
+	option = { # Recruit the fishermen
+		name = pilgrimage_seasia.200.a
+		
+		add_character_modifier = {
+			modifier = local_fishermen_modifier
+			years = 5
+		}
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		worldly_type_option_effect = yes
+		
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+				}
+				set_relation_potential_friend = scope:local_character
+			}
+		}
+		
+		stress_impact = {
+			base = minor_stress_impact_loss
+			shy = minor_stress_impact_gain
+			reclusive = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 5
+			modifier = {
+				OR = {
+					has_trait = shy
+					has_trait = reclusive
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Make an offering and move on
+		name = pilgrimage_seasia.200.b
+		
+		add_piety = minor_piety_gain
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+			zealous = minor_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Make haste
+		name = pilgrimage_seasia.200.c
+		
+		current_travel_plan = {
+			add_destination_progress = { days = 7 }
+		}
+		
+		stress_impact = {
+			generous = medium_stress_impact_gain
+			zealous = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				OR = {
+					has_trait = generous
+					has_trait = zealous
+				}
+				factor = 0
+			}
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# Good Omen - Calm Oceans
+pilgrimage_seasia.300 = {
+	type = character_event
+	title = pilgrimage_seasia.300.t
+	desc = pilgrimage_seasia.300.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = survey
+		camera = camera_event_center_away
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		has_tgp_dlc_trigger = yes
+		is_travelling = yes
+		is_adult = yes
+		OR = {
+			has_variable = good_prophecy_var
+			has_character_modifier = good_omen_modifier
+		}
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		location = {
+			save_scope_as = background_terrain_scope
+		}
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+	}
+
+	option = { # Lets use the favorable winds!
+		name = pilgrimage_seasia.300.a
+		
+		current_travel_plan = {
+			add_travel_plan_modifier = {
+				modifier = good_prophecy_travel_modifier
+			}
+		}
+		
+		very_pious_type_option_effect = yes
+		
+		stress_impact = {
+			base = medium_stress_impact_loss
+		}
+		
+		current_travel_plan = {
+			add_destination_progress = { days = 14 }
+		}
+	}
+	after = {
+		mp_resume_travel_plan = yes
+	}
+}
+
+# Floating Shrine
+pilgrimage_seasia.400 = {
+	type = character_event
+	title = pilgrimage_seasia.400.t
+	desc = pilgrimage_seasia.400.desc
+	theme = travel_pilgrimage
+	override_background = { reference = bp3_riverside }
+	left_portrait = {
+		character = root
+		animation = interested_left
+		camera = camera_event_left_away_3_4
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = prayer
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		has_tgp_dlc_trigger = yes
+		is_travelling = yes
+		OR = {
+			government_has_flag = government_is_mandala
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		is_adult = yes
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+				is_coastal = yes
+				county.faith.religion = { is_in_family = rf_eastern }
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+		location = {
+			random_neighboring_province = {
+				limit = {
+					exists = county
+					OR = {
+						geographical_region = world_asia_southeast_mainland
+						geographical_region = world_asia_southeast_islands
+					}
+					is_coastal = yes
+					county.faith.religion = { is_in_family = rf_eastern }
+				}
+				save_scope_as = background_terrain_scope
+			}
+		}
+		if = {
+			limit = {
+				any_pool_character = {
+					province = scope:background_terrain_scope
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+					can_be_clergy_due_to_gender_trigger = yes
+					religion = { is_in_family = rf_eastern }
+					learning >= 12
+				}
+			}
+			random_pool_character = {
+				province = scope:background_terrain_scope
+				limit = {
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+					can_be_clergy_due_to_gender_trigger = yes
+					religion = { is_in_family = rf_eastern }
+					learning >= 12
+				}
+				save_scope_as = local_character
+			}
+		}
+		else = {
+			create_character = {
+				template = virtuous_priest_character_template
+				location = scope:background_terrain_scope
+				gender_female_chance = root_faith_clergy_gender_female_chance
+				culture = scope:background_terrain_scope.culture
+				faith = scope:background_terrain_scope.faith
+				save_scope_as = local_character
+			}
+		}
+		hidden_effect = {
+			scope:local_character = {
+				assign_random_nickname_effect = yes
+				add_trait = blind
+			}
+		}
+	}
+
+	option = {
+		name = pilgrimage_seasia.400.a
+		trigger = {
+			faith != scope:local_character.faith
+		}
+		set_character_faith = scope:local_character.faith
+		if = {
+			limit = { 
+				scope:local_character.faith = { has_doctrine = doctrine_monotheist }
+			}
+			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
+		}
+		add_piety_level = 1
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		very_pious_type_option_effect = yes
+		
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+				}
+				set_relation_potential_friend = scope:local_character
+			}
+		}
+		
+		
+		stress_impact = {
+			zealous = massive_stress_impact_gain
+			cynical = medium_stress_impact_loss
+		}
+		ai_chance = {
+			base = 5
+			modifier = {
+				has_trait = zealous
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Receive... a prophecy
+		name = pilgrimage_seasia.400.b
+		
+		flavor = a_good_prophecy_tt
+		set_variable = {
+			name = good_prophecy_var
+			years = prophecy_duration
+		}
+		worldly_type_option_effect = yes
+		
+		stress_impact = {
+			cynical = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Receive a blessing
+		name = pilgrimage_seasia.400.c
+		
+		add_piety = minor_piety_gain
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			zealous = minor_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# The Great Raja!
+pilgrimage_seasia.500 = {
+	type = character_event
+	title = pilgrimage_seasia.500.t
+	desc = pilgrimage_seasia.500.desc
+	theme = travel_pilgrimage
+	override_background = { reference = bp3_coast }
+	left_portrait = {
+		character = root
+		animation = wedding_priest
+		camera = camera_event_very_left
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = admiration
+		camera = camera_event_right_pointing_right_scheme
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		OR = {
+			government_has_flag = government_is_mandala
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		is_adult = yes
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+				is_coastal = yes
+				OR = {
+					county.holder = root
+					county.holder.top_liege = root
+				}
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		save_scope_as = root_scope
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+		location = {
+			random_neighboring_province = {
+				limit = {
+					exists = county
+					OR = {
+						geographical_region = world_asia_southeast_mainland
+						geographical_region = world_asia_southeast_islands
+					}
+					is_coastal = yes
+					OR = {
+						county.holder = root
+						county.holder.top_liege = root
+					}
+				}
+				save_scope_as = background_terrain_scope
+			}
+		}
+		if = {
+			limit = {
+				any_pool_character = {
+					province = scope:background_terrain_scope
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+					save_temporary_scope_as = peasant_char
+					are_characters_sensible_lovers_trigger = { INSTIGATING_LOVER = scope:root_scope TARGET_OF_LOVE = scope:peasant_char }
+				}
+			}
+			random_pool_character = {
+				province = scope:background_terrain_scope
+				limit = {
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+					save_temporary_scope_as = peasant_char
+					are_characters_sensible_lovers_trigger = { INSTIGATING_LOVER = scope:root_scope TARGET_OF_LOVE = scope:peasant_char }
+				}
+				save_scope_as = local_character
+			}
+		}
+		else = {
+			create_character = {
+				template = beautiful_peasant_character
+				location = scope:background_terrain_scope
+				gender_female_chance = root_attraction_based_female_chance
+				culture = scope:background_terrain_scope.culture
+				faith = scope:background_terrain_scope.faith
+				save_scope_as = local_character
+			}
+		}
+		hidden_effect = {
+			scope:local_character = {
+				assign_random_nickname_effect = yes
+			}
+		}
+	}
+
+	option = { # Show benevolence
+		name = pilgrimage_seasia.500.a
+		trigger = {
+			has_activity_intent = altruism_intent
+		}
+		scope:background_terrain_scope.county = {
+			add_county_modifier = {
+				modifier = coastal_ruler_visit_travel_modifier
+				years = 10
+			}
+		}
+		add_legitimacy = miniscule_legitimacy_gain
+		very_worldly_type_option_effect = yes
+		
+		reason = activity_intent
+		
+		current_travel_plan = {
+			delay_travel_plan = { days = 5 }
+		}
+		
+		stress_impact = {
+			callous = medium_stress_impact_gain
+			arbitrary = medium_stress_impact_gain
+			zealous = medium_stress_impact_loss
+			generous = medium_stress_impact_loss
+			improvident = medium_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				OR = {
+					has_trait = callous
+					has_trait = arbitrary
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Mass-convert
+		name = pilgrimage_seasia.500.b
+		
+		trigger = {
+			has_activity_intent = zealot_intent
+			any_pool_character = {
+				province = scope:background_terrain_scope
+				faith != root.faith
+			}
+		}
+		
+		reason = activity_intent
+		
+		current_travel_plan = {
+			delay_travel_plan = { days = 5 }
+		}
+		
+		add_piety = minor_piety_gain
+		
+		pious_type_option_effect = yes
+		
+		if = {
+			limit = {
+				scope:background_terrain_scope.faith != root.faith
+			}
+			scope:background_terrain_scope = {
+				set_county_faith = root.faith
+			}
+		}
+		
+		if = {
+			limit = {
+				scope:local_character.faith != root.faith
+			}
+			scope:local_character = {
+				set_character_faith = root.faith
+			}
+		}
+		
+		every_pool_character = {
+			province = scope:background_terrain_scope
+			limit = {
+				faith != root.faith
+				this != scope:local_character
+			}
+			set_character_faith = root.faith
+		}
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Smash
+		name = pilgrimage_seasia.500.c
+		
+		trigger = {
+			NOT = { has_sexuality = asexual }
+		}
+		
+		current_travel_plan = {
+			delay_travel_plan = { days = 5 }
+		}
+		
+		had_sex_with_effect = {
+			CHARACTER = scope:local_character
+			PREGNANCY_CHANCE = pregnancy_chance
+		}
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		if = {
+			limit = {
+				can_set_relation_potential_lover_trigger = { CHARACTER = scope:local_character }
+			}
+			set_relation_potential_lover = scope:local_character
+		}
+		worldly_type_option_effect = yes
+		
+		stress_impact = {
+			lustful = medium_stress_impact_loss
+			chaste = massive_stress_impact_gain
+		}
+		ai_chance = {
+			base = 0
+			modifier = {
+				scope:local_character = {
+					has_conventionally_ugly_trigger = no
+				}
+				are_characters_sensible_and_appropriate_lovers_trigger = {
+					INSTIGATING_LOVER = scope:root_scope
+					TARGET_OF_LOVE = scope:local_character
+				}
+				add = 100
+			}
+		}
+	}
+
+	option = { # Lets not dawdle
+		name = pilgrimage_seasia.500.d
+		
+		add_prestige = minor_prestige_gain
+		
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# An Offering of Rice
+pilgrimage_seasia.600 = {
+	type = character_event
+	title = pilgrimage_seasia.600.t
+	desc = pilgrimage_seasia.600.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = survey
+		camera = camera_event_left_away
+	}
+	right_portrait = {
+		character = scope:entourage_character
+		animation = beg
+		camera = camera_event_center_away
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		OR = {
+			government_has_flag = government_is_mandala
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		is_adult = yes
+		current_travel_plan = {
+			any_entourage_character = {
+				is_available_travelling_ai_adult = yes
+				has_relation_potential_friend = root
+			}
+		}
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		root = { save_scope_as = root_scope }
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+		location = { save_scope_as = background_terrain_scope }
+		current_travel_plan = {
+			random_entourage_character = {
+				limit = {
+					is_available_travelling_ai_adult = yes
+					has_relation_potential_friend = root
+				}
+				save_scope_as = entourage_character
+			}
+		}
+	}
+
+	option = { # The sky, is it an omen?
+		name = pilgrimage_seasia.600.a
+		trigger = {
+			has_activity_intent = reflection_intent
+		}
+		
+		reason = activity_intent
+		
+		bonus_to_all_types_effect = yes
+		
+		add_piety = miniscule_piety_gain
+		
+		stress_impact = {
+			base = minor_stress_impact_loss
+			cynical = minor_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Bond
+		name = pilgrimage_seasia.600.b
+		
+		worldly_type_option_effect = yes
+		set_relation_friend = { 
+			reason = friend_pilgrimage 
+			target = scope:entourage_character 
+		}
+		
+		stress_impact = {
+			cynical = minor_stress_impact_gain
+			shy = minor_stress_impact_gain
+			reclusive = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				OR = {
+					has_trait = cynical
+					has_trait = shy
+					has_trait = reclusive
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Let's eat...
+		name = pilgrimage_seasia.600.c
+		
+		stress_impact = {
+			gluttonous = minor_stress_impact_loss
+			comfort_eater = minor_stress_impact_loss
+		}
+		ai_chance = {
+			base = 5
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+	}
+}
+
+# The Naga's Victim
+pilgrimage_seasia.700 = {
+	type = character_event
+	title = pilgrimage_seasia.700.t
+	desc = pilgrimage_seasia.700.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = personality_coward
+		camera = camera_event_center_close_to_right
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = sick
+	}
+	override_effect_2d = { reference = rain }
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		OR = {
+			government_has_flag = government_is_mandala
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		is_adult = yes
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		root = { save_scope_as = root_scope }
+		location = {
+			random_neighboring_province = {
+				limit = {
+					exists = county
+					OR = {
+						geographical_region = world_asia_southeast_mainland
+						geographical_region = world_asia_southeast_islands
+					}
+					is_coastal = yes
+				}
+				save_scope_as = background_terrain_scope
+			}
+		}
+		if = {
+			limit = {
+				any_pool_character = {
+					province = scope:background_terrain_scope
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+				}
+			}
+			random_pool_character = {
+				province = scope:background_terrain_scope
+				limit = {
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+				}
+				save_scope_as = local_character
+			}
+		}
+		else = {
+			create_character = {
+				template = generic_peasant_character
+				location = scope:background_terrain_scope
+				gender_female_chance = root_faith_dominant_gender_adjusted_female_chance
+				culture = scope:background_terrain_scope.culture
+				faith = scope:background_terrain_scope.faith
+				save_scope_as = local_character
+			}
+		}
+		hidden_effect = {
+			scope:local_character = {
+				set_nickname_effect = { NICKNAME = nick_the_unlucky }
+			}
+		}
+	}
+
+	option = { # Join me, unlucky one
+		name = pilgrimage_seasia.700.a
+		
+		add_piety = minor_piety_gain
+		
+		bonus_to_all_types_effect = yes
+		
+		add_hook = {
+			target = scope:local_character
+			type = saved_my_life_hook
+		}
+		
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		
+		current_travel_plan = {
+			every_entourage_character = {
+				custom = every_entourage_tt
+				add_opinion = {
+					target = root
+					modifier = scared_opinion
+					opinion = -25
+				}
+			}
+		}
+		
+		if = {
+			limit = {
+				can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+			}
+			set_relation_potential_friend = scope:local_character
+		}
+		
+		stress_impact = {
+			sadistic = minor_stress_impact_gain
+			callous = minor_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				OR = {
+					has_trait = sadistic
+					has_trait = callous
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # You have to leave soon
+		name = pilgrimage_seasia.700.b
+		
+		add_piety = minor_piety_gain
+		
+		add_to_entourage_and_activity_but_not_court_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		
+		stress_impact = {
+			compassionate = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = compassionate
+				factor = 0
+			}
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# Shadows in the Water
+pilgrimage_seasia.800 = {
+	type = character_event
+	title = pilgrimage_seasia.800.t
+	desc = pilgrimage_seasia.800.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = relaxed_spear
+		camera = camera_combat_window
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		is_adult = yes
+		OR = {
+			government_has_flag = government_is_mandala
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		location = {
+			save_scope_as = background_terrain_scope
+		}
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+	}
+
+	option = { # This is a good omen
+		name = pilgrimage_seasia.800.a
+		trigger = {
+			has_activity_intent = reflection_intent
+		}
+		flavor = a_good_omen_tt
+		
+		reason = activity_intent
+		
+		set_variable = {
+			name = good_prophecy_var
+			years = prophecy_duration
+		}
+		
+		stress_impact = {
+			base = minor_stress_impact_loss
+			cynical = minor_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Let us make an offering
+		name = pilgrimage_seasia.800.b
+		
+		remove_short_term_gold = { 1 25 }
+		
+		add_piety = minor_piety_gain
+		
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			zealous = minor_stress_impact_loss
+			cynical = minor_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # They are just fish... let's fish
+		name = pilgrimage_seasia.800.c
+		
+		add_gold = { 5 35 }
+		
+		stress_impact = {
+			cynical = minor_stress_impact_loss
+			zealous = minor_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = zealous
+				factor = 0
+			}
+		}
+	}
+	after = {
+		mp_resume_travel_plan = yes
+	}
+}
+
+# Sampan Pirates
+pilgrimage_seasia.900 = {
+	type = character_event
+	title = pilgrimage_seasia.900.t
+	desc = pilgrimage_seasia.900.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = sword_coup_degrace
+		camera = camera_event_center_pointing_right
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = shock
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		OR = {
+			government_has_flag = government_is_mandala
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		is_adult = yes
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+				is_coastal = yes
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		location = {
+			random_neighboring_province = {
+				limit = {
+					exists = county
+					OR = {
+						geographical_region = world_asia_southeast_mainland
+						geographical_region = world_asia_southeast_islands
+					}
+					is_coastal = yes
+				}
+				save_scope_as = background_terrain_scope
+			}
+		}
+		if = {
+			limit = {
+				any_pool_character = {
+					province = scope:background_terrain_scope
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+					is_clergy = no
+					can_be_combatant_based_on_gender_trigger = { ARMY_OWNER = root }
+				}
+			}
+			random_pool_character = {
+				province = scope:background_terrain_scope
+				limit = {
+					is_available_healthy_ai_adult = yes
+					has_no_particular_noble_roots_trigger = yes
+					is_clergy = no
+					can_be_combatant_based_on_gender_trigger = { ARMY_OWNER = root }
+				}
+				save_scope_as = local_character
+			}
+		}
+		else = {
+			create_character = {
+				template = generic_peasant_character
+				location = scope:background_terrain_scope
+				culture = scope:background_terrain_scope.culture
+				faith = scope:background_terrain_scope.faith
+				gender_female_chance = root_soldier_female_chance
+				save_scope_as = local_character
+			}
+		}
+		hidden_effect = {
+			scope:local_character = {
+				assign_random_nickname_effect = yes
+			}
+		}
+	}
+
+	option = { # Give the pirates resources to start new lives
+		name = pilgrimage_seasia.900.a
+		trigger = {
+			has_activity_intent = altruism_intent
+		}
+		
+		reason = activity_intent
+		bonus_to_all_types_effect = yes
+		add_piety = { minor_piety_gain medium_piety_gain }
+		remove_short_term_gold = { 20 60 }
+		
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+				}
+				set_relation_potential_friend = scope:local_character
+			}
+		}
+		
+		stress_impact = {
+			base = minor_stress_impact_loss
+			shy = minor_stress_impact_gain
+			reclusive = minor_stress_impact_gain
+		}
+		ai_chance = {
+			base = 5
+			modifier = {
+				OR = {
+					has_trait = shy
+					has_trait = reclusive
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Recruit the pirates
+		name = pilgrimage_seasia.900.b
+		
+		worldly_type_option_effect = yes
+		
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		
+		reverse_add_opinion = {
+			modifier = grateful_opinion
+			target = scope:local_character
+			opinion = 50
+		}
+		
+		if = {
+			limit = {
+				can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+			}
+			set_relation_potential_friend = scope:local_character
+		}
+		
+		random_maa_regiment = {
+			limit = {
+				can_upgrade_maa = yes
+				NOT = {
+					is_unit_type = siege_weapon
+				}
+			}
+			change_maa_regiment_size = 2
+		}
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+			zealous = minor_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Demand that they give you passage
+		name = pilgrimage_seasia.900.c
+		
+		add_legitimacy = miniscule_legitimacy_gain
+		
+		current_travel_plan = {
+			add_destination_progress = { days = 7 }
+		}
+		
+		stress_impact = {
+			generous = medium_stress_impact_gain
+			zealous = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				OR = {
+					has_trait = generous
+					has_trait = zealous
+				}
+				factor = 0
+			}
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# Traders of Tanah Makkah
+pilgrimage_seasia.1000 = {
+	type = character_event
+	title = pilgrimage_seasia.1000.t
+	desc = pilgrimage_seasia.1000.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = pondering
+		camera = camera_event_left_away_3_4
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = obsequious_bow
+		camera = camera_event_right_away
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		is_adult = yes
+		OR = {
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		capital_province ?= {
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+			}
+		}
+		title:c_mecca.religion = religion:islam_religion
+		location = {
+			has_sea_danger_type = { TRAVEL = root.current_travel_plan }
+			any_neighboring_province = {
+				exists = county
+				OR = {
+					geographical_region = world_asia_southeast_mainland
+					geographical_region = world_asia_southeast_islands
+				}
+				is_coastal = yes
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		random_held_title = {
+			limit = {
+				tier = tier_county
+				any_county_province = {
+					province_has_no_holding_trigger = yes
+				}
+			}
+			random_county_province = {
+				limit = {
+					province_has_no_holding_trigger = yes
+				}
+				save_scope_as = mosque_location
+			}
+		}
+		location = {
+			save_scope_as = background_terrain_scope
+		}
+		title:c_mecca.kingdom = {
+			random_in_de_jure_hierarchy = {
+				continue = {
+					tier >= tier_duchy
+				}
+				limit = {
+					tier = tier_county
+					religion = religion:islam_religion
+					title_province = { province_has_no_holding_trigger = no }
+					is_coastal_county = yes
+				}
+				save_scope_as = merchant_home
+			}
+		}
+		create_character = {
+			template = good_merchant_template
+			location = scope:background_terrain_scope
+			culture = scope:merchant_home.culture
+			faith = scope:merchant_home.faith
+			gender_female_chance = {
+				if = {
+					limit = { scope:merchant_home.faith = { has_doctrine = doctrine_gender_male_dominated } }
+					add = 0
+				}
+				else_if = {
+					limit = { scope:merchant_home.faith = { has_doctrine = doctrine_gender_female_dominated } }
+					add = 100
+				}
+				else = {
+					add = 50
+				}
+			}
+			save_scope_as = local_character
+		}
+		hidden_effect = {
+			scope:local_character = {
+				assign_random_nickname_effect = yes
+			}
+		}
+	}
+
+	option = { # Convert to Islam
+		name = pilgrimage_seasia.1000.a
+		
+		worldly_type_option_effect = yes
+		add_gold = { major_gold_value monumental_gold_value }
+		
+		set_character_faith = scope:local_character.faith
+		if = {
+			limit = { 
+				scope:local_character.faith = { has_doctrine = doctrine_monotheist }
+			}
+			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
+		}
+		current_travel_plan = {
+			every_entourage_character = {
+				limit = {
+					faith != scope:local_character.faith
+				}
+				custom = every_entourage_tt
+				set_character_faith = scope:local_character.faith
+			}
+		}
+		
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+				}
+				set_relation_potential_friend = scope:local_character
+			}
+		}
+		
+		scope:mosque_location = {
+			begin_create_holding = {
+				type = church_holding
+			}
+		}
+		scope:mosque_location.county = {
+			random = {
+				chance = scope:local_character.learning
+				set_county_faith = scope:local_character.faith
+			}
+		}
+		
+		add_legitimacy = medium_legitimacy_gain
+		
+		stress_impact = {
+			zealous = massive_stress_impact_gain
+			humble = major_stress_impact_gain
+			stubborn = major_stress_impact_gain
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				OR = {
+					has_trait = zealous
+					has_trait = humble
+					has_trait = stubborn
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Convert the Traders
+		name = pilgrimage_seasia.1000.b
+		
+		trigger = {
+			custom_tooltip = {
+				text = zealotry_intent_tt
+				has_activity_intent = zealot_intent
+			}
+			learning >= 16
+		}
+		
+		reason = activity_intent
+		show_as_unavailable = { always = yes }
+		skill = learning
+		
+		pious_type_option_effect = yes
+		
+		add_piety = medium_piety_gain
+		
+		scope:local_character = {
+			set_character_faith = root.faith
+		}
+		
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+				}
+				set_relation_potential_friend = scope:local_character
+			}
+		}
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+			zealous = minor_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Accept Temple
+		name = pilgrimage_seasia.1000.c
+		
+		trigger = {
+			exists = scope:mosque_location
+		}
+		very_worldly_type_option_effect = yes
+		
+		scope:mosque_location = {
+			begin_create_holding = {
+				type = church_holding
+			}
+		}
+		scope:mosque_location.county = {
+			random = {
+				chance = scope:local_character.learning
+				set_county_faith = scope:local_character.faith
+			}
+		}
+		
+		add_legitimacy = medium_legitimacy_gain
+		
+		stress_impact = {
+			zealous = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = zealous
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Make some deals
+		name = pilgrimage_seasia.1000.d
+		
+		add_gold = { tiny_gold_value medium_gold_value }
+		
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# Rattan Snare
+pilgrimage_seasia.1100 = {
+	type = character_event
+	title = pilgrimage_seasia.1100.t
+	desc = pilgrimage_seasia.1100.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = shock
+		camera = camera_event_very_left
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = throne_room_cheer_2
+		camera = camera_event_right_upside_down
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		is_adult = yes
+		location = {
+			terrain = jungle
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+				geographical_region = world_burma
+				geographical_region = world_india
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		save_scope_as = root_scope
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+		location = {
+			save_scope_as = background_terrain_scope
+		}
+		if = {
+			limit = {
+				any_pool_character = {
+					province = scope:background_terrain_scope
+					is_available_healthy_ai_adult = yes
+					aptitude = {
+						court_position = travel_leader_court_position
+						value >= 4
+					}
+					travel_leader_validity_trigger = { EMPLOYER = root }
+				}
+			}
+			random_pool_character = {
+				province = scope:background_terrain_scope
+				limit = {
+					is_available_healthy_ai_adult = yes
+					aptitude = {
+						court_position = travel_leader_court_position
+						value >= 4
+					}
+					travel_leader_validity_trigger = { EMPLOYER = root }
+				}
+				save_scope_as = local_character
+			}
+		}
+		
+		else = {
+			create_character = {
+				template = travel_leader_court_position_template
+				location = scope:background_terrain_scope
+				culture = scope:background_terrain_scope.culture
+				faith = scope:background_terrain_scope.faith
+				save_scope_as = local_character
+			}
+		}
+		if = {
+			limit = {
+				any_court_position_holder = {
+					type = travel_leader_court_position
+				}
+			}
+			random_court_position_holder = {
+				type = travel_leader_court_position
+				save_scope_as = current_holder
+			}
+		}
+		hidden_effect = {
+			scope:local_character = {
+				assign_random_nickname_effect = yes
+			}
+		}
+	}
+
+	option = { # Leave him
+		name = pilgrimage_seasia.1100.c
+		
+		trigger = {
+			OR = {
+				has_trait = sadistic
+				has_trait = torturer
+				has_trait = callous
+				has_trait = arbitrary
+			}
+		}
+		trait = sadistic
+		trait = torturer
+		trait = callous
+		trait = arbitrary
+		
+		scope:local_character = {
+			death = {
+				death_reason = death_wild_animal
+			}
+		}
+		
+		stress_impact = {
+			sadistic = massive_stress_impact_loss
+			torturer = medium_stress_impact_loss
+			callous = major_stress_impact_loss
+			arbitrary = major_stress_impact_loss
+			compassionate = massive_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = compassionate
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Cut him down
+		name = pilgrimage_seasia.1100.a
+		trigger = {
+			is_valid_to_hire_court_position_type = travel_leader_court_position
+		}
+		
+		hire_for_court_position_journey_effect = {
+			CHARACTER = scope:local_character
+			COURT_POSITION = travel_leader
+		}
+		
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		
+		if = {
+			limit = {
+				can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+			}
+			set_relation_potential_friend = scope:local_character
+		}
+		
+		worldly_type_option_effect = yes
+		
+		stress_impact = {
+			callous = medium_stress_impact_gain
+			arbitrary = medium_stress_impact_gain
+			zealous = medium_stress_impact_loss
+			generous = medium_stress_impact_loss
+			improvident = medium_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				OR = {
+					has_trait = callous
+					has_trait = arbitrary
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Cut him down, let him go
+		name = pilgrimage_seasia.1100.b
+		
+		add_piety = minor_piety_gain
+		pious_type_option_effect = yes
+		
+		if = {
+			limit = {
+				culture != scope:local_character.culture
+			}
+			culture = {
+				change_cultural_acceptance = {
+					target = scope:local_character.culture
+					value = 2
+					desc = cultural_acceptance_gain_event
+				}
+			}
+		}
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# A Wanderer from Nalanda
+pilgrimage_seasia.1200 = {
+	type = character_event
+	title = pilgrimage_seasia.1200.t
+	desc = pilgrimage_seasia.1200.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = holding_staff
+		camera = camera_event_very_left
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = happy_teacher
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		is_adult = yes
+		location = {
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+			}
+		}
+		OR = {
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		capital_province ?= {
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+			}
+		}
+		title:c_magadha.title_province = { has_building_or_higher = nalanda_university }
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		save_scope_as = root_scope
+		save_scope_as = liege
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+		location = {
+			save_scope_as = background_terrain_scope
+			duchy = {
+				save_scope_as = exploration_target
+				random_in_de_jure_hierarchy = {
+					continue = {
+						tier >= tier_county
+						this != scope:background_terrain_scope.barony
+					}
+					save_scope_as = other_barony
+				}
+			}
+		}
+		
+		if = {
+			limit = {
+				any_character_artifact = {
+					is_equipped = yes
+				}
+			}
+			random_character_artifact = {
+				limit = {
+					is_equipped = yes
+				}
+				save_scope_as = blessed_artifact
+				save_scope_as = artifact_target
+			}
+		}
+		title:c_magadha.kingdom = {
+			random_in_de_jure_hierarchy = {
+				continue = {
+					tier >= tier_county
+				}
+				limit = {
+					exists = culture
+				}
+				title_province = { save_scope_as = character_home }
+			}
+		}
+		random_list = {
+			50 = {
+				religion:buddhism_religion = {
+					random_faith = {
+						limit = {
+							NOR = {
+								this = faith:dhyana
+								this = faith:pundarika
+								this = faith:vinaya
+								this = faith:avatamsaka
+								this = faith:sukhavati
+								this = faith:acharya
+								this = faith:mantrayana
+								this = faith:maitreya
+								this = faith:yogacara
+							}
+						}
+						save_scope_as = character_faith
+					}
+				}
+			}
+			50 = {
+				religion:hinduism_religion = {
+					random_faith = {
+						save_scope_as = character_faith
+					}
+				}
+			}
+		}
+		create_character = {
+			template = monk_character_template
+			location = scope:background_terrain_scope
+			culture = scope:character_home.culture
+			faith = scope:character_faith
+			gender_female_chance = {
+				if = {
+					limit = { scope:character_faith = { has_doctrine = doctrine_gender_male_dominated } }
+					add = 0
+				}
+				else_if = {
+					limit = { scope:character_faith = { has_doctrine = doctrine_gender_female_dominated } }
+					add = 100
+				}
+				else = {
+					add = 50
+				}
+			}
+			save_scope_as = local_character
+		}
+		hidden_effect = {
+			scope:local_character = {
+				add_trait = scholar
+				save_scope_as = antiquarian_from_task
+			}
+		}
+	}
+
+	option = { # Convert to his faith
+		name = pilgrimage_seasia.1200.a
+		
+		trigger = {
+			faith != scope:local_character.faith
+		}
+		set_character_faith = scope:local_character.faith
+		if = {
+			limit = { 
+				scope:local_character.faith = { has_doctrine = doctrine_monotheist }
+			}
+			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
+		}
+		add_piety_level = 1
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		very_pious_type_option_effect = yes
+		
+		hidden_effect = {
+			if = {
+				limit = {
+					can_set_relation_potential_friend_trigger = { CHARACTER = scope:local_character }
+				}
+				set_relation_potential_friend = scope:local_character
+			}
+		}
+		
+		stress_impact = {
+			zealous = massive_stress_impact_gain
+			cynical = medium_stress_impact_loss
+		}
+		ai_chance = {
+			base = 5
+			modifier = {
+				has_trait = zealous
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Bless an artifact
+		name = pilgrimage_seasia.1200.b
+		trigger = {
+			exists = scope:blessed_artifact
+		}
+		
+		pious_type_option_effect = yes
+		scope:blessed_artifact = {
+			custom_tooltip = {
+				text = improved_artifact_tt
+				antiquarian_improve_artifact_effect = yes
+			}
+		}
+		
+		stress_impact = {
+			callous = medium_stress_impact_gain
+			arbitrary = medium_stress_impact_gain
+			zealous = medium_stress_impact_loss
+			generous = medium_stress_impact_loss
+			improvident = medium_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				OR = {
+					has_trait = callous
+					has_trait = arbitrary
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Tell about meditation destination
+		name = pilgrimage_seasia.1200.c
+		
+		add_piety = miniscule_piety_gain
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}
+
+# The Croaking Pool
+pilgrimage_seasia.1300 = {
+	type = character_event
+	title = pilgrimage_seasia.1300.t
+	desc = pilgrimage_seasia.1300.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = survey_staff
+		camera = camera_event_left_away_3_4_far
+	}
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		is_adult = yes
+		location = {
+			OR = {
+				terrain = wetlands
+				terrain = terraced_hills
+			}
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+			}
+		}
+		OR = {
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		capital_province ?= {
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		location = {
+			save_scope_as = background_terrain_scope
+		}
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+	}
+
+	option = { # Reflect
+		name = pilgrimage_seasia.1300.a
+		trigger = {
+			has_activity_intent = reflection_intent
+		}
+		
+		reason = activity_intent
+		
+		bonus_to_all_types_effect = yes
+		
+		add_piety = medium_piety_gain
+		
+		current_travel_plan = {
+			delay_travel_plan = { days = 14 }
+		}
+		
+		stress_impact = {
+			base = minor_stress_impact_loss
+			cynical = minor_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Make offering
+		name = pilgrimage_seasia.1300.b
+		
+		pious_type_option_effect = yes
+		
+		add_piety = miniscule_piety_gain
+		
+		remove_short_term_gold = { 1 3 }
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+			zealous = minor_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Leave
+		name = pilgrimage_seasia.1300.c
+		
+		stress_impact = {
+			zealous = minor_stress_impact_gain
+			humble = minor_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+		}
+	}
+	after = {
+		mp_resume_travel_plan = yes
+	}
+}
+
+# Face of a God
+pilgrimage_seasia.1400 = {
+	type = character_event
+	title = pilgrimage_seasia.1400.t
+	desc = pilgrimage_seasia.1400.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = interested
+		camera = camera_event_very_left_lean_down
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = dead
+		camera = camera_event_right_massive_head
+		hide_info = yes
+	}
+	override_effect_2d = { reference = fog }
+	cooldown = { years = 50 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		is_adult = yes
+		location = {
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+			}
+		}
+		OR = {
+			religion = { is_in_family = rf_eastern }
+			faith = faith:aluk
+			faith = faith:dayawism
+			faith = faith:hantuism
+			faith = faith:kaharingan
+			faith = faith:satsana_phi
+			faith = faith:tolotang
+			faith = faith:utaki
+		}
+		capital_province ?= {
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		location = {
+			save_scope_as = background_terrain_scope
+		}
+		current_travel_plan.final_destination_province = { save_scope_as = destination }
+		create_character = {
+			template = generic_peasant_character
+			location = scope:background_terrain_scope
+			culture = scope:background_terrain_scope.culture
+			faith = scope:background_terrain_scope.faith
+			save_scope_as = local_character
+		}
+		hidden_effect = {
+			scope:local_character = {
+				add_trait = disfigured
+				add_trait = albino
+				add_character_flag = no_headgear
+				death = { death_reason = death_vanished }
+			}
+		}
+		religion:hinduism_religion = {
+			random_faith = {
+				limit = {
+					this != root.faith
+				}
+				save_scope_as = character_faith
+			}
+		}
+	}
+
+	option = { # CreatorName
+		name = pilgrimage_seasia.1400.a
+		
+		trigger = {
+			has_activity_intent = reflection_intent
+		}
+		
+		reason = activity_intent
+		add_learning_skill = 1
+		add_legitimacy = miniscule_legitimacy_gain
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # WealthGod
+		name = pilgrimage_seasia.1400.b
+		
+		trigger = {
+			has_activity_intent = altruism_intent
+		}
+		
+		reason = activity_intent
+		add_stewardship_skill = 1
+		add_legitimacy = miniscule_legitimacy_gain
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # WarGod
+		name = pilgrimage_seasia.1400.c
+		
+		trigger = {
+			has_activity_intent = zealot_intent
+		}
+		
+		reason = activity_intent
+		add_martial_skill = 1
+		add_legitimacy = miniscule_legitimacy_gain
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # This is the true faith
+		name = pilgrimage_seasia.1400.d
+		
+		set_character_faith = scope:character_faith
+		add_legitimacy = medium_legitimacy_gain
+		add_piety = major_piety_gain
+		pious_type_option_effect = yes
+		
+		stress_impact = {
+			cynical = massive_stress_impact_gain
+			humble = minor_stress_impact_gain
+			stubborn = major_stress_impact_gain
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				OR = {
+					has_trait = cynical
+					has_trait = humble
+					has_trait = stubborn
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # God of travel
+		name = pilgrimage_seasia.1400.e
+		
+		current_travel_plan = {
+			add_destination_progress = { days = 7 }
+		}
+		
+		stress_impact = {
+			zealous = medium_stress_impact_gain
+		}
+		
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = zealous
+				factor = 0
+			}
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+	}
+}
+
+# The Pawang
+pilgrimage_seasia.1500 = {
+	type = character_event
+	title = pilgrimage_seasia.1500.t
+	desc = pilgrimage_seasia.1500.desc
+	theme = travel_pilgrimage
+	left_portrait = {
+		character = root
+		animation = shiver
+		camera = camera_event_very_left
+	}
+	right_portrait = {
+		character = scope:local_character
+		animation = storyteller
+		camera = camera_event_very_right
+	}
+	override_effect_2d = { reference = legend_glow }
+	cooldown = { years = 10 }
+
+	trigger = {
+		is_travelling = yes
+		has_tgp_dlc_trigger = yes
+		is_adult = yes
+		location = {
+			OR = {
+				geographical_region = world_asia_southeast_mainland
+				geographical_region = world_asia_southeast_islands
+			}
+		}
+	}
+
+	immediate = {
+		mp_delay_travel_plan = { DAYS = 90 }
+		location = {
+			save_scope_as = background_terrain_scope
+		}
+		create_character = {
+			template = virtuous_priest_character_template
+			location = scope:background_terrain_scope
+			culture = scope:background_terrain_scope.culture
+			faith = scope:background_terrain_scope.faith
+			gender_female_chance = {
+				if = {
+					limit = { scope:background_terrain_scope.faith = { has_doctrine = doctrine_gender_male_dominated } }
+					add = 0
+				}
+				else_if = {
+					limit = { scope:background_terrain_scope.faith = { has_doctrine = doctrine_gender_female_dominated } }
+					add = 100
+				}
+				else = {
+					add = 50
+				}
+			}
+			save_scope_as = local_character
+		}
+		hidden_effect_new_object = {
+			scope:local_character = {
+				add_trait = lifestyle_mystic
+				assign_random_nickname_effect = yes
+			}
+		}
+	}
+
+	option = { # Recruit the Pawang
+		name = pilgrimage_seasia.1500.a
+		
+		random = {
+			chance = 50
+			send_interface_toast = {
+				title = pilgrimage_seasia.1500.t
+				current_travel_plan = { add_travel_plan_modifier = good_weather_modifier }
+			}
+		}
+		
+		worldly_type_option_effect = yes
+		
+		add_to_entourage_court_and_activity_effect = { 
+			CHAR_TO_ADD = scope:local_character 
+			NEW_COURT_OWNER = root 
+		}
+		
+		stress_impact = {
+			zealous = massive_stress_impact_gain
+			humble = major_stress_impact_gain
+			stubborn = major_stress_impact_gain
+		}
+		ai_chance = {
+			base = 1
+			modifier = {
+				OR = {
+					has_trait = zealous
+					has_trait = humble
+					has_trait = stubborn
+				}
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Ask for a weather-blessing
+		name = pilgrimage_seasia.1500.b
+		
+		add_piety = minor_piety_gain
+		pious_type_option_effect = yes
+		
+		remove_short_term_gold = { 3 20 }
+		
+		random = {
+			chance = 50
+			send_interface_toast = {
+				title = pilgrimage_seasia.1500.t
+				current_travel_plan = { add_travel_plan_modifier = good_weather_modifier }
+			}
+		}
+		
+		stress_impact = {
+			cynical = medium_stress_impact_gain
+			zealous = minor_stress_impact_loss
+		}
+		ai_chance = {
+			base = 100
+			modifier = {
+				has_trait = cynical
+				factor = 0
+			}
+		}
+	}
+
+	option = { # Continue onwards
+		name = pilgrimage_seasia.1500.c
+		
+		random = {
+			chance = 50
+			send_interface_toast = {
+				title = pilgrimage_seasia.1500.t
+				current_travel_plan = { add_travel_plan_modifier = good_weather_modifier }
+			}
+		}
+		
+		ai_chance = {
+			base = 100
+		}
+	}
+
+	after = {
+		mp_resume_travel_plan = yes
+		scope:local_character = {
+			silent_disappear_ai_if_not_hired = yes
+		}
+	}
+}

--- a/events/activities/pilgrimage_activity/pilgrimage_events_seasia.txt
+++ b/events/activities/pilgrimage_activity/pilgrimage_events_seasia.txt
@@ -1616,11 +1616,11 @@ pilgrimage_seasia.1000 = {
 				limit = {
 					tier = tier_county
 					religion = religion:islam_religion
-					#Unop inline the former province_has_no_holding_trigger body: this picks a developed merchant home, unrelated to whether a holding can be built
+					#Unop inline the former province_has_no_holding_trigger body (De Morgan of its negation): pick a developed merchant home, unrelated to whether a holding can be built
 					title_province = {
-						NOT = {
-							has_ongoing_construction = no
-							has_holding = no
+						OR = {
+							has_ongoing_construction = yes
+							has_holding = yes
 						}
 					}
 					is_coastal_county = yes

--- a/events/activities/pilgrimage_activity/pilgrimage_events_seasia.txt
+++ b/events/activities/pilgrimage_activity/pilgrimage_events_seasia.txt
@@ -787,7 +787,7 @@ pilgrimage_seasia.500 = {
 			limit = {
 				scope:background_terrain_scope.faith != root.faith
 			}
-			scope:background_terrain_scope = {
+			scope:background_terrain_scope.county = { #Unop set_county_faith needs a county scope, not a province
 				set_county_faith = root.faith
 			}
 		}
@@ -1616,7 +1616,13 @@ pilgrimage_seasia.1000 = {
 				limit = {
 					tier = tier_county
 					religion = religion:islam_religion
-					title_province = { province_has_no_holding_trigger = no }
+					#Unop inline the former province_has_no_holding_trigger body: this picks a developed merchant home, unrelated to whether a holding can be built
+					title_province = {
+						NOT = {
+							has_ongoing_construction = no
+							has_holding = no
+						}
+					}
 					is_coastal_county = yes
 				}
 				save_scope_as = merchant_home


### PR DESCRIPTION
Fixes #532

**fixer:** hold_court church/city events (`hold_court.8060`/`8070`) could pick baronies that can't have holdings (e.g. `b_djado_route` in the Sahara corridor).

The fix lives in the shared trigger, not in the hold_court events:

- `common/scripted_triggers/02_ep1_scripted_triggers.txt`: added `barony_cannot_construct_holding = no` to `province_has_no_holding_trigger`. Because `county_has_empty_province_trigger` is defined as `any_county_province = { province_has_no_holding_trigger = yes }`, tightening the base trigger propagates to both the province pick and the county gate, so county-selection and province-selection stay consistent and hold_court 8060/8070 are fixed without editing them. Every other `= yes` build-site caller (bp2, laamp, petition_liege, tgp_mandala, the seasia mosque path) inherits the fix too. Vanilla `mpo_decisions.txt` pairs `has_holding = no` with `barony_cannot_construct_holding = no` at its build sites, corroborating the discriminator.
- The only inverted (`= no`) usage in all of vanilla is `pilgrimage_seasia.1000`, which picks a *developed* merchant home. Its meaning must be preserved, so the original trigger body is inlined there — now written as `OR = { has_ongoing_construction = yes  has_holding = yes }` (the De Morgan form, per review, avoiding a multi-entry `NOT`).
- Also fixes a genuine latent bug in the same newly-added seasia file: the mass-convert option ran `set_county_faith` on a province scope instead of `.county`, so the conversion silently no-op'd. It's incidental to #532 but a correct fix in a file this PR already adds — happy to split it into its own PR if preferred.

Vanilla seasia file added unmodified in its own commit; fix in follow-ups. `make tiger` clean (0/0).