### PR TITLE
Stop GOK Onslaught devastation razing silk road market holdings

### DIFF
--- a/common/scripted_effects/09_mpo_greatest_of_khans_effects.txt
+++ b/common/scripted_effects/09_mpo_greatest_of_khans_effects.txt
@@ -7062,6 +7062,7 @@ gok_realm_devastation_effect = {
 					limit = {
 						has_holding = yes
 						is_county_capital = no
+						NOT = { has_building_with_flag = { flag = silk_road_node } } #Unop Don't raze silk road market holdings, as that breaks the silk road situation
 					}
 					random = {
 						chance = 50


### PR DESCRIPTION
Fixes #533

**fixer:** The Greatest of All Khans Onslaught CB runs `gok_realm_devastation_effect` on victory. In the refused-submission branch, its `remove_holding` loop razes whole non-capital holdings in the devastation area (`has_holding = yes`, `is_county_capital = no`, 50% chance) with no protection for holdings carrying a special situation building — so the Changan silk road market (a non-capital `silk_road_node` special building) could be destroyed, breaking the silk road situation. Capital silk-road markets already survive via the existing `is_county_capital = no` guard.

Added `NOT = { has_building_with_flag = { flag = silk_road_node } }` to the per-province `remove_holding` limit so silk-road node holdings are never razed. The building-destruction path (`destroy_random_building_*`) already cannot select `type = special` buildings, so it needs no change.