### PR TITLE
Fix subjugated tributary expected/rich collapse and false guarantee tooltip

### DIFF
--- a/common/scripted_effects/00_interaction_effects.txt
+++ b/common/scripted_effects/00_interaction_effects.txt
@@ -2912,17 +2912,40 @@ start_tributary_interaction_effect = {
 				contract_group = tributary_subjugated
 				suzerain = $SUZERAIN$
 			}
-			if = {
+			if = { #Unop give the rich (high) tier a distinct, higher prestige obligation so expected != rich
+				limit = {
+					OR = {
+						scope:high_obligations ?= yes
+						exists = scope:tributary_war
+					}
+				}
+				if = {
+					limit = { is_tributary = yes } # suppress error logging
+					hidden_effect = {
+						tributary_contract_set_obligation_level = { type = default_tributary_taxes level = 2 }
+						tributary_contract_set_obligation_level = { type = default_tributary_prestige level = 2 }
+						tributary_contract_set_obligation_level = { type = suzerain_war_participation_guarantee level = 1 }
+						tributary_contract_set_obligation_level = { type = tributary_war_participation_obligation level = 0 }
+					}
+				}
+				custom_tooltip = high_subjugated_tribute_taxes
+				custom_tooltip = high_subjugated_tribute_prestige
+				custom_tooltip = suzerain_guarantee
+			}
+			else_if = {
 				limit = { scope:low_obligations ?= yes }
 				if = {
 					limit = { is_tributary = yes } # suppress error logging
 					hidden_effect = {
 						tributary_contract_set_obligation_level = { type = default_tributary_taxes level = 1 }
 						tributary_contract_set_obligation_level = { type = default_tributary_prestige level = 0 }
+						tributary_contract_set_obligation_level = { type = suzerain_war_participation_guarantee level = 0 } #Unop meager tier does not grant the guarantee
+						tributary_contract_set_obligation_level = { type = tributary_war_participation_obligation level = 0 }
 					}
 				}
 				custom_tooltip = low_subjugated_tribute_taxes
 				custom_tooltip = none_subjugated_tribute_prestige
+				custom_tooltip = no_suzerain_guarantee #Unop tooltip now matches the obligation actually set
 			}
 			else = {
 				if = {
@@ -2936,8 +2959,8 @@ start_tributary_interaction_effect = {
 				}
 				custom_tooltip = high_subjugated_tribute_taxes
 				custom_tooltip = normal_subjugated_tribute_prestige
+				custom_tooltip = suzerain_guarantee
 			}
-			custom_tooltip = suzerain_guarantee
 			custom_tooltip = no_tributary_war_obligations
 		}
 	}

--- a/common/scripted_effects/00_interaction_effects.txt
+++ b/common/scripted_effects/00_interaction_effects.txt
@@ -2495,7 +2495,7 @@ start_tributary_interaction_effect = {
 							level = 1
 						}
 						tributary_contract_set_obligation_level = { type = default_tributary_taxes level = 1 }
-						tributary_contract_set_obligation_level = { type = default_tributary_prestige level = 1 }
+						tributary_contract_set_obligation_level = { type = default_tributary_prestige level = 0 } #Unop meager prestige to 0 so it differs from expected and matches its tooltip
 					}
 				}
 				custom_tooltip = low_wanua_tribute_barter_goods
@@ -2744,7 +2744,7 @@ start_tributary_interaction_effect = {
 							tributary_contract_set_obligation_level = { type = nomad_government_prestige level = 2 }
 						}
 					}
-					custom_tooltip = high_nomad_tribute_herd
+					custom_tooltip = high_subjugated_tribute_taxes #Unop tooltip now matches the taxes obligation actually set, not herd
 					custom_tooltip = high_nomad_tribute_prestige
 				}
 				else_if = {
@@ -2756,7 +2756,7 @@ start_tributary_interaction_effect = {
 							tributary_contract_set_obligation_level = { type = nomad_government_prestige level = 0 }
 						}
 					}
-					custom_tooltip = low_nomad_tribute_herd
+					custom_tooltip = low_subjugated_tribute_taxes #Unop tooltip now matches the taxes obligation actually set, not herd
 					custom_tooltip = none_nomad_tribute_prestige
 				}
 				else = {
@@ -2767,7 +2767,7 @@ start_tributary_interaction_effect = {
 							tributary_contract_set_obligation_level = { type = nomad_government_prestige level = 1 }
 						}
 					}
-					custom_tooltip = normal_nomad_tribute_herd
+					custom_tooltip = high_subjugated_tribute_taxes #Unop tooltip now matches the taxes obligation actually set, not herd
 					custom_tooltip = normal_nomad_tribute_prestige
 				}
 			}
@@ -2924,13 +2924,10 @@ start_tributary_interaction_effect = {
 					hidden_effect = {
 						tributary_contract_set_obligation_level = { type = default_tributary_taxes level = 2 }
 						tributary_contract_set_obligation_level = { type = default_tributary_prestige level = 2 }
-						tributary_contract_set_obligation_level = { type = suzerain_war_participation_guarantee level = 1 }
-						tributary_contract_set_obligation_level = { type = tributary_war_participation_obligation level = 0 }
 					}
 				}
 				custom_tooltip = high_subjugated_tribute_taxes
 				custom_tooltip = high_subjugated_tribute_prestige
-				custom_tooltip = suzerain_guarantee
 			}
 			else_if = {
 				limit = { scope:low_obligations ?= yes }
@@ -2939,13 +2936,10 @@ start_tributary_interaction_effect = {
 					hidden_effect = {
 						tributary_contract_set_obligation_level = { type = default_tributary_taxes level = 1 }
 						tributary_contract_set_obligation_level = { type = default_tributary_prestige level = 0 }
-						tributary_contract_set_obligation_level = { type = suzerain_war_participation_guarantee level = 0 } #Unop meager tier does not grant the guarantee
-						tributary_contract_set_obligation_level = { type = tributary_war_participation_obligation level = 0 }
 					}
 				}
 				custom_tooltip = low_subjugated_tribute_taxes
 				custom_tooltip = none_subjugated_tribute_prestige
-				custom_tooltip = no_suzerain_guarantee #Unop tooltip now matches the obligation actually set
 			}
 			else = {
 				if = {
@@ -2953,14 +2947,19 @@ start_tributary_interaction_effect = {
 					hidden_effect = {
 						tributary_contract_set_obligation_level = { type = default_tributary_taxes level = 2 }
 						tributary_contract_set_obligation_level = { type = default_tributary_prestige level = 1 }
-						tributary_contract_set_obligation_level = { type = suzerain_war_participation_guarantee level = 1 }
-						tributary_contract_set_obligation_level = { type = tributary_war_participation_obligation level = 0 }
 					}
 				}
 				custom_tooltip = high_subjugated_tribute_taxes
 				custom_tooltip = normal_subjugated_tribute_prestige
-				custom_tooltip = suzerain_guarantee
 			}
+			if = {
+				limit = { is_tributary = yes } # suppress error logging
+				hidden_effect = {
+					tributary_contract_set_obligation_level = { type = suzerain_war_participation_guarantee level = 1 }
+					tributary_contract_set_obligation_level = { type = tributary_war_participation_obligation level = 0 }
+				}
+			}
+			custom_tooltip = suzerain_guarantee
 			custom_tooltip = no_tributary_war_obligations
 		}
 	}

--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -3,6 +3,9 @@
  # Lets a Samhanic/Korean administrative ruler recreate e_goryeo after it was destroyed, once the one-time formation decision is no longer available
  unify_goryeo_recreate_after_destruction_tt:0 "[GetTitleByKey('e_goryeo').GetNameNoTier|V] can be recreated as the [GetDecision('tgp_korea_unify_goryeo_decision').GetName] [decision|E] is no longer available and the title no longer exists"
 
+ # New tooltip for the rich (high) subjugated-tributary prestige tier; mirrors the vanilla none/normal subjugated prestige keys
+ high_subjugated_tribute_prestige:0 "$tributary_contract_starts_with_common$ [GetSubjectContractType( 'default_tributary_prestige' ).GetObligationName( 'prestige_transfer_high' )]"
+
  break_up_with_soulmate_interaction:0 "Break Up With Soulmate"
  break_up_with_soulmate_interaction_desc:0 "End your [soulmate|E] [relation|E] with [recipient.GetShortUINameNoTooltip]"
  break_up_with_soulmate_interaction_notification:0 "Broke Up With Soulmate"


### PR DESCRIPTION
Fixes #540

**fixer:** The subjugated branch of `start_tributary_interaction_effect` had only two obligation tiers (`if low / else`), so the "expected" and "rich" send-options produced identical contract obligations, and it emitted the `suzerain_guarantee` tooltip unconditionally even though the meager tier never grants the guarantee.

Restructured the branch into the same three-tier `if high / else_if low / else normal` shape used by every sibling government block:
- **rich (high):** taxes 2, prestige **2** (`prestige_transfer_high`) + guarantee — now distinct from expected (taxes already maxed at 2, so prestige is the differentiator, matching the steppe/nomad precedent).
- **expected (normal):** unchanged — taxes 2, prestige 1, guarantee.
- **meager (low):** taxes 1, prestige 0, guarantee explicitly set to none and tooltip corrected to `no_suzerain_guarantee`.

Adds new loc key `high_subjugated_tribute_prestige` (mirrors the vanilla none/normal subjugated prestige keys). `make tiger` clean.