### PR TITLE
Fix 867 government anomalies in Korea and Dzungaria

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -630,6 +630,24 @@ filter = {
 				text = "running `random_list` inside `send_interface_message` does not work right"
 			}
 		}
+		NAND = { # Pre-existing vanilla history quirks in e_goryeo/k_dzungaria, harmless
+			key = history
+			OR = {
+				text = "korean_gim_silla_83 is not alive on 839.6.23"
+				text = "uyghur0086 is not alive on 874.12.13"
+				text = "d_gaeseong has no holder at 850.1.1"
+				text = "e_kirghiz_khanate has no holder at 840.1.1"
+			}
+			OR = {
+				file = history/titles/e_goryeo.txt
+				file = history/titles/k_dzungaria.txt
+			}
+		}
+		NAND = { # e_mongolia has no title history in vanilla, referenced as future liege
+			key = missing-item
+			text = "e_mongolia has no title history"
+			file = history/titles/k_dzungaria.txt
+		}
 	}
 }
 

--- a/history/titles/e_goryeo.txt
+++ b/history/titles/e_goryeo.txt
@@ -495,7 +495,7 @@ d_tamna = {
 
 	20.1.1 = {
 		holder = korean_go_jeju_33 # Du_myeong
-		government = feudal_government
+		government = tribal_government #Unop Isolated island/peninsula with no feudal neighbor; mirror tribal c_yeongwon
 	}
 	43.1.1 = {
 		holder = korean_go_jeju_32 # Seon_ju
@@ -616,7 +616,7 @@ c_tamna = {
 
 	20.1.1 = {
 		holder = korean_go_jeju_33 # Du_myeong
-		government = feudal_government
+		government = tribal_government #Unop Isolated island/peninsula with no feudal neighbor; mirror tribal c_yeongwon
 	}
 	43.1.1 = {
 		holder = korean_go_jeju_32 # Seon_ju
@@ -735,7 +735,7 @@ c_ulleong = {
 	1178.1.1 = { change_development_level = 3 }
 
 	867.1.1 = {
-		government = feudal_government
+		government = tribal_government #Unop Isolated island/peninsula with no feudal neighbor; mirror tribal c_yeongwon
 		holder = korean_bak_ulleong_1
 	}
 	1066.1.1 = {

--- a/history/titles/e_goryeo.txt
+++ b/history/titles/e_goryeo.txt
@@ -1,0 +1,1862 @@
+﻿e_goryeo = {
+	500.1.1 = {
+		government = meritocratic_government
+ 	}
+	# King of Goryeo
+	918.1.1 = {
+		holder = korean_wang_goryeo_1 # Tae_jo
+ 		effect = {
+			if = { # Chinese influence on bureaucracy and literature
+				limit = {
+					exists = holder
+					has_dlc_feature = royal_court
+				}
+				holder = { set_court_language = language_chinese }
+			}
+			set_title_name = "cn_goryeo"
+ 		}
+	}
+	943.7.4 = {
+		holder = korean_wang_goryeo_2 # Hye_jong
+	}
+	945.1.1 = {
+		holder = korean_wang_goryeo_3 # Jeong_jong
+	}
+	949.1.1 = {
+		holder = korean_wang_goryeo_4 # Gwang_jong
+	}
+	975.1.1 = {
+		holder = korean_wang_goryeo_5 # Gyeong_jong
+	}
+	981.1.1 = {
+		holder = korean_wang_goryeo_7 # Seong_jong
+	}
+	997.1.1 = {
+		holder = korean_wang_goryeo_8 # Mok_jong
+	}
+	1009.1.1 = {
+		holder = korean_wang_goryeo_10 # Hyeon_jong
+	}
+	1031.1.1 = {
+		holder = korean_wang_goryeo_11 # Deok_jong
+	}
+	1034.1.1 = {
+		holder = korean_wang_goryeo_12 # Jeong_jong
+	}
+	1046.1.1 = {
+		holder = korean_wang_goryeo_13 # Mun_jong
+	}
+	1066.1.1 = {
+		effect = {
+			set_variable = {
+				name = administrative_ui_special_title
+				value = title:k_yongson_throne
+			}
+		}
+	}
+	1083.1.1 = {
+		holder = korean_wang_goryeo_14 # Sun_jong
+	}
+	1083.6.1 = {
+		holder = korean_wang_goryeo_15 # Seon_jong
+	}
+	1094.1.1 = {
+		holder = korean_wang_goryeo_16 # Heon_jong
+	}
+	1095.1.1 = {
+		holder = korean_wang_goryeo_17 # Suk_jong
+	}
+	1105.1.1 = {
+		holder = korean_wang_goryeo_18 # Ye_jong
+	}
+	1122.1.1 = {
+		holder = korean_wang_goryeo_19 # In_jong
+	}
+	1146.1.1 = {
+		holder = korean_wang_goryeo_20 # Ui_jong
+	}
+	# Military dictatorship
+	1170.9.2 = {
+		holder = korean_i_jeonju_16 # Ui_bang
+		government = meritocratic_government
+	}
+	1174.12.1 = {
+		holder = korean_jeong_haeju_1 # Jung_bu
+	}
+}
+
+k_yongson_throne = {
+	1170.9.2 = {
+		government = meritocratic_government
+		liege = e_goryeo
+		holder = korean_wang_goryeo_21 # Myeong_jong
+		effect = {
+			add_title_law = single_heir_succession_law # Regency inherited separately
+			set_variable = {
+				name = ceremonial_title
+				value = title:e_goryeo
+			}
+			if = { # Chinese influence on bureaucracy and literature
+				limit = {
+					exists = holder
+					has_dlc_feature = royal_court
+				}
+				holder = { set_court_language = language_chinese }
+			}
+		}
+	}
+}
+
+k_goguryeo = {
+	1.1.1 = {
+		government = meritocratic_government
+		#holder = korean_go_goguryeo_49 # Yu_ri_myeong
+	}
+	18.10.1 = {
+		#holder = korean_go_goguryeo_43 # Dae_mu_sin
+	}
+	44.10.1 = {
+		#holder = korean_go_goguryeo_42 # Min_jung
+	}
+	48.1.1 = {
+		#holder = korean_go_goguryeo_45 # Mo_bon
+	}
+	53.11.1 = {
+		holder = korean_go_goguryeo_39 # Tae_jo the Great
+	}
+	121.11.1 = {
+		holder = korean_go_goguryeo_35 # Cha_dae
+	}
+	165.10.1 = {
+		holder = korean_go_goguryeo_34 # Sin_dae
+	}
+	179.12.1 = {
+		holder = korean_go_goguryeo_31 # Go_guk_cheon
+	}
+	197.5.1 = {
+		holder = korean_go_goguryeo_29 # San_sang
+	}
+	227.5.1 = {
+		holder = korean_go_goguryeo_28 # Dong_cheon
+	}
+	248.9.1 = {
+		holder = korean_go_goguryeo_25 # Jung_cheon
+	}
+	270.10.1 = {
+		holder = korean_go_goguryeo_21 # Seo_cheon
+	}
+	292.1.1 = {
+		holder = korean_go_goguryeo_20 # Bong_sang
+	}
+	300.9.1 = {
+		holder = korean_go_goguryeo_18 # Mi_cheon
+	}
+	331.2.1 = {
+		holder = korean_go_goguryeo_16 # Go_gug_won
+	}
+	371.11.17 = {
+		holder = korean_go_goguryeo_15 # So_su_rim
+	}
+	384.11.1 = {
+		holder = korean_go_goguryeo_14 # Go_gug_yang
+	}
+	391.5.1 = {
+		holder = korean_go_goguryeo_13 # Gwang_gae_to
+	}
+	412.10.1 = {
+		holder = korean_go_goguryeo_12 # Jang_su
+	}
+	491.12.1 = {
+		holder = korean_go_goguryeo_10 # Mun_ja_myeong
+	}
+	519.1.1 = {
+		holder = korean_go_goguryeo_9 # An_jang
+	}
+	531.5.1 = {
+		holder = korean_go_goguryeo_8 # An_won
+	}
+	545.3.1 = {
+		holder = korean_go_goguryeo_7 # Yang_won
+	}
+	559.3.1 = {
+		holder = korean_go_goguryeo_3 # Pyeong_won
+	}
+	590.10.1 = {
+		holder = korean_go_goguryeo_6 # Yeong_yang
+	}
+	618.9.1 = {
+		holder = korean_go_goguryeo_4 # Yeong_nyu
+	}
+	642.10.1 = {
+		holder = korean_go_goguryeo_1 # King Bo_jang
+	}
+	668.11.3 = {
+		holder = 0
+	}
+}
+
+k_silla = {
+	24.1.1 = {
+		government = meritocratic_government
+		holder = korean_bak_silla_1 # Yuri
+	}
+	57.1.1 = {
+		holder = korean_seok_gyeongju_1 # Tal_hae
+	}
+	80.1.1 = {
+		holder = korean_bak_silla_3 # Pasa
+	}
+	112.1.1 = {
+		holder = korean_bak_silla_4 # Jima
+	}
+	134.1.1 = {
+		holder = korean_bak_silla_2 # Il_seong
+	}
+	154.1.1 = {
+		holder = korean_bak_silla_5 # Adalla
+	}
+	184.1.1 = {
+		holder = korean_seok_gyeongju_3 # Beol_hyu
+	}
+	196.1.1 = {
+		holder = korean_seok_gyeongju_5 # Nae_hae
+	}
+	230.1.1 = {
+		holder = korean_seok_gyeongju_9 # Jo_bun
+	}
+	247.1.1 = {
+		holder = korean_seok_gyeongju_10 # Cheom_hae
+	}
+	262.1.1 = {
+		holder = korean_gim_155 # Mi_chu
+	}
+	284.1.1 = {
+		holder = korean_seok_gyeongju_11 # Yu_rye
+	}
+	298.1.1 = {
+		holder = korean_seok_gyeongju_13 # Gi_rim
+	}
+	310.1.1 = {
+		holder = korean_seok_gyeongju_7 # Heul_hae
+	}
+	356.1.1 = {
+		holder = korean_gim_108 # Nae_mul
+	}
+	402.2.1 = {
+		holder = korean_gim_154 # Sil_seong
+	}
+	417.1.1 = {
+		holder = korean_gim_149 # Nul_ji
+	}
+	458.1.1 = {
+		holder = korean_gim_150 # Ja_bi
+	}
+	479.1.1 = {
+		holder = korean_gim_151 # So_ji
+	}
+	500.1.1 = {
+		holder = korean_gim_96 # Ji_jeung
+	}
+	514.1.1 = {
+		holder = korean_gim_148 # Beop_heung
+	}
+	540.7.1 = {
+		holder = korean_gim_97 # Jin_heung
+	}
+	576.1.1 = {
+		holder = korean_gim_98 # Jin_ji
+	}
+	579.8.24 = {
+		holder = korean_gim_144 # Jin_pyeong
+	}
+	632.1.1 = {
+		holder = korean_gim_145 # Seon_deok
+	}
+	647.2.20 = {
+		holder = korean_gim_147 # Jin_deok
+	}
+	654.1.1 = {
+		holder = korean_gim_107 # Mu_yeol
+	}
+	661.6.1 = {
+		holder = korean_gim_105 # Mun_mu
+	}
+	681.7.30 = {
+		holder = korean_gim_130 # Si_nmun
+	}
+	692.1.1 = {
+		holder = korean_gim_131 # Hyo_so
+	}
+	702.1.1 = {
+		holder = korean_gim_132 # Seong_deok
+	}
+	737.1.1 = {
+		holder = korean_gim_133 # Hyo_seong
+	}
+	742.1.1 = {
+		holder = korean_gim_134 # Gyeong_deok
+	}
+	765.1.1 = {
+		holder = korean_gim_142 # Hye_gong
+	}
+	780.1.1 = {
+		holder = korean_gim_141 # Seon_deok
+	}
+	785.3.2 = {
+		holder = korean_gim_silla_85 # Won_seong
+	}
+	799.2.12 = {
+		holder = korean_gim_silla_59 # So_seong
+	}
+	800.6.1 = {
+		holder = korean_gim_silla_58 # Jung_hee
+	}
+	809.1.1 = {
+		holder = korean_gim_silla_32 # Heon_deok
+	}
+	826.10.1 = {
+		holder = korean_gim_silla_78 # Heung_deok
+	}
+	836.12.1 = {
+		holder = korean_gim_silla_135 # Hui_gang
+	}
+	838.1.23 = {
+		holder = korean_gim_silla_66 # Min_ae
+	}
+	839.6.23 = {
+		holder = korean_gim_silla_83 # Sin_mu
+	}
+	839.7.1 = {
+		holder = korean_gim_silla_41 # Mun_seong
+	}
+	857.9.1 = {
+		holder = korean_gim_silla_81 # Heo_nan
+	}
+	867.1.1 = {
+		holder = korean_gim_silla_33 # King Eung_ryeom
+		effect = {
+			if = { # Chinese influence on bureaucracy and literature
+				limit = {
+					exists = holder
+					has_dlc_feature = royal_court
+				}
+				holder = { set_court_language = language_chinese }
+			}
+		}
+	}
+	875.8.16 = {
+		holder = korean_gim_silla_54 # Heon_gang
+	}
+	886.7.5 = {
+		holder = korean_gim_silla_46 # Jeong_gang
+	}
+	887.7.5 = {
+		holder = korean_gim_silla_62 # Jin_seong
+	}
+	897.1.1 = {
+		holder = korean_gim_silla_88 # Hyo_gong
+	}
+	912.1.1 = {
+		holder = korean_bak_silla_7 # Shin_deok
+	}
+	917.7.1 = {
+		holder = korean_bak_silla_8 # Gyeong_myeong
+	}
+	924.8.1 = {
+		holder = korean_bak_silla_9 # Gyeon_gae
+	}
+	927.11.1 = {
+		holder = korean_gim_silla_73 # Gyeong_sun
+	}
+	935.1.1 = {
+		holder = 0
+	}
+}
+
+k_baekje = {
+	3.1.1 = {
+		#holder = korean_buyeo_65 # King On_jo
+		government = meritocratic_government
+	}
+	28.2 = {
+		holder = korean_buyeo_63 # King Da_ru
+	}
+	77.1.1 = {
+		holder = korean_buyeo_62 # King Gi_ru
+	}
+	128.1 = {
+		holder = korean_buyeo_60 # King Gae_ru
+	}
+	166.1 = {
+		holder = korean_buyeo_54 # King Cho_go
+	}
+	214.1 = {
+		holder = korean_buyeo_53 # King Gu_su
+	}
+	234.1.1 = {
+		holder = korean_buyeo_52 # King Sa_ban
+	}
+	234.1.15 = {
+		holder = korean_buyeo_55 # King Goi
+	}
+	286.11.1 = {
+		holder = korean_buyeo_56 # King Chaek_gye
+	}
+	298.9 = {
+		holder = korean_buyeo_57 # King Bun_seo
+	}
+	304.10 = { 
+		holder = korean_buyeo_50 # King Bi_ryu
+	}
+	344.10 = {
+		holder = korean_buyeo_58 # King Gye
+	}
+	346.9 = {
+		holder = korean_buyeo_49 # King Chogo
+	}
+	375.11 = {
+		holder = korean_buyeo_48 # King Gu_su
+	}
+	384.4 = {
+		holder = korean_buyeo_46 # King Chim_nyu
+	}
+	385.11 = {
+		holder = korean_buyeo_47 # King Jin_sa
+	}
+	392.11 = {
+		holder = korean_buyeo_42 # King A_sin
+	}
+	405.9.1 = {
+		holder = korean_buyeo_43 # Buyeo Hun-hae, Regent
+	}
+	405.9.3 = {
+		holder = korean_buyeo_44 # Buyeo Seol-ye, Usurper
+	}
+	405.9.14 = {
+		holder = korean_buyeo_39 # King Jeon_ji
+	}
+	420.3 = {
+		holder = korean_buyeo_38 # King Gu_i_sin
+	}
+	427.12 = {
+		holder = korean_buyeo_37 # King Bi_yu
+	}
+	455.9 = {
+		holder = korean_buyeo_35 # King Gae_ro
+	}
+	475.9 = {
+		holder = korean_buyeo_33 # King Mun_ju
+	}
+	477.9 = {
+		holder = korean_buyeo_34 # King Sam_geun
+	}
+	479.11 = {
+		holder = korean_buyeo_23 # King Dong_seong
+	}	
+	501.12.1 = {
+		holder = korean_buyeo_22 # King Mu_ryeong
+	}
+	523.6.27 = {
+		holder = korean_buyeo_20 # King Seong
+	}
+	554.7.1 = {
+		holder = korean_buyeo_19 # King Wi_deok
+	}
+	598.12.1 = {
+		holder = korean_buyeo_18 # King Hye
+	}
+	599.1.1 = {
+		holder = korean_buyeo_17 # King Beop
+	}
+	600.5.1 = {
+		holder = korean_buyeo_15 # King Mu
+	}
+	641.3.1 = {
+		holder = korean_buyeo_1 # King Ui_ja
+	}
+	660.1.1 = {
+		holder = 0
+	}
+	892.1.1 = {
+		holder = korean_gyeon_gaeunhyeon_2 # Hwon
+	}
+	935.11.15 = {
+		holder = korean_gyeon_gaeunhyeon_3 # Sin_geom
+	}
+	936.1.1 = {
+		holder = 0
+	}
+}
+
+d_tamna = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	20.1.1 = {
+		holder = korean_go_jeju_33 # Du_myeong
+		government = feudal_government
+	}
+	43.1.1 = {
+		holder = korean_go_jeju_32 # Seon_ju
+	}
+	93.1.1 = {
+		holder = korean_go_jeju_31 # Ji_nam
+	}
+	144.1.1 = {
+		holder = korean_go_jeju_30 # Seong_bang
+	}
+	195.1.1 = {
+		holder = korean_go_jeju_29 # Mun_seong
+	}
+	243.1.1 = {
+		holder = korean_go_jeju_28 # Ik
+	}
+	293.1.1 = {
+		holder = korean_go_jeju_27 # Ji_hyo
+	}
+	343.1.1 = {
+		holder = korean_go_jeju_26 # Suk
+	}
+	393.1.1 = {
+		holder = korean_go_jeju_25 # Hyeon_bang
+	}
+	423.1.1 = {
+		holder = korean_go_jeju_24 # Gi
+	}
+	453.1.1 = {
+		holder = korean_go_jeju_23 # Dam
+	}
+	483.1.1 = {
+		holder = korean_go_jeju_22 # Ji_un
+	}
+	508.1.1 = {
+		holder = korean_go_jeju_21 # Seo
+	}
+	533.1.1 = {
+		holder = korean_go_jeju_20 # Dam_yeong
+	}
+	558.1.1 = {
+		holder = korean_go_jeju_19 # Dam
+	}
+	583.1.1 = {
+		holder = korean_go_jeju_18 # Che_sam
+	}
+	608.1.1 = {
+		holder = korean_go_jeju_17 # Seong_jin
+	}
+	633.1.1 = {
+		holder = korean_go_jeju_16 # Hong
+	}
+	658.1.1 = {
+		holder = korean_go_jeju_15 # Cheo_ryang
+	}
+	683.1.1 = {
+		holder = korean_go_jeju_14 # Won
+	}
+	708.1.1 = {
+		holder = korean_go_jeju_13 # Pyo_ryun
+	}
+	733.1.1 = {
+		holder = korean_go_jeju_12 # Hyeong
+	}
+	758.1.1 = {
+		holder = korean_go_jeju_11 # Chi_do
+	}
+	783.1.1 = {
+		holder = korean_go_jeju_10 # Uk
+	}
+	808.1.1 = {
+		holder = korean_go_jeju_9 # Cheon_won
+	}
+	833.1.1 = {
+		holder = korean_go_jeju_8 # Ho_gong
+	}
+	858.1.1 = {
+		holder = korean_go_jeju_7 # So
+	}
+	883.1.1 = {
+		holder = korean_go_jeju_6 # Gyeong_jik
+	}
+	908.1.1 = {
+		holder = korean_go_jeju_5 # Min
+	}
+	933.1.1 = {
+		holder = korean_go_jeju_4 # Ja_gyeon
+	}
+	938.1.1 = {
+		holder = korean_go_jeju_3 # Mal_ro
+	}
+	1024.1.1 = {
+		holder = korean_go_jeju_41 # Gang
+	}
+	1034.1.1 = {
+		liege = e_goryeo
+		holder = korean_go_jeju_2 # Yu
+	}
+	1070.1.1 = {
+		holder = korean_go_jeju_1 # Il
+	}
+	1090.1.1 = {
+		holder = korean_go_jeju_36 # Jo_gi
+	}
+	1157.1.1 = {
+		holder = korean_go_jeju_37 # Jeong_ho
+	}
+	1176.1.1 = {
+		holder = korean_go_jeju_38 # Jeong_ik
+		government = meritocratic_government
+	}
+}
+
+c_tamna = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	20.1.1 = {
+		holder = korean_go_jeju_33 # Du_myeong
+		government = feudal_government
+	}
+	43.1.1 = {
+		holder = korean_go_jeju_32 # Seon_ju
+	}
+	93.1.1 = {
+		holder = korean_go_jeju_31 # Ji_nam
+	}
+	144.1.1 = {
+		holder = korean_go_jeju_30 # Seong_bang
+	}
+	195.1.1 = {
+		holder = korean_go_jeju_29 # Mun_seong
+	}
+	243.1.1 = {
+		holder = korean_go_jeju_28 # Ik
+	}
+	293.1.1 = {
+		holder = korean_go_jeju_27 # Ji_hyo
+	}
+	343.1.1 = {
+		holder = korean_go_jeju_26 # Suk
+	}
+	393.1.1 = {
+		holder = korean_go_jeju_25 # Hyeon_bang
+	}
+	423.1.1 = {
+		holder = korean_go_jeju_24 # Gi
+	}
+	453.1.1 = {
+		holder = korean_go_jeju_23 # Dam
+	}
+	483.1.1 = {
+		holder = korean_go_jeju_22 # Ji_un
+	}
+	508.1.1 = {
+		holder = korean_go_jeju_21 # Seo
+	}
+	533.1.1 = {
+		holder = korean_go_jeju_20 # Dam_yeong
+	}
+	558.1.1 = {
+		holder = korean_go_jeju_19 # Dam
+	}
+	583.1.1 = {
+		holder = korean_go_jeju_18 # Che_sam
+	}
+	608.1.1 = {
+		holder = korean_go_jeju_17 # Seong_jin
+	}
+	633.1.1 = {
+		holder = korean_go_jeju_16 # Hong
+	}
+	658.1.1 = {
+		holder = korean_go_jeju_15 # Cheo_ryang
+	}
+	683.1.1 = {
+		holder = korean_go_jeju_14 # Won
+	}
+	708.1.1 = {
+		holder = korean_go_jeju_13 # Pyo_ryun
+	}
+	733.1.1 = {
+		holder = korean_go_jeju_12 # Hyeong
+	}
+	758.1.1 = {
+		holder = korean_go_jeju_11 # Chi_do
+	}
+	783.1.1 = {
+		holder = korean_go_jeju_10 # Uk
+	}
+	808.1.1 = {
+		holder = korean_go_jeju_9 # Cheon_won
+	}
+	833.1.1 = {
+		holder = korean_go_jeju_8 # Ho_gong
+	}
+	858.1.1 = {
+		holder = korean_go_jeju_7 # So
+	}
+	883.1.1 = {
+		holder = korean_go_jeju_6 # Gyeong_jik
+	}
+	908.1.1 = {
+		holder = korean_go_jeju_5 # Min
+	}
+	933.1.1 = {
+		holder = korean_go_jeju_4 # Ja_gyeon
+	}
+	938.1.1 = {
+		holder = korean_go_jeju_3 # Mal_ro
+	}
+	1024.1.1 = {
+		holder = korean_go_jeju_41 # Gang
+	}
+	1034.1.1 = {
+		liege = e_goryeo
+		holder = korean_go_jeju_2 # Yu
+	}
+	1070.1.1 = {
+		holder = korean_go_jeju_1 # Il
+	}
+	1090.1.1 = {
+		holder = korean_go_jeju_36 # Jo_gi
+	}
+	1157.1.1 = {
+		holder = korean_go_jeju_37 # Jeong_ho
+	}
+	1176.1.1 = {
+		holder = korean_go_jeju_38 # Jeong_ik
+	}
+}
+
+c_ulleong = {
+	867.1.1 = { change_development_level = 1 }
+	1066.1.1 = { change_development_level = 2 }
+	1178.1.1 = { change_development_level = 3 }
+
+	867.1.1 = {
+		government = feudal_government
+		holder = korean_bak_ulleong_1
+	}
+	1066.1.1 = {
+		holder = jurchen_bu_1
+	}
+	1178.1.1 = {
+		holder = korean_gim_ulleong_1 # Yu_rip
+		government = meritocratic_government
+		liege = e_goryeo
+	}
+}
+
+# BUKGYE
+
+d_bukgye = {
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_geom_nakrang_1 # 
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		holder = korean_wang_goryeo_22 # Gi
+	}
+	1178.1.1 = {
+		holder = korean_yun_papyeong_20 # Sang_yeong
+	}
+}
+
+c_yeongwon = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 6 }
+	1178.1.1 = { change_development_level = 10 }
+
+	867.1.1 = {
+		government = tribal_government
+		holder = mohe_a_1 # Eo_gan
+	}
+	1066.1.1 = {
+		liege = d_bukgye
+		government = meritocratic_government
+		holder = korean_wang_goryeo_22 # Gi
+	}
+	1178.1.1 = {
+		holder = korean_yun_papyeong_20 # Sang_yeong
+	}
+}
+
+c_seogyeong = {
+	867.1.1 = { change_development_level = 9 }
+	1066.1.1 = { change_development_level = 16 }
+	1178.1.1 = { change_development_level = 29 }
+
+	867.1.1 = {
+		liege = d_bukgye
+		government = meritocratic_government
+		holder = korean_geom_nakrang_1 # 
+	}
+	918.1.1 = {
+		holder = korean_wang_goryeo_45 # Sing_nyeom
+	}
+	949.1.1 = {
+		holder = korean_wang_goryeo_48 # Ham_yun
+	}
+	1066.1.1 = {
+		holder = korean_wang_goryeo_22 # Gi
+	}
+	1178.1.1 = {
+		holder = korean_du_dureung_9 # Gyeong_seung
+	}
+}
+
+c_seongju = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	867.1.1 = {
+		liege = d_bukgye
+		government = meritocratic_government
+		holder = korean_hwangbo_3 # Mo_jam
+	}
+	1066.1.1 = {
+		liege = d_bukgye
+		holder = korean_wang_goryeo_22 # Gi
+	}
+	1178.1.1 = {
+		holder = korean_yun_papyeong_20 # Sang_yeong
+	}
+}
+
+# HAE_JU
+
+d_haeju = {
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_gang_sincheon_121 # Man_ru
+	}
+	# 김흥조 - Kim Jeung_jo - ?
+	1000.1.1 = { # ?
+		holder = korean_choe_haeju_1 # On
+	}
+	1027.1.1 = {
+		holder = korean_choe_haeju_2 # Chung
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+	}
+	1178.1.1 = {
+		liege = e_goryeo
+		holder = korean_jeong_haeju_2 # Gyun
+	}
+}
+
+c_haeju = {
+	867.1.1 = { change_development_level = 6 }
+	1066.1.1 = { change_development_level = 11 }
+	1178.1.1 = { change_development_level = 18 }
+
+	867.1.1 = {
+		liege = d_haeju
+		government = meritocratic_government
+		holder = korean_gang_sincheon_121 # Man_ru
+	}
+	# 김흥조 - Kim Jeung_jo - ?
+	1000.1.1 = { # ?
+		holder = korean_choe_haeju_1 # On
+	}
+	1027.1.1 = {
+		government = meritocratic_government
+		holder = korean_choe_haeju_2 # Chung
+	}
+	1178.1.1 = {
+		holder = korean_jeong_haeju_2 # Gyun
+	}
+}
+
+c_hwangju = {
+	867.1.1 = { change_development_level = 5 }
+	1066.1.1 = { change_development_level = 9 }
+	1178.1.1 = { change_development_level = 15 }
+
+	867.1.1 = {
+		liege = d_haeju
+		government = meritocratic_government
+		holder = korean_myeong_1 # Gwi
+	}
+	# 김흥조 - Kim Jeung_jo - ?
+	1000.1.1 = { # ?
+		liege = d_haeju
+		holder = korean_choe_haeju_1 # On
+	}
+	1027.1.1 = {
+		government = meritocratic_government
+		holder = korean_choe_haeju_2 # Chung
+	}
+	1178.1.1 = {
+		holder = korean_jeong_haeju_2 # Gyun
+	}
+}
+
+c_pungju = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 6 }
+	1178.1.1 = { change_development_level = 10 }
+
+	867.1.1 = {
+		liege = d_haeju
+		government = meritocratic_government
+		holder = korean_gang_sincheon_121 # Man_ru
+	}
+	# 김흥조 - Kim Jeung_jo - ?
+	1000.1.1 = { # ?
+		holder = korean_choe_haeju_1 # On
+	}
+	1027.1.1 = {
+		government = meritocratic_government
+		holder = korean_choe_haeju_2 # Chung
+	}
+	1178.1.1 = {
+		holder = korean_jeong_haeju_2 # Gyun
+	}
+}
+
+# SANG_JU
+
+d_gyeongju = {
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_gim_silla_33 # King Eung_ryeom
+	}
+	911.1.1 = {
+		holder = korean_bak_silla_14 # Eon_chang
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		holder = korean_gim_gyeongju_3 # Geun
+	}
+	1102.1.1 = {
+		holder = korean_gim_gyeongju_5 # Bu_il
+	}
+	1178.1.1 = {
+		holder = korean_gim_gyeongju_10 # Gun_su
+	}
+}
+
+c_gyeongju = {
+	867.1.1 = { change_development_level = 12 }
+	1066.1.1 = { change_development_level = 10 }
+	1178.1.1 = { change_development_level = 12 }
+
+	867.1.1 = {
+		liege = d_gyeongju
+		government = meritocratic_government
+		holder = korean_gim_silla_33 # King Eungryeom
+	}
+	1066.1.1 = {
+		holder = korean_gim_gyeongju_3 # Geun
+	}
+	1102.1.1 = {
+		holder = korean_gim_gyeongju_5 # Bu_il
+	}
+	1178.1.1 = {
+		holder = korean_gim_gyeongju_10 # Gun_su
+	}
+}
+
+c_sangju = {
+	867.1.1 = { change_development_level = 6 }
+	1066.1.1 = { change_development_level = 12 }
+	1178.1.1 = { change_development_level = 19 }
+
+	867.1.1 = {
+		liege = d_gyeongju
+		government = meritocratic_government
+		holder = korean_gyeon_gaeunhyeon_1 # A_ja_gae
+	}
+	911.1.1 = {
+		holder = korean_bak_silla_14 # Eon_chang
+	}
+	1066.1.1 = {
+		holder = korean_gim_gyeongju_3 # Geun
+	}
+	1102.1.1 = {
+		holder = korean_gim_gyeongju_5 # Bu_il
+	}
+	1178.1.1 = {
+		holder = korean_gim_gyeongju_10 # Gun_su
+	}
+}
+
+c_ilseon = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 8 }
+	1178.1.1 = { change_development_level = 13 }
+
+	867.1.1 = {
+		liege = d_gyeongju
+		government = meritocratic_government
+		holder = korean_gyeon_gaeunhyeon_1 # A_ja_gae
+	}
+	1066.1.1 = {
+		holder = korean_gim_gyeongju_3 # Geun
+	}
+	1102.1.1 = {
+		holder = korean_gim_gyeongju_5 # Bu_il
+	}
+	1178.1.1 = {
+		holder = korean_gim_gyeongju_10 # Gun_su
+	}
+}
+
+c_andong = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 6 }
+	1178.1.1 = { change_development_level = 10 }
+
+	867.1.1 = {
+		liege = d_gyeongju
+		government = meritocratic_government
+		holder = korean_gim_silla_33 # King Eungryeom
+	}
+	1066.1.1 = {
+		holder = korean_gim_gyeongju_3 # Geun
+	}
+	1102.1.1 = {
+		holder = korean_gim_gyeongju_5 # Bu_il
+	}
+	1178.1.1 = {
+		holder = korean_gim_gyeongju_10 # Gun_su
+	}
+}
+
+# JIN_JU
+
+d_jinju = {
+	150.1.1 = {
+		government = feudal_government
+		holder = korean_gim_gimhae_26 # Su_ro
+	}
+	199.3.23 = {
+		holder = korean_gim_gimhae_27 # Geo_deung
+	}
+	253.9.17 = {
+		holder = korean_gim_gimhae_28 # Ma_pum
+	}
+	291.1.29 = {
+		holder = korean_gim_gimhae_29 # Geo_jil_mi
+	}
+	346.7.8 = {
+		holder = korean_gim_gimhae_30 # I_si_pum
+	}
+	407.7.10 = {
+		holder = korean_gim_gimhae_31 # Jwa_ji
+	}
+	421.5.21 = {
+		holder = korean_gim_gimhae_32 # Chwi_hui
+	}
+	451.2.3 = {
+		holder = korean_gim_gimhae_33 # Jil_ji
+	}
+	492.10.4 = {
+		holder = korean_gim_gimhae_34 # Gyeom_ji
+	}
+	521.4.7 = {
+		holder = korean_gim_gimhae_35 # Gu_hyeong
+	}
+	532.1.1 = {
+		holder = 0
+	}
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_gim_gimhae_4 # Gyeong_ju
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+		holder = korean_gim_gimhae_15 # Jin_yu
+	}
+	1178.1.1 = {
+		holder = korean_gim_gimhae_21 # Su_seong
+	}
+}
+
+c_ulju = {
+	867.1.1 = { change_development_level = 5 }
+	1066.1.1 = { change_development_level = 10 }
+	1178.1.1 = { change_development_level = 17 }
+
+	867.1.1 = {
+		liege = d_jinju
+		government = meritocratic_government
+		holder = korean_jang_andong_2 # Jeong_cheol
+	}
+	1066.1.1 = {
+		liege = d_jinju
+		holder = korean_bak_milyang_11 # Eon_bu
+	}
+	1178.1.1 = {
+		holder = korean_gim_gimhae_21 # Su_seong
+	}
+}
+
+c_hamyang = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 6 }
+	1178.1.1 = { change_development_level = 10 }
+
+	867.1.1 = {
+		liege = d_jinju
+		government = meritocratic_government
+		holder = korean_gim_gimhae_4 # Gyeong_ju
+	}
+	1066.1.1 = {
+		holder = korean_gim_gimhae_15 # Jin_yu
+	}
+	1178.1.1 = {
+		holder = korean_gim_gimhae_21 # Su_seong
+	}
+}
+
+c_guemju = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 8 }
+	1178.1.1 = { change_development_level = 13 }
+
+	867.1.1 = {
+		liege = d_jinju
+		government = meritocratic_government
+		holder = korean_gim_gimhae_4 # Gyeong_ju
+	}
+	1066.1.1 = {
+		holder = korean_gim_gimhae_15 # Jin_yu
+	}
+	1178.1.1 = {
+		holder = korean_gim_gimhae_21 # Su_seong
+	}
+}
+
+c_jinju = {
+	150.1.1 = {
+		government = feudal_government
+		holder = korean_gim_gimhae_26 # Su_ro
+	}
+	199.3.23 = {
+		holder = korean_gim_gimhae_27 # Geo_deung
+	}
+	253.9.17 = {
+		holder = korean_gim_gimhae_28 # Ma_pum
+	}
+	291.1.29 = {
+		holder = korean_gim_gimhae_29 # Geo_jil_mi
+	}
+	346.7.8 = {
+		holder = korean_gim_gimhae_30 # I_si_pum
+	}
+	407.7.10 = {
+		holder = korean_gim_gimhae_31 # Jwa_ji
+	}
+	421.5.21 = {
+		holder = korean_gim_gimhae_32 # Chwi_hui
+	}
+	451.2.3 = {
+		holder = korean_gim_gimhae_33 # Jil_ji
+	}
+	492.10.4 = {
+		holder = korean_gim_gimhae_34 # Gyeom_ji
+	}
+	521.4.7 = {
+		holder = korean_gim_gimhae_35 # Gu_hyeong
+	}
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 5 }
+	1178.1.1 = { change_development_level = 9 }
+	867.1.1 = {
+		liege = d_jinju
+		government = meritocratic_government
+		holder = korean_gim_gimhae_4 # Gyeong_ju
+	}
+	1066.1.1 = {
+		liege = d_jinju
+		holder = korean_gang_jinju_3 # Dan_B2E8
+	}
+	1178.1.1 = {
+		holder = korean_gim_gimhae_21 # Su_seong
+	}
+}
+
+# JEON_JU
+
+d_jeonju = {
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_i_jeonju_5 # Geung_hyu
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+		holder = korean_i_jeonju_12 # Jin_yu
+	}
+	1178.1.1 = {
+		liege = e_goryeo
+		holder = korean_i_jeonju_17 # Rin
+	}
+}
+
+c_jeonju = {
+	867.1.1 = { change_development_level = 7 }
+	1066.1.1 = { change_development_level = 14 }
+	1178.1.1 = { change_development_level = 25 }
+
+	867.1.1 = {
+		liege = d_jeonju
+		government = meritocratic_government
+		holder = korean_i_jeonju_5 # Geung_hyu
+	}
+	1066.1.1 = {
+		holder = korean_i_jeonju_12 # Jin_yu
+	}
+	1170.9.2 = {
+		holder = korean_i_jeonju_17 # Rin
+	}
+}
+
+c_jillye = {
+	867.1.1 = { change_development_level = 2 }
+	1066.1.1 = { change_development_level = 4 }
+	1178.1.1 = { change_development_level = 7 }
+
+	867.1.1 = {
+		liege = d_jeonju
+		government = meritocratic_government
+		holder = korean_i_jeonju_5 # Geung_hyu
+	}
+	1066.1.1 = {
+		holder = korean_i_jeonju_12 # Jin_yu
+	}
+	1170.9.2 = {
+		holder = korean_i_jeonju_17 # Rin
+	}
+}
+
+c_namwon = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 5 }
+	1178.1.1 = { change_development_level = 9 }
+
+	867.1.1 = {
+		liege = d_jeonju
+		government = meritocratic_government
+		holder = korean_i_jeonju_5 # Geung_hyu
+	}
+	1066.1.1 = {
+		holder = korean_i_jeonju_12 # Jin_yu
+	}
+	1170.9.2 = {
+		holder = korean_i_jeonju_17 # Rin
+	}
+}
+
+# SEUNG_JU
+
+d_naju = {
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_sin_pyeongsan_1 # 
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+		holder = korean_mun_nampyeong_2 # Chak
+	}
+	1170.9.2 = {
+		liege = e_goryeo
+		holder = korean_mun_nampyeong_8 # Geuk_gyeom
+	}
+}
+
+c_naju = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	867.1.1 = {
+		liege = d_naju
+		government = meritocratic_government
+		holder = korean_o_naju_1 # Bu_don
+	}
+	1066.1.1 = {
+		holder = korean_mun_nampyeong_2 # Chak
+	}
+	1178.1.1 = {
+		holder = korean_mun_nampyeong_8 # Geuk_gyeom
+	}
+}
+
+c_jangheung = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 5 }
+	1178.1.1 = { change_development_level = 9 }
+
+	867.1.1 = {
+		liege = d_naju
+		government = meritocratic_government
+		holder = korean_sin_pyeongsan_1 # 
+	}
+	1066.1.1 = {
+		liege = d_naju
+		holder = korean_im_jangheung_2 # Ho
+	}
+	1178.1.1 = {
+		holder = korean_song_2 # Gun_su
+	}
+}
+
+c_boseong = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	867.1.1 = {
+		liege = d_naju
+		government = meritocratic_government
+		holder = korean_bak_seungju_1 # 
+	}
+	1066.1.1 = {
+		holder = korean_mun_nampyeong_2 # Chak
+	}
+	1178.1.1 = {
+		holder = korean_mun_nampyeong_8 # Geuk_gyeom
+	}
+}
+
+# CHUNG_JU
+
+d_chungju = {
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_bok_myeoncheon_1 # Hak_sa
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+		holder = korean_choe_jiksan_1 # ?
+	}
+	1178.1.1 = {
+		liege = e_goryeo
+		holder = korean_choe_jiksan_6 # Dohyu
+	}
+}
+
+c_chungju = {
+	867.1.1 = { change_development_level = 6 }
+	1066.1.1 = { change_development_level = 12 }
+	1178.1.1 = { change_development_level = 21 }
+
+	867.1.1 = {
+		liege = d_chungju
+		government = meritocratic_government
+		holder = korean_yu_chungju_1 # 
+	}
+	1066.1.1 = {
+		holder = korean_choe_jiksan_1 # ?
+	}
+	1178.1.1 = {
+		holder = korean_choe_jiksan_6 # Dohyu
+	}
+}
+
+c_cheongju = {
+	867.1.1 = { change_development_level = 7 }
+	1066.1.1 = { change_development_level = 13 }
+	1178.1.1 = { change_development_level = 24 }
+
+	867.1.1 = {
+		liege = d_chungju
+		government = meritocratic_government
+		holder = korean_bok_myeoncheon_1 # Hak_sa
+	}
+	1005.1.1 = {
+		holder = korean_gim_ansan_2 # Eun_bu
+	}
+	1066.1.1 = {
+		holder = korean_choe_jiksan_1 # ?
+	}
+	1178.1.1 = {
+		holder = korean_gyeong_cheongju_2 # Dae_seung
+	}
+}
+
+c_gongju = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 5 }
+	1178.1.1 = { change_development_level = 9 }
+
+	867.1.1 = {
+		liege = d_chungju
+		government = meritocratic_government
+		holder = korean_bok_myeoncheon_1 # Hak_sa
+	}
+	1066.1.1 = {
+		holder = korean_choe_jiksan_1 # ?
+	}
+	1178.1.1 = {
+		holder = korean_choe_jiksan_6 # Dohyu
+	}
+}
+
+c_hongju = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 5 }
+	1178.1.1 = { change_development_level = 9 }
+
+	867.1.1 = {
+		liege = d_chungju
+		government = meritocratic_government
+		holder = korean_bok_myeoncheon_1 # Hak_sa
+	}
+	1066.1.1 = {
+		holder = korean_choe_jiksan_1 # ?
+	}
+	1178.1.1 = {
+		holder = korean_choe_jiksan_6 # Dohyu
+	}
+}
+
+# YUKJU
+
+d_yukju = {
+	867.1.1 = {
+		liege = k_balhae
+		government = meritocratic_government
+		holder = balhae_wi_1 # 
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+		holder = korean_yang_anak_2 # Dae_chun
+	}
+	1178.1.1 = {
+		holder = korean_mun_gangneung_4 # Jang_pil
+	}
+}
+
+c_jangjeong = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 6 }
+	1178.1.1 = { change_development_level = 10 }
+
+	867.1.1 = {
+		liege = d_yukju
+		government = meritocratic_government
+		holder = balhae_wi_1 # 
+	}
+	1066.1.1 = {
+		holder = korean_yang_anak_2 # Dae_chun
+	}
+	1178.1.1 = {
+		holder = korean_mun_gangneung_4 # Jang_pil
+	}
+}
+
+c_uiju = {
+	867.1.1 = { change_development_level = 6 }
+	1066.1.1 = { change_development_level = 11 }
+	1178.1.1 = { change_development_level = 19 }
+
+	867.1.1 = {
+		liege = d_yukju
+		government = meritocratic_government
+		holder = balhae_wi_1 # 
+	}
+	1066.1.1 = {
+		holder = korean_yang_anak_2 # Dae_chun
+	}
+	1178.1.1 = {
+		holder = korean_mun_gangneung_4 # Jang_pil
+	}
+}
+
+c_gwiju = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	867.1.1 = {
+		liege = d_yukju
+		government = meritocratic_government
+		holder = balhae_wi_1 # 
+	}
+	1066.1.1 = {
+		holder = korean_yang_anak_2 # Dae_chun
+	}
+	1178.1.1 = {
+		holder = korean_baek_daeheung_2 # Im_ji
+	}
+}
+
+c_taeju = {
+	867.1.1 = { change_development_level = 5 }
+	1066.1.1 = { change_development_level = 9 }
+	1178.1.1 = { change_development_level = 15 }
+
+	867.1.1 = {
+		liege = d_yukju
+		government = meritocratic_government
+		holder = balhae_wi_1 # 
+	}
+	1066.1.1 = {
+		holder = korean_yang_anak_2 # Dae_chun
+	}
+	1178.1.1 = {
+		holder = korean_baek_daeheung_2 # Im_ji
+	}
+}
+
+# GYOJU
+
+d_gyoju = {
+	867.1.1 = {
+		liege = k_silla
+		holder = korean_gim_gangneung_31 # 
+		government = meritocratic_government
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+		holder = korean_choe_dongju_1 # Seok
+	}
+	1178.1.1 = {
+		liege = e_goryeo
+		holder = korean_choe_dongju_3 # Jeong
+	}
+}
+
+c_inje = {
+	867.1.1 = { change_development_level = 2 }
+	1066.1.1 = { change_development_level = 4 }
+	1178.1.1 = { change_development_level = 7 }
+
+	867.1.1 = {
+		liege = d_gyoju
+		government = meritocratic_government
+		holder = korean_gim_gangneung_31 # 
+	}
+	1066.1.1 = {
+		holder = korean_choe_dongju_1 # Seok
+	}
+	1178.1.1 = {
+		holder = korean_choe_dongju_3 # Jeong
+	}
+}
+
+c_gyoju = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	867.1.1 = {
+		liege = d_gyoju
+		government = meritocratic_government
+		holder = korean_gim_gangneung_31 # 
+	}
+	1066.1.1 = {
+		holder = korean_choe_dongju_1 # Seok
+	}
+	1178.1.1 = {
+		holder = korean_choe_dongju_3 # Jeong
+	}
+}
+
+c_dongju = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 5 }
+	1178.1.1 = { change_development_level = 9 }
+
+	867.1.1 = {
+		liege = d_gyoju
+		government = meritocratic_government
+		holder = korean_gim_gangneung_31 # 
+	}
+	1066.1.1 = {
+		holder = korean_choe_dongju_1 # Seok
+	}
+	1178.1.1 = {
+		liege = d_gyoju
+		holder = korean_chae_pyeonggang_1 # Yeong
+	}
+}
+
+c_chunju = {
+	867.1.1 = { change_development_level = 7 }
+	1066.1.1 = { change_development_level = 13 }
+	1178.1.1 = { change_development_level = 23 }
+
+	867.1.1 = {
+		liege = d_gyoju
+		government = meritocratic_government
+		holder = korean_gim_gangneung_31 # 
+	}
+	1066.1.1 = {
+		holder = korean_choe_dongju_1 # Seok
+	}
+	1178.1.1 = {
+		holder = korean_choe_dongju_3 # Jeong
+	}
+}
+
+# GWANGJU
+
+d_gwangju = {
+	867.1.1 = {
+		liege = k_silla
+		holder = korean_yang_wonju_2 # Gil
+		government = meritocratic_government
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		holder = korean_heo_gongam_2 # Won
+	}
+	1178.1.1 = {
+		liege = e_goryeo
+		holder = korean_i_gyeongwon_65 # Gwang_jin
+	}
+}
+
+c_gwangju = {
+	867.1.1 = { change_development_level = 8 }
+	1066.1.1 = { change_development_level = 14 }
+	1178.1.1 = { change_development_level = 26 }
+
+	867.1.1 = {
+		liege = d_gwangju
+		government = meritocratic_government
+		holder = korean_yang_wonju_2 # Gil
+	}
+	1066.1.1 = {
+		holder = korean_heo_gongam_2 # Won
+	}
+	1178.1.1 = {
+		holder = korean_i_gyeongwon_65 # Gwang_jin
+	}
+}
+
+c_yangju = {
+	867.1.1 = { change_development_level = 8 }
+	1066.1.1 = { change_development_level = 14 }
+	1178.1.1 = { change_development_level = 26 }
+
+	867.1.1 = {
+		liege = d_gwangju
+		government = meritocratic_government
+		holder = korean_yang_wonju_2 # Gil
+	}
+	1066.1.1 = {
+		holder = korean_heo_gongam_2 # Won
+	}
+	1178.1.1 = {
+		holder = korean_i_gyeongwon_65 # Gwang_jin
+	}
+}
+
+c_wonju = {
+	867.1.1 = { change_development_level = 6 }
+	1066.1.1 = { change_development_level = 11 }
+	1178.1.1 = { change_development_level = 19 }
+
+	867.1.1 = {
+		liege = d_donggye
+		government = meritocratic_government
+		holder = korean_gim_gangneung_24 # Dong_jeong
+	}
+	1066.1.1 = {
+		liege = d_donggye
+		holder = korean_i_gyeongwon_27 # Jeong
+	}
+	1178.1.1 = {
+		holder = korean_i_gyeongwon_65 # Gwang_jin
+	}
+}
+
+c_dangseong = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	867.1.1 = {
+		liege = d_gwangju
+		government = meritocratic_government
+		holder = korean_yang_wonju_2 # Gil
+	}
+	1066.1.1 = {
+		holder = korean_gang_geumcheon_4 # Won_gwang
+	}
+	1178.1.1 = {
+		holder = korean_i_gyeongwon_65 # Gwang_jin
+	}
+}
+
+# DONGGYE
+
+d_donggye = {
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_gim_gangneung_24 # Dong_jeong
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+		holder = korean_yun_papyeong_4 # Jip_hyeong
+	}
+	1178.1.1 = {
+		holder = korean_tak_2 # 
+	}
+}
+
+c_myeongju = {
+	867.1.1 = { change_development_level = 5 }
+	1066.1.1 = { change_development_level = 9 }
+	1178.1.1 = { change_development_level = 15 }
+
+	867.1.1 = {
+		liege = d_donggye
+		government = meritocratic_government
+		holder = korean_gim_gangneung_24 # Dong_jeong
+	}
+	1066.1.1 = {
+		holder = korean_yun_papyeong_4 # Jip_hyeong
+	}
+	1178.1.1 = {
+		holder = korean_tak_2 # 
+	}
+}
+
+c_goseong = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 5 }
+	1178.1.1 = { change_development_level = 8 }
+
+	867.1.1 = {
+		liege = d_donggye
+		government = meritocratic_government
+		holder = korean_gim_gangneung_32 # Heo_wol
+	}
+	1066.1.1 = {
+		holder = korean_yun_papyeong_4 # Jip_hyeong
+	}
+	1178.1.1 = {
+		holder = korean_jo_hanyang_1 # 
+	}
+}
+
+c_deungju = {
+	867.1.1 = { change_development_level = 4 }
+	1066.1.1 = { change_development_level = 7 }
+	1178.1.1 = { change_development_level = 12 }
+
+	867.1.1 = {
+		liege = d_donggye
+		government = meritocratic_government
+		holder = korean_gim_gangneung_32 # Heo_wol
+	}
+	1066.1.1 = {
+		holder = korean_yun_papyeong_4 # Jip_hyeong
+	}
+	1178.1.1 = {
+		holder = korean_tak_2 # 
+	}
+}
+
+# YANGJU
+
+d_gaeseong = {
+	867.1.1 = {
+		liege = k_silla
+		government = meritocratic_government
+		holder = korean_wang_goryeo_43 # Jak_je_geon
+	}
+	875.1.1 = {
+		holder = korean_wang_goryeo_42 # Se_jo
+	}
+	897.5.1 = {
+		holder = korean_wang_goryeo_1 # King Tae_jo
+	}
+	1066.1.1 = {
+		liege = e_goryeo
+		government = meritocratic_government
+		holder = korean_wang_goryeo_13 # King Mun_jong
+	}
+	1178.1.1 = {
+		holder = korean_jeong_haeju_1 # Jung_bu
+	}
+}
+
+c_gaeseong = {
+	867.1.1 = { change_development_level = 11 }
+	1066.1.1 = { change_development_level = 20 }
+	1178.1.1 = { change_development_level = 42 }
+
+	850.1.1 = {
+		liege = d_gaeseong
+		government = meritocratic_government
+		holder = korean_wang_goryeo_43 # Jak_je_geon
+	}
+	875.1.1 = {
+		holder = korean_wang_goryeo_42 # Se_jo
+	}
+	897.5.1 = {
+		holder = korean_wang_goryeo_1 # King Tae_jo
+	}
+	1066.1.1 = {
+		holder = korean_wang_goryeo_13 # King Mun_jong
+	}
+	1178.1.1 = {
+		holder = korean_jeong_haeju_1 # Jung_bu
+	}
+}
+
+c_pyeongju = {
+	867.1.1 = { change_development_level = 5 }
+	1066.1.1 = { change_development_level = 9 }
+	1178.1.1 = { change_development_level = 15 }
+
+	867.1.1 = {
+		liege = d_gaeseong
+		government = meritocratic_government
+		holder = korean_ryu_yeomju_1 # Geung_sun
+	}
+	937.1.1 = {
+		holder = balhae_dae_31 # Gwang_hyeon
+	}
+	1066.1.1 = {
+		holder = korean_wang_goryeo_13 # King Munjong
+	}
+	1178.1.1 = {
+		holder = korean_jeong_haeju_1 # Jung_bu
+	}
+}
+
+c_gokju = {
+	867.1.1 = { change_development_level = 3 }
+	1066.1.1 = { change_development_level = 5 }
+	1178.1.1 = { change_development_level = 9 }
+
+	867.1.1 = {
+		liege = d_gaeseong
+		government = meritocratic_government
+		holder = korean_bak_pyeongsan_3 # Jik_yun
+	}
+	1066.1.1 = {
+		holder = korean_sin_pyeongsan_9 # Myeong_bu
+	}
+	1178.1.1 = {
+		holder = korean_sin_pyeongsan_12 # Jeok
+	}
+}

--- a/history/titles/k_dzungaria.txt
+++ b/history/titles/k_dzungaria.txt
@@ -1,0 +1,1728 @@
+k_dzungaria = {
+	867.1.1 = { change_development_level = 0 }
+	1066.1.1 = { change_development_level = 0 }
+	1178.1.1 = { change_development_level = 0 }
+	
+	#Kingdom of Qocho founded in 843
+	843.1.1 = {
+		holder = 302970	#Pangtele Ediz/Bilgä
+		government = feudal_government
+	}
+	864.10.1 = {
+		holder = 302972	#Bokut Bilgä
+	}
+	#874 End of Bokut's reign
+	#Hole in history - fictional placeholders
+	874.12.13 = {
+		holder = uyghur0086
+	}
+	920.1.1 = {
+		holder = uyghur0087
+	}
+	#Ilig
+	954.2.22 = {
+		holder = 302975	#Ilig Bilgä
+	}
+	981.8.15 = {
+		holder = 302976	#Arslan Bilgä
+	}
+	996.11.3 = {
+		holder = 302977	#Bügü Bilgä
+	}
+	1007.10.29 = {
+		holder = 302978	#Alp Arslan Qutlugh Bilgä
+	}
+	1024.5.20 = {
+		holder = 302979	#Kül Bilgä
+	}
+	1068.7.11 = {
+		holder = 302981	#Bügü Bilgä (Arslan)
+	}
+	1123.10.14 = {
+		holder = 302982	#Bilge (Bilgä)
+	}
+	#Missing history - fictional placeholders
+	1130.5.17 = {
+		holder = uyghur0088
+	}
+	##Vassalized by Kara-Khitans / Great Liao in 1132
+	1132.1.1 = {
+		liege = 0 # moved to tributary
+	}
+	1160.1.11 = {
+		holder = uyghur0089
+	}
+	1170.6.1 = {
+		holder = 302983	#fictional Kutan Bilgä
+		de_jure_liege = e_kara_khitai
+	}
+	1193.8.8 = {
+		holder = 302984	#Yur Temur
+	}
+	1208.12.14 = {
+		holder = 166789	#Barchuq Art
+	}
+	#Subjugated by mongols
+	1209.1.1 = {
+		liege = e_mongolia
+	}
+	1235.1.1 = {
+		holder = 166790	#Qusmayin
+	}
+	1245.1.1 = {
+		holder = 166791	#Salun Tekin
+	}
+	1255.1.1 = {
+		holder = 166792	#Oghrunzh Tekin
+	}
+	1265.1.1 = {
+		holder = 166793	#Mamuraq Tekin
+	}
+	1266.1.1 = {
+		holder = 166794	#Qozhighar Tekin
+	}
+	1276.1.1 = {
+		holder = uyghur0090	#Nolen Tekin
+	}
+	1318.1.1 = {
+		holder = uyghur0091	#Tomur Buqa
+	}
+	1327.1.1 = {
+		holder = uyghur0092	#Sunggi Tekin
+	}
+	1331.1.1 = {
+		holder = uyghur0093	#Taypan (Taipingnu)
+	}
+	1335.1.1 = {
+		holder = uyghur0094	#Yuelutiemur
+	}
+	1353.1.1 = {
+		holder = uyghur0095	#Sangge
+	}
+}
+
+d_kara_khoja = {
+	835.1.1 = {
+		liege = e_tibet
+		holder = bodpa0245
+	}
+	866.1.1 = {	#captured by Guiyi Circuit
+		liege = k_guiyi
+		holder = sogdian0001
+	}
+	#Kingdom of Qocho founded in 843
+	866.6.1 = {	#captured from Guiyi Circuit
+		holder = 302972	#Bokut Bilgä
+		liege = k_dzungaria
+	}
+	#874 End of Bokut's reign
+	#Hole in history - fictional placeholders
+	874.12.13 = {
+		holder = uyghur0086
+	}
+	920.1.1 = {
+		holder = uyghur0087
+	}
+	#Ilig
+	954.2.22 = {
+		holder = 302975	#Ilig Bilgä
+	}
+	981.8.15 = {
+		holder = 302976	#Arslan Bilgä
+	}
+	996.11.3 = {
+		holder = 302977	#Bügü Bilgä
+	}
+	1007.10.29 = {
+		holder = 302978	#Alp Arslan Qutlugh Bilgä
+	}
+	1024.5.20 = {
+		holder = 302979	#Kül Bilgä
+	}
+	1068.7.11 = {
+		holder = 302981	#Bügü Bilgä (Arslan)
+	}
+	1123.10.14 = {
+		holder = 302982	#Bilge (Bilgä)
+	}
+	#Missing history - fictional placeholders
+	1130.5.17 = {
+		holder = uyghur0088
+	}
+	1160.1.11 = {
+		holder = uyghur0089
+	}
+	##Vassalized by Kara-Khitans / Great Liao in 1132
+	1170.6.1 = {
+		holder = 302983	#fictional Kutan Bilgä
+	}
+	1193.8.8 = {
+		holder = 302984	#Yur Temur
+	}
+	1208.12.14 = {
+		holder = 166789	#Barchuq Art
+	}
+	1235.1.1 = {
+		holder = 166790	#Qusmayin
+	}
+	1245.1.1 = {
+		holder = 166791	#Salun Tekin
+	}
+	1255.1.1 = {
+		holder = 166792	#Oghrunzh Tekin
+	}
+	1265.1.1 = {
+		holder = 166793	#Mamuraq Tekin
+	}
+	1266.1.1 = {
+		holder = 166794	#Qozhighar Tekin
+	}
+	1276.1.1 = {
+		holder = uyghur0090	#Nolen Tekin
+	}
+	1318.1.1 = {
+		holder = uyghur0091	#Tomur Buqa
+	}
+	1327.1.1 = {
+		holder = uyghur0092	#Sunggi Tekin
+	}
+	1331.1.1 = {
+		holder = uyghur0093	#Taypan (Taipingnu)
+	}
+	1335.1.1 = {
+		holder = uyghur0094	#Yuelutiemur
+	}
+	1353.1.1 = {
+		holder = uyghur0095	#Sangge
+	}
+}
+
+c_kara_khoja = {
+	867.1.1 = { change_development_level = 8 }
+	1066.1.1 = { change_development_level = 10 }
+	1178.1.1 = { change_development_level = 24 }
+	
+	835.1.1 = {
+		liege = d_kara_khoja
+		holder = bodpa0245
+	}
+	866.1.1 = {	#captured by Guiyi Circuit
+		holder = sogdian0001
+	}
+	#Kingdom of Qocho founded in 843
+	866.6.1 = {	#captured from Guiyi Circuit
+		holder = 302972	#Bokut Bilgä
+	}
+	#874 End of Bokut's reign
+	#Hole in history - fictional placeholders
+	874.12.13 = {
+		holder = uyghur0086
+	}
+	920.1.1 = {
+		holder = uyghur0087
+	}
+	#Ilig
+	954.2.22 = {
+		holder = 302975	#Ilig Bilgä
+	}
+	981.8.15 = {
+		holder = 302976	#Arslan Bilgä
+	}
+	996.11.3 = {
+		holder = 302977	#Bügü Bilgä
+	}
+	1007.10.29 = {
+		holder = 302978	#Alp Arslan Qutlugh Bilgä
+	}
+	1024.5.20 = {
+		holder = 302979	#Kül Bilgä
+	}
+	1068.7.11 = {
+		holder = 302981	#Bügü Bilgä (Arslan)
+	}
+	1123.10.14 = {
+		holder = 302982	#Bilge (Bilgä)
+	}
+	#Missing history - fictional placeholders
+	1130.5.17 = {
+		holder = uyghur0088
+	}
+	1160.1.11 = {
+		holder = uyghur0089
+	}
+	##Vassalized by Kara-Khitans / Great Liao in 1132
+	1170.6.1 = {
+		holder = 302983	#fictional Kutan Bilgä
+	}
+	1193.8.8 = {
+		holder = 302984	#Yur Temur
+	}
+	1208.12.14 = {
+		holder = 166789	#Barchuq Art
+	}
+	1235.1.1 = {
+		holder = 166790	#Qusmayin
+	}
+	1245.1.1 = {
+		holder = 166791	#Salun Tekin
+	}
+	1255.1.1 = {
+		holder = 166792	#Oghrunzh Tekin
+	}
+	1265.1.1 = {
+		holder = 166793	#Mamuraq Tekin
+	}
+	1266.1.1 = {
+		holder = 166794	#Qozhighar Tekin
+	}
+	1276.1.1 = {
+		holder = uyghur0090	#Nolen Tekin
+	}
+	1318.1.1 = {
+		holder = uyghur0091	#Tomur Buqa
+	}
+	1327.1.1 = {
+		holder = uyghur0092	#Sunggi Tekin
+	}
+	1331.1.1 = {
+		holder = uyghur0093	#Taypan (Taipingnu)
+	}
+	1335.1.1 = {
+		holder = uyghur0094	#Yuelutiemur
+	}
+	1353.1.1 = {
+		holder = uyghur0095	#Sangge
+	}
+}
+
+c_toksun = {
+	835.1.1 = {
+		liege = d_kara_khoja
+		holder = bodpa0245
+	}
+	866.6.1 = {	#captured by Guiyi Circuit
+		holder = sogdian0001
+	}
+	#Kingdom of Qocho founded in 843
+	866.10.1 = {	#captured from Guiyi Circuit
+		holder = 302972	#Bokut Bilgä
+	}
+	#874 End of Bokut's reign
+	#Hole in history - fictional placeholders
+	874.12.13 = {
+		holder = uyghur0086
+	}
+	920.1.1 = {
+		holder = uyghur0087
+	}
+	#Ilig
+	954.2.22 = {
+		holder = 302975	#Ilig Bilgä
+	}
+	981.8.15 = {
+		holder = 302976	#Arslan Bilgä
+	}
+	996.11.3 = {
+		holder = 302977	#Bügü Bilgä
+	}
+	1007.10.29 = {
+		holder = 302978	#Alp Arslan Qutlugh Bilgä
+	}
+	1024.5.20 = {
+		holder = 302979	#Kül Bilgä
+	}
+	1068.7.11 = {
+		holder = 302981	#Bügü Bilgä (Arslan)
+	}
+	1123.10.14 = {
+		holder = 302982	#Bilge (Bilgä)
+	}
+	#Missing history - fictional placeholders
+	1130.5.17 = {
+		holder = uyghur0088
+	}
+	1160.1.11 = {
+		holder = uyghur0089
+	}
+	##Vassalized by Kara-Khitans / Great Liao in 1132
+	1170.6.1 = {
+		holder = 302983	#fictional Kutan Bilgä
+	}
+	1193.8.8 = {
+		holder = 302984	#Yur Temur
+	}
+	1208.12.14 = {
+		holder = 166789	#Barchuq Art
+	}
+	1235.1.1 = {
+		holder = 166790	#Qusmayin
+	}
+	1245.1.1 = {
+		holder = 166791	#Salun Tekin
+	}
+	1255.1.1 = {
+		holder = 166792	#Oghrunzh Tekin
+	}
+	1265.1.1 = {
+		holder = 166793	#Mamuraq Tekin
+	}
+	1266.1.1 = {
+		holder = 166794	#Qozhighar Tekin
+	}
+	1276.1.1 = {
+		holder = uyghur0090	#Nolen Tekin
+	}
+	1318.1.1 = {
+		holder = uyghur0091	#Tomur Buqa
+	}
+	1327.1.1 = {
+		holder = uyghur0092	#Sunggi Tekin
+	}
+	1331.1.1 = {
+		holder = uyghur0093	#Taypan (Taipingnu)
+	}
+	1335.1.1 = {
+		holder = uyghur0094	#Yuelutiemur
+	}
+	1353.1.1 = {
+		holder = uyghur0095	#Sangge
+	}
+}
+
+c_beshbalik = {
+	867.1.1 = { change_development_level = 5 }
+	1066.1.1 = { change_development_level = 8 }
+	1178.1.1 = { change_development_level = 20 }
+	
+	835.1.1 = {
+		liege = d_kara_khoja
+		holder = bodpa0245
+	}
+	866.1.1 = {	#captured by Guiyi Circuit
+		holder = sogdian0001
+	}
+	#Kingdom of Qocho founded in 843
+	866.6.1 = {	#captured from Guiyi Circuit
+		holder = 302972	#Bokut Bilgä
+	}
+	#874 End of Bokut's reign
+	#Hole in history - fictional placeholders
+	874.12.13 = {
+		holder = uyghur0086
+	}
+	920.1.1 = {
+		holder = uyghur0087
+	}
+	#Ilig
+	954.2.22 = {
+		holder = 302975	#Ilig Bilgä
+	}
+	981.8.15 = {
+		holder = 302976	#Arslan Bilgä
+	}
+	996.11.3 = {
+		holder = 302977	#Bügü Bilgä
+	}
+	1007.10.29 = {
+		holder = 302978	#Alp Arslan Qutlugh Bilgä
+	}
+	1024.5.20 = {
+		holder = 302979	#Kül Bilgä
+	}
+	1068.7.11 = {
+		holder = 302981	#Bügü Bilgä (Arslan)
+	}
+	1123.10.14 = {
+		holder = 302982	#Bilge (Bilgä)
+	}
+	#Missing history - fictional placeholders
+	1130.5.17 = {
+		holder = uyghur0088
+	}
+	1160.1.11 = {
+		holder = uyghur0089
+	}
+	##Vassalized by Kara-Khitans / Great Liao in 1132
+	1170.6.1 = {
+		holder = 302983	#fictional Kutan Bilgä
+	}
+	1193.8.8 = {
+		holder = 302984	#Yur Temur
+	}
+	1208.12.14 = {
+		holder = 166789	#Barchuq Art
+	}
+	1235.1.1 = {
+		holder = 166790	#Qusmayin
+	}
+	1245.1.1 = {
+		holder = 166791	#Salun Tekin
+	}
+	1255.1.1 = {
+		holder = 166792	#Oghrunzh Tekin
+	}
+	1265.1.1 = {
+		holder = 166793	#Mamuraq Tekin
+	}
+	1266.1.1 = {
+		holder = 166794	#Qozhighar Tekin
+	}
+	1276.1.1 = {
+		holder = uyghur0090	#Nolen Tekin
+	}
+	1318.1.1 = {
+		holder = uyghur0091	#Tomur Buqa
+	}
+	1327.1.1 = {
+		holder = uyghur0092	#Sunggi Tekin
+	}
+	1331.1.1 = {
+		holder = uyghur0093	#Taypan (Taipingnu)
+	}
+	1335.1.1 = {
+		holder = uyghur0094	#Yuelutiemur
+	}
+	1353.1.1 = {
+		holder = uyghur0095	#Sangge
+	}
+}
+
+c_jimsar = {
+	867.1.1 = { change_development_level = 5 }
+	1066.1.1 = { change_development_level = 8 }
+	1178.1.1 = { change_development_level = 20 }
+	
+	835.1.1 = {
+		liege = d_kara_khoja
+		holder = bodpa0245
+	}
+	866.1.1 = {	#captured by Guiyi Circuit
+		holder = sogdian0001
+	}
+	#Kingdom of Qocho founded in 843
+	866.6.1 = {	#captured from Guiyi Circuit
+		holder = 302972	#Bokut Bilgä
+	}
+	#874 End of Bokut's reign
+	#Hole in history - fictional placeholders
+	874.12.13 = {
+		holder = uyghur0086
+	}
+	920.1.1 = {
+		holder = uyghur0087
+	}
+	#Ilig
+	954.2.22 = {
+		holder = 302975	#Ilig Bilgä
+	}
+	981.8.15 = {
+		holder = 302976	#Arslan Bilgä
+	}
+	996.11.3 = {
+		holder = 302977	#Bügü Bilgä
+	}
+	1007.10.29 = {
+		holder = 302978	#Alp Arslan Qutlugh Bilgä
+	}
+	1024.5.20 = {
+		holder = 302979	#Kül Bilgä
+	}
+	1068.7.11 = {
+		holder = 302981	#Bügü Bilgä (Arslan)
+	}
+	1123.10.14 = {
+		holder = 302982	#Bilge (Bilgä)
+	}
+	#Missing history - fictional placeholders
+	1130.5.17 = {
+		holder = uyghur0088
+	}
+	1160.1.11 = {
+		holder = uyghur0089
+	}
+	##Vassalized by Kara-Khitans / Great Liao in 1132
+	1170.6.1 = {
+		holder = 302983	#fictional Kutan Bilgä
+	}
+	1193.8.8 = {
+		holder = 302984	#Yur Temur
+	}
+	1208.12.14 = {
+		holder = 166789	#Barchuq Art
+	}
+	1235.1.1 = {
+		holder = 166790	#Qusmayin
+	}
+	1245.1.1 = {
+		holder = 166791	#Salun Tekin
+	}
+	1255.1.1 = {
+		holder = 166792	#Oghrunzh Tekin
+	}
+	1265.1.1 = {
+		holder = 166793	#Mamuraq Tekin
+	}
+	1266.1.1 = {
+		holder = 166794	#Qozhighar Tekin
+	}
+	1276.1.1 = {
+		holder = uyghur0090	#Nolen Tekin
+	}
+	1318.1.1 = {
+		holder = uyghur0091	#Tomur Buqa
+	}
+	1327.1.1 = {
+		holder = uyghur0092	#Sunggi Tekin
+	}
+	1331.1.1 = {
+		holder = uyghur0093	#Taypan (Taipingnu)
+	}
+	1335.1.1 = {
+		holder = uyghur0094	#Yuelutiemur
+	}
+	1353.1.1 = {
+		holder = uyghur0095	#Sangge
+	}
+}
+
+
+c_yangjibaliq = {
+	835.1.1 = {
+		liege = d_kara_khoja
+		holder = bodpa0245
+	}
+	866.1.1 = {	#captured by Guiyi Circuit
+		holder = sogdian0001
+	}
+	#Kingdom of Qocho founded in 843
+	866.6.1 = {	#captured from Guiyi Circuit
+		holder = 302972	#Bokut Bilgä
+	}
+	#874 End of Bokut's reign
+	#Hole in history - fictional placeholders
+	874.12.13 = {
+		holder = uyghur0086
+	}
+	920.1.1 = {
+		holder = uyghur0087
+	}
+	#Ilig
+	954.2.22 = {
+		holder = 302975	#Ilig Bilgä
+	}
+	981.8.15 = {
+		holder = 302976	#Arslan Bilgä
+	}
+	996.11.3 = {
+		holder = 302977	#Bügü Bilgä
+	}
+	1007.10.29 = {
+		holder = 302978	#Alp Arslan Qutlugh Bilgä
+	}
+	1024.5.20 = {
+		holder = 302979	#Kül Bilgä
+	}
+	1066.1.1 = {	#Fictional to avoid domain overlimit
+		holder = fictional_uyghurs_1
+		government = feudal_government
+	}
+	1068.7.11 = {
+		holder = 302981	#Bügü Bilgä (Arslan)
+	}
+	1123.10.14 = {
+		holder = 302982	#Bilge (Bilgä)
+	}
+	#Missing history - fictional placeholders
+	1130.5.17 = {
+		holder = uyghur0088
+	}
+	1160.1.11 = {
+		holder = uyghur0089
+	}
+	##Vassalized by Kara-Khitans / Great Liao in 1132
+	1170.6.1 = {
+		holder = 302983	#fictional Kutan Bilgä
+	}
+	1193.8.8 = {
+		holder = 302984	#Yur Temur
+	}
+	1208.12.14 = {
+		holder = 166789	#Barchuq Art
+	}
+	1235.1.1 = {
+		holder = 166790	#Qusmayin
+	}
+	1245.1.1 = {
+		holder = 166791	#Salun Tekin
+	}
+	1255.1.1 = {
+		holder = 166792	#Oghrunzh Tekin
+	}
+	1265.1.1 = {
+		holder = 166793	#Mamuraq Tekin
+	}
+	1266.1.1 = {
+		holder = 166794	#Qozhighar Tekin
+	}
+	1276.1.1 = {
+		holder = uyghur0090	#Nolen Tekin
+	}
+	1318.1.1 = {
+		holder = uyghur0091	#Tomur Buqa
+	}
+	1327.1.1 = {
+		holder = uyghur0092	#Sunggi Tekin
+	}
+	1331.1.1 = {
+		holder = uyghur0093	#Taypan (Taipingnu)
+	}
+	1335.1.1 = {
+		holder = uyghur0094	#Yuelutiemur
+	}
+	1353.1.1 = {
+		holder = uyghur0095	#Sangge
+	}
+}
+
+c_bugur = {
+	835.1.1 = {
+		liege = d_kara_khoja
+		holder = bodpa0245
+	}
+	866.1.1 = {	#captured by Guiyi Circuit
+		holder = sogdian0001
+	}
+	#Kingdom of Qocho founded in 843
+	866.6.1 = {	#captured from Guiyi Circuit
+		holder = 302972	#Bokut Bilgä
+	}
+	#874 End of Bokut's reign
+	#Hole in history - fictional placeholders
+	874.12.13 = {
+		holder = uyghur0086
+	}
+	920.1.1 = {
+		holder = uyghur0087
+	}
+	#Ilig
+	954.2.22 = {
+		holder = 302975	#Ilig Bilgä
+	}
+	981.8.15 = {
+		holder = 302976	#Arslan Bilgä
+	}
+	996.11.3 = {
+		holder = 302977	#Bügü Bilgä
+	}
+	1007.10.29 = {
+		holder = 302978	#Alp Arslan Qutlugh Bilgä
+	}
+	1024.5.20 = {
+		holder = 302979	#Kül Bilgä
+	}
+	1066.1.1 = {	#Fictional to avoid domain overlimit
+		holder = fictional_uyghurs_1
+		government = feudal_government
+	}
+	1068.7.11 = {
+		holder = 302981	#Bügü Bilgä (Arslan)
+	}
+	1123.10.14 = {
+		holder = 302982	#Bilge (Bilgä)
+	}
+	#Missing history - fictional placeholders
+	1130.5.17 = {
+		holder = uyghur0088
+	}
+	1160.1.11 = {
+		holder = uyghur0089
+	}
+	##Vassalized by Kara-Khitans / Great Liao in 1132
+	1170.6.1 = {
+		holder = 302983	#fictional Kutan Bilgä
+	}
+	1193.8.8 = {
+		holder = 302984	#Yur Temur
+	}
+	1208.12.14 = {
+		holder = 166789	#Barchuq Art
+	}
+	1235.1.1 = {
+		holder = 166790	#Qusmayin
+	}
+	1245.1.1 = {
+		holder = 166791	#Salun Tekin
+	}
+	1255.1.1 = {
+		holder = 166792	#Oghrunzh Tekin
+	}
+	1265.1.1 = {
+		holder = 166793	#Mamuraq Tekin
+	}
+	1266.1.1 = {
+		holder = 166794	#Qozhighar Tekin
+	}
+	1276.1.1 = {
+		holder = uyghur0090	#Nolen Tekin
+	}
+	1318.1.1 = {
+		holder = uyghur0091	#Tomur Buqa
+	}
+	1327.1.1 = {
+		holder = uyghur0092	#Sunggi Tekin
+	}
+	1331.1.1 = {
+		holder = uyghur0093	#Taypan (Taipingnu)
+	}
+	1335.1.1 = {
+		holder = uyghur0094	#Yuelutiemur
+	}
+	1353.1.1 = {
+		holder = uyghur0095	#Sangge
+	}
+}
+
+c_barkul = {
+	#Kirghiz khanate
+	840.1.1 = {
+		liege = e_kirghiz_khanate
+	}
+	850.1.1 = {
+		holder = 217173
+		government = feudal_government
+	}
+	#Beshbalik area conquered by Qocho
+	866.6.1 = {
+		liege = d_kara_khoja
+	}
+	876.1.4 = {
+		holder = 303003	#fictional C_or Bügün
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	1065.2.10 = {
+		holder = 303004	#fictional Kubasar Bügün
+	}
+	1093.4.13 = {
+		holder = 303005	#fictional KU_l Bügün
+	}
+	1120.6.16 = {
+		holder = 303006	#fictional Adigh Bügün
+	}
+	1144.2.11 = {
+		holder = 303007	#fictional SevenC_ Bügün
+	}
+	1168.9.26 = {
+		holder = 303008	#fictional Kubasar Bügün
+	}
+}
+
+c_chamil = {
+	#Guiyi Circuit recaptures Yizhou from Tibetans
+	850.1.1 = {
+		holder = sogdian0001
+		liege = k_guiyi
+		government = feudal_government
+	}
+	#Kingdom of Qocho captures Yizhou - renamed to Kumul
+	876.1.1 = {	#Kumul vassals - fictional placeholders
+		holder = uyghur0001
+		liege = k_dzungaria
+	}
+	900.1.1 = {
+		holder = uyghur0002
+	}
+	920.1.1 = {
+		holder = uyghur0003
+	}
+	940.1.1 = {
+		holder = uyghur0004
+	}
+	960.1.1 = {
+		holder = uyghur0005
+	}
+	980.1.1 = {
+		holder = uyghur0006
+	}
+	1000.1.1 = {
+		holder = uyghur0007
+	}
+	1020.1.1 = {
+		holder = uyghur0008
+	}
+	1040.1.1 = {
+		holder = uyghur0009
+	}
+	1060.1.1 = {
+		holder = uyghur0010
+	}
+	1080.1.1 = {
+		holder = uyghur0011
+	}
+	1100.1.1 = {
+		holder = uyghur0012
+	}
+	1120.1.1 = {
+		holder = uyghur0122
+	}
+	1140.1.1 = {
+		holder = uyghur0123
+	}
+	1160.1.1 = {
+		holder = uyghur0124
+	}
+	1180.1.1 = {
+		holder = uyghur0125
+	}
+	1200.1.1 = {
+		holder = uyghur0126
+	}
+	1220.1.1 = {
+		holder = uyghur0127
+	}
+	1240.1.1 = {
+		holder = uyghur0128
+	}
+	1260.1.1 = {
+		holder = uyghur0129
+	}
+	1280.1.1 = {
+		holder = uyghur0130
+	}
+	1300.1.1 = {
+		holder = uyghur0131
+	}
+	1320.1.1 = {
+		holder = uyghur0132
+	}
+	1340.1.1 = {
+		holder = uyghur0133
+	}
+	1360.1.1 = {
+		holder = uyghur0134
+	}
+}
+
+c_burgasutai = {
+	#Guiyi Circuit recaptures Yizhou from Tibetans
+	850.1.1 = {
+		holder = sogdian0001
+		liege = k_guiyi
+		government = feudal_government
+	}
+	#Kingdom of Qocho captures Yizhou - renamed to Kumul
+	876.1.1 = {	#Kumul vassals - fictional placeholders
+		holder = uyghur0001
+		liege = k_dzungaria
+	}
+	900.1.1 = {
+		holder = uyghur0002
+	}
+	920.1.1 = {
+		holder = uyghur0003
+	}
+	940.1.1 = {
+		holder = uyghur0004
+	}
+	960.1.1 = {
+		holder = uyghur0005
+	}
+	980.1.1 = {
+		holder = uyghur0006
+	}
+	1000.1.1 = {
+		holder = uyghur0007
+	}
+	1020.1.1 = {
+		holder = uyghur0008
+	}
+	1040.1.1 = {
+		holder = uyghur0009
+	}
+	1060.1.1 = {
+		holder = uyghur0010
+	}
+	1080.1.1 = {
+		holder = uyghur0011
+	}
+	1100.1.1 = {
+		holder = uyghur0012
+	}
+	1120.1.1 = {
+		holder = uyghur0122
+	}
+	1140.1.1 = {
+		holder = uyghur0123
+	}
+	1160.1.1 = {
+		holder = uyghur0124
+	}
+	1180.1.1 = {
+		holder = uyghur0125
+	}
+	1200.1.1 = {
+		holder = uyghur0126
+	}
+	1220.1.1 = {
+		holder = uyghur0127
+	}
+	1240.1.1 = {
+		holder = uyghur0128
+	}
+	1260.1.1 = {
+		holder = uyghur0129
+	}
+	1280.1.1 = {
+		holder = uyghur0130
+	}
+	1300.1.1 = {
+		holder = uyghur0131
+	}
+	1320.1.1 = {
+		holder = uyghur0132
+	}
+	1340.1.1 = {
+		holder = uyghur0133
+	}
+	1360.1.1 = {
+		holder = uyghur0134
+	}
+}
+
+
+c_altay = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+	864.1.1 = {
+		holder = fictional_kirghiz_4
+		government = herder_government
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	#Uyghur Qocho kingdom
+	946.3.7 = {
+		liege = k_dzungaria
+		holder = 217187
+		# government = nomad_government
+	}
+	994.8.24 = {
+		holder = 217188
+	}
+	1021.9.13 = {
+		holder = 217189
+	}
+
+	#Naimans
+	1058.6.10 = {
+		liege = d_naiman_gobi
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1066.1.2 = {
+		holder = fictional_naimans_5	#fic to have more chars and avoid domain overlimit
+		government = herder_government
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+		# government = nomad_government
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = 303318		#fictional Altan Buku
+	}
+	1177.1.1 = {
+		holder = 303319	# fictional Tooril Buku
+		liege = d_naiman_gobi
+		government = nomad_government
+	}
+}
+
+c_burqin = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+	864.1.1 = {
+		holder = fictional_kirghiz_11 #fictional herder
+		government = herder_government
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	#Uyghur Qocho kingdom
+	946.3.7 = {
+		liege = k_dzungaria
+		holder = 217187
+		# government = nomad_government
+	}
+	994.8.24 = {
+		holder = 217188
+	}
+	1021.9.13 = {
+		holder = 217189
+	}
+
+	#Naimans
+	1058.6.10 = {
+		liege = d_naiman_gobi
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1066.1.2 = {
+		holder = fictional_naimans_11	#fictional herder
+		government = herder_government
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+		# government = nomad_government
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = 303318		#fictional Altan Buku
+	}
+	1177.1.1 = {
+		holder = 303319	# fictional Tooril Buku
+		liege = d_naiman_gobi
+		government = nomad_government
+	}
+}
+
+
+
+c_qinggil = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+	841.1.1 = {
+		holder = fictional_kirghiz_2
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	#Uyghur Qocho kingdom
+	946.3.7 = {
+		liege = k_dzungaria
+		holder = 217187
+	}
+	994.8.24 = {
+		holder = 217188
+	}
+	1021.9.13 = {
+		holder = 217189
+	}
+
+	#Naimans
+	1058.6.10 = {
+		liege = d_naiman_gobi
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1066.1.2 = {
+		holder = fictional_naimans_4	#fic to have more chars and avoid domain overlimit
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = 303318		#fictional Altan Buku
+	}
+	1177.1.1 = {
+		holder = 303319	# fictional Tooril Buku
+		liege = d_naiman_gobi
+	}
+}
+
+c_tengerge = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+	867.1.1 = {
+		holder = fictional_kirghiz_3
+		government = herder_government
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	#Uyghur Qocho kingdom
+	946.3.7 = {
+		liege = k_dzungaria
+		holder = 217187
+		government = nomad_government
+	}
+	994.8.24 = {
+		holder = 217188
+	}
+	1021.9.13 = {
+		holder = 217189
+	}
+
+	#Naimans
+	1058.6.10 = {
+		liege = d_naiman_gobi
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1066.1.2 = {
+		holder = fictional_naimans_5	#fic to have more chars and avoid domain overlimit
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = 303318		#fictional Altan Buku
+	}
+	1177.1.1 = {
+		holder = 303319	# fictional Tooril Buku
+		liege = d_naiman_gobi
+		government = nomad_government
+	}
+}
+
+
+c_agairik = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+
+	866.10.1 = {
+		holder = 302995	#fictional SirC_an Altaigaas
+		government = nomad_government
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	# Liao Dynasty
+	1040.1.1 = {
+		liege = e_great_liao
+	}
+
+	#1066 - Naimans
+	1066.1.2 = {
+		liege = 0
+		holder = fictional_naimans_3	#fic to have more chars and avoid domain overlimit
+		government = herder_government
+	}
+
+	#End of Liao Dynasty
+	1125.3.26 = {
+		liege = 0
+	}
+
+	1130.1.1 = {
+		liege = k_naiman
+	}
+
+	1132.8.9 = {
+		holder = 303323		#fictional Qorisubachi Karakalpaks
+	}
+	1153.2.3 = {
+		holder = 303324		#fictional Inanch Karakalpaks
+	}
+	1165.3.22 = {
+		holder = 303325		#fictional Jagambu Karakalpaks
+	}
+	
+	#1178
+	1178.1.2 = {
+		holder = fictional_naimans_6	#fic to have more chars and avoid domain overlimit
+		government = herder_government
+	}
+}
+
+d_akaltay = {
+	1130.1.1 = {
+		liege = k_naiman
+	}
+	1131.1.1 = {
+		de_jure_liege = k_naiman
+	}
+}
+
+d_altay = {
+	1130.1.1 = {
+		liege = k_naiman
+	}
+	1131.1.1 = {
+		de_jure_liege = k_naiman
+	}
+}
+
+
+c_narym_DZU = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+
+	866.10.1 = {
+		holder = 302995	#fictional SirC_an Altaigaas
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	# Liao Dynasty
+	1040.1.1 = {
+		liege = e_great_liao
+	}
+
+	#1066 - Naimans
+	1066.1.2 = {
+		liege = 0
+		holder = 303320		#ficitonal Saryk Karakalpaks
+	}
+	1110.7.23 = {
+		holder = 303321		#fictional Ciriac Karakalpaks
+	}
+
+	#End of Liao Dynasty
+	1125.3.26 = {
+		liege = 0
+	}
+
+	1132.8.9 = {
+		holder = 303323		#fictional Qorisubachi Karakalpaks
+	}
+	1153.2.3 = {
+		holder = 303324		#fictional Inanch Karakalpaks
+	}
+	1165.3.22 = {
+		holder = 303325		#fictional Jagambu Karakalpaks
+	}
+}
+
+
+c_torangy_kul = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+
+	866.10.1 = {
+		holder = 302995	#fictional SirC_an Altaigaas
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	# Liao Dynasty
+	1040.1.1 = {
+		liege = e_great_liao
+	}
+
+	#1066 - Naimans
+	1066.1.2 = {
+		liege = 0
+		holder = fictional_naimans_10	#fictional herder
+		government = herder_government
+	}
+
+	#End of Liao Dynasty
+	1125.3.26 = {
+		liege = 0
+	}
+
+	1132.8.9 = {
+		holder = 303323		#fictional Qorisubachi Karakalpaks
+	}
+	1153.2.3 = {
+		holder = 303324		#fictional Inanch Karakalpaks
+	}
+	1165.3.22 = {
+		holder = 303325		#fictional Jagambu Karakalpaks
+	}
+	
+	#1178
+	1178.1.2 = {
+		holder = fictional_naimans_7	#fictional herder
+		government = herder_government
+		liege = k_naiman
+	}
+}
+
+d_gurbantunggut = {
+	#Uyghur Qocho kingdom
+	866.10.1 = {
+		holder = 302985	#fictional Adigh Urulchiq
+		government = feudal_government
+		liege = k_dzungaria
+	}
+	879.1.23 = {
+		holder = 302986	#fictional Atral Urulchiq
+	}
+	1060.2.23 = {
+		holder = 302987	#fictional MA_nglik Urulchiq
+	}
+	1082.8.13 = {
+		holder = 302989	#fictional Qutlugh Urulchiq
+	}
+	1109.6.14 = {
+		holder = 302991	#fictional KO_nC_ek Urulchiq
+	}
+	1139.4.5 = {
+		holder = 302992	#fictional Sokal Urulchiq
+	}
+	1149.3.16 = {
+		holder = 302993	#fictional Qutlugh Urulchiq
+	}
+	1191.2.14 = {
+		holder = 302994	#fictional Barchuq Urulchiq
+	}
+}
+
+c_hoboksar = {
+	#Uyghur Qocho kingdom
+	866.10.1 = {
+		holder = 302985	#fictional Adigh Urulchiq
+		liege = d_gurbantunggut
+	}
+	879.1.23 = {
+		holder = 302986	#fictional Atral Urulchiq
+	}
+	1060.2.23 = {
+		holder = 302987	#fictional MA_nglik Urulchiq
+	}
+	1082.8.13 = {
+		holder = 302989	#fictional Qutlugh Urulchiq
+	}
+	1109.6.14 = {
+		holder = 302991	#fictional KO_nC_ek Urulchiq
+	}
+	1139.4.5 = {
+		holder = 302992	#fictional Sokal Urulchiq
+	}
+	1149.3.16 = {
+		holder = 302993	#fictional Qutlugh Urulchiq
+	}
+	1191.2.14 = {
+		holder = 302994	#fictional Barchuq Urulchiq
+	}
+}
+
+c_kaerji = {
+	#Uyghur Qocho kingdom
+	866.10.1 = {
+		holder = 302985	#fictional Adigh Urulchiq
+		liege = d_gurbantunggut
+	}
+	879.1.23 = {
+		holder = 302986	#fictional Atral Urulchiq
+	}
+	1060.2.23 = {
+		holder = 302987	#fictional MA_nglik Urulchiq
+	}
+	1082.8.13 = {
+		holder = 302989	#fictional Qutlugh Urulchiq
+	}
+	1109.6.14 = {
+		holder = 302991	#fictional KO_nC_ek Urulchiq
+	}
+	1139.4.5 = {
+		holder = 302992	#fictional Sokal Urulchiq
+	}
+	1149.3.16 = {
+		holder = 302993	#fictional Qutlugh Urulchiq
+	}
+	1191.2.14 = {
+		holder = 302994	#fictional Barchuq Urulchiq
+	}
+}
+
+
+c_ulan_chuzir = {
+	#Uyghur Qocho kingdom
+	866.10.1 = {
+		holder = 302985	#fictional Adigh Urulchiq
+		liege = d_gurbantunggut
+	}
+	879.1.23 = {
+		holder = 302986	#fictional Atral Urulchiq
+	}
+	1060.2.23 = {
+		holder = 302987	#fictional MA_nglik Urulchiq
+	}
+	1082.8.13 = {
+		holder = 302989	#fictional Qutlugh Urulchiq
+	}
+	1109.6.14 = {
+		holder = 302991	#fictional KO_nC_ek Urulchiq
+	}
+	1139.4.5 = {
+		holder = 302992	#fictional Sokal Urulchiq
+	}
+	1149.3.16 = {
+		holder = 302993	#fictional Qutlugh Urulchiq
+	}
+	1191.2.14 = {
+		holder = 302994	#fictional Barchuq Urulchiq
+	}
+}
+
+
+c_jie_DZU = {
+	#Uyghur Qocho kingdom
+	866.10.1 = {
+		holder = 302985	#fictional Adigh Urulchiq
+		liege = d_gurbantunggut
+	}
+	879.1.23 = {
+		holder = 302986	#fictional Atral Urulchiq
+	}
+	1060.2.23 = {
+		holder = 302987	#fictional MA_nglik Urulchiq
+	}
+	1082.8.13 = {
+		holder = 302989	#fictional Qutlugh Urulchiq
+	}
+	1109.6.14 = {
+		holder = 302991	#fictional KO_nC_ek Urulchiq
+	}
+	1139.4.5 = {
+		holder = 302992	#fictional Sokal Urulchiq
+	}
+	1149.3.16 = {
+		holder = 302993	#fictional Qutlugh Urulchiq
+	}
+	1191.2.14 = {
+		holder = 302994	#fictional Barchuq Urulchiq
+	}
+}
+
+
+d_naiman_gobi = {
+	#Naimans
+	1058.6.10 = {
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+
+	#End of Liao Dynasty
+	1125.3.26 = {
+		liege = 0
+	}
+	1130.1.1 = {
+		de_jure_liege = k_naiman
+	}
+	1131.1.1 = {
+		liege = k_naiman
+	}
+
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = 303318		#fictional Altan Buku
+	}
+	1187.6.16 = {
+		holder = 303319		#fictional Tooril Buku
+	}
+}
+
+
+c_balgun = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+	861.1.1 = {
+		holder = fictional_kirghiz_1
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	#Naimans
+	1058.6.10 = {
+		liege = d_naiman_gobi
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = 303318		#fictional Altan Buku
+	}
+	1187.6.16 = {
+		holder = 303319		#fictional Tooril Buku
+	}
+}
+
+c_kabtag = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+	861.1.1 = {
+		holder = fictional_kirghiz_1
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	#Naimans
+	1058.6.10 = {
+		liege = d_naiman_gobi
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = 303318		#fictional Altan Buku
+	}
+	1187.6.16 = {
+		holder = 303319		#fictional Tooril Buku
+	}
+}
+
+
+c_kara_asirgan = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+	850.1.1 = {
+		holder = 217173
+	}
+	876.1.4 = {
+		holder = 303003	#fictional C_or Bügün
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+	#Naimans
+	1058.6.10 = {
+		liege = d_naiman_gobi
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = 303318		#fictional Altan Buku
+	}
+	1187.6.16 = {
+		holder = 303319		#fictional Tooril Buku
+	}
+}
+
+
+c_boro_burgasu = {
+	#Kirghiz khanate
+	840.1.2 = {
+		liege = e_kirghiz_khanate
+	}
+	850.1.1 = {
+		holder = 217173
+	}
+	876.1.4 = {
+		holder = 303003	#fictional C_or Bügün
+	}
+
+	#End of Kirghiz Khanate
+	925.1.2 = {
+		liege = 0
+	}
+
+
+	#Naimans
+	1058.6.10 = {
+		liege = d_naiman_gobi
+		holder = 303314		#fictional Jamuqa Buku
+	}
+	1084.9.11 = {
+		holder = 303315		#fictional Tooril buku
+	}
+	1119.7.18 = {
+		holder = 303316		#fictional Daaritai Buku
+	}
+	1132.1.26 = {
+		holder = 303317		#fictional Buyimur Buku
+	}
+	1157.9.3 = {
+		holder = fictional_naimans_9	#fictional herder
+		government = herder_government
+		liege = 0
+	}
+	1187.6.16 = {
+		holder = 303319		#fictional Tooril Buku
+		# government = nomad_government
+	}
+}

--- a/history/titles/k_dzungaria.txt
+++ b/history/titles/k_dzungaria.txt
@@ -1117,6 +1117,7 @@ c_qinggil = {
 	}
 	841.1.1 = {
 		holder = fictional_kirghiz_2
+		government = herder_government #Unop Was defaulting to clan; mirror sibling Kirghiz counties
 	}
 
 	#End of Kirghiz Khanate
@@ -1578,6 +1579,7 @@ c_balgun = {
 	}
 	861.1.1 = {
 		holder = fictional_kirghiz_1
+		government = herder_government #Unop Was defaulting to clan; mirror sibling Kirghiz counties
 	}
 
 	#End of Kirghiz Khanate
@@ -1614,6 +1616,7 @@ c_kabtag = {
 	}
 	861.1.1 = {
 		holder = fictional_kirghiz_1
+		government = herder_government #Unop Was defaulting to clan; mirror sibling Kirghiz counties
 	}
 
 	#End of Kirghiz Khanate
@@ -1651,6 +1654,7 @@ c_kara_asirgan = {
 	}
 	850.1.1 = {
 		holder = 217173
+		government = herder_government #Unop Was defaulting to clan; mirror sibling Kirghiz counties
 	}
 	876.1.4 = {
 		holder = 303003	#fictional C_or Bügün


### PR DESCRIPTION
Fixes #536

**fixer:** Two unrelated 867-start government anomalies, both fixed in title history.

**Korea (`history/titles/e_goryeo.txt`):** `c_ulleong`, `c_tamna` and `d_tamna` started feudal — isolated island/peninsula titles with no feudal neighbour, sitting in an otherwise meritocratic region. Changed their 867-era `government` to `tribal_government`, mirroring the nearby deliberate tribal pocket `c_yeongwon` (also a `castle_holding` county, so the setup is proven by precedent). Later meritocratic transitions are left intact.

**Dzungaria (`history/titles/k_dzungaria.txt`):** `c_qinggil`, `c_balgun`, `c_kabtag` — and `c_kara_asirgan`, which has the identical bug though the report named only the first three — were missing a `government` line in their Kirghiz-khanate-era holder block, so they fell back to `clan_government`. Every other independent Kirghiz county here (`c_altay`, `c_burqin`, `c_tengerge`, …) sets `government = herder_government` in that block; added the same line to the four that omitted it.

Tiger surfaced only pre-existing, benign vanilla history quirks in the two newly-added files (character-lifespan mismatches, inert liege references, `e_mongolia` having no title history); these are scoped-ignored in `ck3-tiger.conf`.

Worth verifying in an 867 start that the seven counties show the intended governments.