### PR TITLE
Allow recreating e_goryeo after destruction once formation decision is consumed

### DIFF
--- a/common/landed_titles/05_goryeo.txt
+++ b/common/landed_titles/05_goryeo.txt
@@ -18,9 +18,19 @@ e_goryeo = {
 					}
 				}
 			}
-			custom_tooltip = {
-				text = unify_goryeo_decision_requirement_tt
-				NOT = { government_allows = administrative }
+			OR = { #Unop also allow recreation after e_goryeo is destroyed, once the one-time formation decision is gone
+				custom_tooltip = {
+					text = unify_goryeo_decision_requirement_tt
+					NOT = { government_allows = administrative }
+				}
+				custom_description = {
+					text = unify_goryeo_recreate_after_destruction_tt
+					NOT = { exists = title:e_goryeo.holder }
+					is_target_in_global_variable_list = {
+						name = unavailable_unique_decisions
+						target = flag:unify_goryeo_decision
+					}
+				}
 			}
 		}
 	}

--- a/common/landed_titles/05_goryeo.txt
+++ b/common/landed_titles/05_goryeo.txt
@@ -1,0 +1,1176 @@
+﻿@correct_culture_primary_score = 100
+@better_than_the_alternatives_score = 50
+@always_primary_score = 1000
+@never_primary_score = -1000
+
+e_goryeo = {
+	color = { 220 205 250 }
+
+	capital = c_gaeseong
+
+	can_create = {
+		trigger_if = {
+			limit = {
+				culture = {
+					OR = {
+						has_cultural_pillar = heritage_korean
+						any_parent_culture = { has_cultural_pillar = heritage_korean }
+					}
+				}
+			}
+			custom_tooltip = {
+				text = unify_goryeo_decision_requirement_tt
+				NOT = { government_allows = administrative }
+			}
+		}
+	}
+
+	# Ceremonial Liege/Regent in personal relation summary
+	#
+	# Scopes
+	# ------
+	# root: Inspected character (who holds this title).
+	# target: Character we are evaluating relationships to (usually local player).
+	# title: This title (held by inspected character).
+	# liege: Inspected characters liege.
+	# vassal: Vassal who matches the trigger below, if any.
+	#
+	# Alternate descriptions are provided to trim the extra "Your" before this entry in the summary.
+	#
+	personal_relation_entry = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					exists = scope:target
+					scope:vassal ?= scope:target
+				}
+				desc = japan_personal_relation_ceremonial_regent_same
+			}
+			triggered_desc = {
+				trigger = { exists = scope:vassal }
+				desc = japan_personal_relation_ceremonial_regent_other
+			}
+		}
+	}
+	personal_relation_vassal = {
+		has_title = title:k_yongson_throne
+	}
+	
+	k_goguryeo = {
+		color = { 55 85 190 }
+
+		capital = c_seogyeong
+
+		cultural_names = {
+			name_list_yamato = cn_koma
+			name_list_emishi = cn_koma
+		}
+
+		can_create = {
+			# Cannot be created by Goryeo after it is formed
+			custom_tooltip = {
+				text = unify_goryeo_decision_blocker_tt
+				NOT = {
+					top_liege = {
+						has_title = title:e_goryeo
+						has_government = meritocratic_government
+					}
+				}
+			}
+		}
+		
+		d_gaeseong = {
+			color = { 75 105 210 }
+
+			capital = c_gaeseong
+
+			c_gaeseong = {
+				color = { 90 120 225 }
+
+				b_Goryeo_Gaeseong_Gaeseong = {
+					province = 9906
+
+					color = { 90 120 225 }
+				}
+				b_Goryeo_Gaeseong_Tosan = {
+					province = 9905
+
+					color = { 90 120 225 }
+				}
+				b_Goryeo_Gaeseong_Chuiljeon = {
+					province = 9907
+
+					color = { 90 120 225 }
+				}
+				b_Goryeo_Yanggwan_Ganghwa = {
+					province = 9945
+
+					color = { 90 120 225 }
+				}
+			}
+			
+			c_gokju = {
+				color = { 55 90 225 }
+
+				b_Goryeo_Seohae_Gokju = {
+					province = 9911
+
+					color = { 55 90 225 }
+				}
+				b_Goryeo_Seohae_Suan = {
+					province = 9909
+
+					color = { 55 90 225 }
+				}
+				b_Goryeo_Seohae_Tosan = {
+					province = 9908
+
+					color = { 55 90 225 }
+				}
+				b_Goryeo_Seohae_Sineun = {
+					province = 9910
+
+					color = { 55 90 225 }
+				}
+			}
+			
+			c_pyeongju = {
+				color = { 100 125 210 }
+
+				b_Goryeo_Seohae_Pyeongju = {
+					province = 9922
+
+					color = { 100 125 210 }
+				}
+				b_Goryeo_Seohae_Dongju = {
+					province = 9915
+
+					color = { 120 225 230 }
+				}
+			}
+		}
+		
+		d_haeju = {
+			color = { 21 166 173 }
+
+			capital = c_haeju
+
+			c_haeju = {
+				color = { 51 186 193 }
+
+				b_Goryeo_Seohae_Haeju = {
+					province = 9919
+
+					color = { 51 186 193 }
+				}
+				b_Goryeo_Seohae_Ongjin = {
+					province = 9920
+
+					color = { 51 186 193 }
+				}
+				b_Goryeo_Seohae_Yeomju = {
+					province = 9921
+
+					color = { 100 125 210 }
+				}
+			}
+			
+			c_hwangju = {
+				color = { 120 225 230 }
+
+				b_Goryeo_Seohae_Hwangju = {
+					province = 9912
+
+					color = { 120 225 230 }
+				}
+				b_Goryeo_Seohae_Anak = {
+					province = 9913
+
+					color = { 120 225 230 }
+				}
+				b_Goryeo_Seohae_Bongju = {
+					province = 9914
+
+					color = { 120 225 230 }
+				}
+			}
+
+			c_pungju = {
+				color = { 20 205 215 }
+
+				b_Goryeo_Seohae_Pungju = {
+					province = 9916
+
+					color = { 20 205 215 }
+				}
+				b_Goryeo_Seohae_Jangyeon = {
+					province = 9917
+
+					color = { 20 205 215 }
+				}
+				b_Goryeo_Seohae_Cheongsong = {
+					province = 9918
+
+					color = { 20 205 215 }
+				}
+			}
+		}
+		
+		d_gyoju = {
+			color = { 50 120 225 }
+
+			capital = c_gyoju
+
+			c_gyoju = {
+				color = { 70 140 245 }
+
+				b_Goryeo_Gyoju_Gyoju = {
+					province = 9873
+
+					color = { 70 140 245 }
+				}
+				b_Goryeo_Gyoju_Geumseong = {
+					province = 9874
+
+					color = { 70 140 245 }
+				}
+				b_Goryeo_Gyoju_Nangcheon = {
+					province = 9875
+
+					color = { 70 140 245 }
+				}
+			}
+			
+			c_inje = {
+				color = { 95 155 250 }
+
+				b_Goryeo_Gyoju_Inje = {
+					province = 9870
+
+					color = { 95 155 250 }
+				}
+				b_Goryeo_Gyoju_Yanggu = {
+					province = 9872
+
+					color = { 95 155 250 }
+				}
+			}
+			
+			c_dongju = {
+				color = { 30 115 240 }
+
+				b_Goryeo_Gyoju_Dongju = {
+					province = 9879
+
+					color = { 30 115 240 }
+				}
+				b_Goryeo_Gyoju_Pyeonggang = {
+					province = 9876
+
+					color = { 30 115 240 }
+				}
+				b_Goryeo_Gyoju_Icheon = {
+					province = 9877
+
+					color = { 30 115 240 }
+				}
+				b_Goryeo_Gyoju_Anhyeop = {
+					province = 9878
+
+					color = { 30 115 240 }
+				}
+			}
+
+			c_chunju = {
+				color = { 30 90 170 }
+
+				b_Goryeo_Gyoju_Chunju = {
+					province = 9880
+
+					color = { 30 90 170 }
+				}
+				b_Goryeo_Gyoju_Hoengcheon = {
+					province = 9881
+
+					color = { 30 90 170 }
+				}
+				b_Goryeo_Gyoju_Hongcheon = {
+					province = 9882
+
+					color = { 30 90 170 }
+				}
+			}
+		}
+		
+		d_yukju = {
+			color = { 30 40 145 }
+
+			capital = c_jangjeong
+
+			c_jangjeong = {
+				color = { 35 35 120 }
+
+				b_Goryeo_Bukgye_Jangjeong = {
+					province = 9887
+
+					color = { 35 35 120 }
+				}
+				b_Goryeo_Bukgye_Sakju = {
+					province = 9888
+
+					color = { 35 35 120 }
+				}
+				b_FIC_EMan_Bao = {
+					province = 12454
+
+					color = { 35 35 120 }
+				}
+			}
+
+			c_uiju = {
+				color = { 60 60 130 }
+
+				b_Goryeo_Bukgye_Uiju = {
+					province = 9889
+
+					color = { 60 60 130 }
+				}
+				b_Goryeo_Bukgye_Cheolju = {
+					province = 9890
+
+					color = { 60 60 130 }
+				}
+			}
+			
+			c_gwiju = {
+				color = { 40 45 170 }
+
+				b_Goryeo_Bukgye_Gwiju = {
+					province = 9891
+
+					color = { 40 45 170 }
+				}
+				b_Goryeo_Bukgye_Seonju = {
+					province = 9892
+
+					color = { 40 45 170 }
+				}
+				b_Goryeo_Bukgye_Gaju = {
+					province = 9893
+
+					color = { 40 45 170 }
+				}
+			}
+
+			c_taeju = {
+				color = { 30 35 220 }
+
+				b_Goryeo_Bukgye_Taeju = {
+					province = 9894
+
+					color = { 30 35 220 }
+				}
+				b_Goryeo_Bukgye_Sukju = {
+					province = 9895
+
+					color = { 30 35 220 }
+				}
+				b_Goryeo_Bukgye_Wiju = {
+					province = 9896
+
+					color = { 30 35 220 }
+				}
+			}
+		}
+		
+		d_bukgye = {
+			color = { 160 72 175 }
+
+			capital = c_seogyeong
+			
+			c_seogyeong = {
+				color = { 135 42 169 }
+
+				b_Goryeo_Bukgye_Seogyeong = {
+					province = 9899
+
+					color = { 135 42 169 }
+				}
+				b_Goryeo_Bukgye_Tonghae = {
+					province = 9900
+
+					color = { 135 42 169 }
+				}
+				b_Goryeo_Bukgye_Samhwa = {
+					province = 9897
+
+					color = { 135 42 169 }
+				}
+				b_Goryeo_Bukgye_Yonggang = {
+					province = 9898
+
+					color = { 135 42 169 }
+				}
+			}
+
+			c_seongju = {
+				color = { 180 92 195 }
+
+				b_Goryeo_Bukgye_Seongju = {
+					province = 9902
+
+					color = { 180 92 195 }
+				}
+				b_Goryeo_Bukgye_Jaju = {
+					province = 9901
+
+					color = { 180 92 195 }
+				}
+				b_Goryeo_Bukgye_Yangam = {
+					province = 9903
+
+					color = { 180 92 195 }
+				}
+				b_Goryeo_Bukgye_Isan = {
+					province = 9904
+
+					color = { 180 92 195 }
+				}
+			}
+			
+			c_yeongwon = {
+				color = { 155 100 165 }
+
+				b_Goryeo_Bukgye_Yeongwon = {
+					province = 9883
+
+					color = { 155 100 165 }
+				}
+				b_Goryeo_Bukgye_Muju = {
+					province = 9884
+
+					color = { 155 100 165 }
+				}
+				b_Goryeo_Bukgye_Deokju = {
+					province = 9885
+
+					color = { 155 100 165 }
+				}
+				b_Goryeo_Bukgye_Maengju = {
+					province = 9886
+
+					color = { 155 100 165 }
+				}
+			}
+		}
+		
+		d_gwangju = {
+			color = { 115 172 174 }
+
+			capital = c_gwangju
+
+			c_gwangju = {
+				color = { 135 192 194 }
+
+				b_Goryeo_Yanggwan_Gwangju = {
+					province = 9939
+
+					color = { 135 192 194 }
+				}
+				b_Goryeo_Yanggwan_Yanggeun = {
+					province = 9928
+
+					color = { 105 190 205 }
+				}
+				b_Goryeo_Yanggwan_Cheonyeong = {
+					province = 9929
+
+					color = { 105 190 205 }
+				}
+			}
+
+			c_yangju = {
+				color = { 135 192 194 }
+
+				b_Goryeo_Yanggwan_Yangju = {
+					province = 9925
+
+					color = { 135 192 194 }
+				}
+				b_Goryeo_Yanggwan_Gyeonju = {
+					province = 9924
+
+					color = { 135 192 194 }
+				}
+				b_Goryeo_Yanggwan_Poju = {
+					province = 9923
+
+					color = { 135 192 194 }
+				}
+			}
+
+			c_dangseong = {
+				color = { 120 185 175 }
+
+				b_Goryeo_Yanggwan_Dangseong = {
+					province = 9946
+
+					color = { 120 185 175 }
+				}
+				b_Goryeo_Yanggwan_Anseong = {
+					province = 9948
+
+					color = { 120 185 175 }
+				}
+				b_Goryeo_Yanggwan_Jukju = {
+					province = 9947
+
+					color = { 120 185 175 }
+				}
+			}
+		}
+	}
+	
+	k_silla = {
+		color = { 120 45 40 }
+
+		capital = c_gyeongju
+
+		cultural_names = {
+			name_list_yamato = cn_shiragi
+			name_list_emishi = cn_shiragi
+		}
+
+		can_create = {  
+			# Cannot be created by Goryeo after it is formed
+			custom_tooltip = {
+				text = unify_goryeo_decision_blocker_tt
+				NOT = {
+					top_liege = {
+						has_title = title:e_goryeo
+						has_government = meritocratic_government
+					}
+				}
+			}
+		}
+		
+		d_gyeongju = {
+			color = { 135 60 55 }
+
+			capital = c_gyeongju
+
+			c_gyeongju = {
+				color = { 150 75 70 }
+
+				b_Goryeo_Gyeongsang_Gyeongju = {
+					province = 9973
+
+					color = { 150 75 70 }
+				}
+				b_Goryeo_Gyeongsang_Janggi = {
+					province = 9970
+
+					color = { 150 75 70 }
+				}
+				b_Goryeo_Gyeongsang_Yeju = {
+					province = 9972
+
+					color = { 150 75 70 }
+				}
+			}
+
+			c_andong = {
+				color = { 205 125 115 }
+
+				b_Goryeo_Gyeongsang_Andong = {
+					province = 9979
+
+					color = { 205 125 115 }
+				}
+				b_Goryeo_Gyeongsang_Sunan = {
+					province = 9978
+
+					color = { 205 125 115 }
+				}
+				b_Goryeo_Gyeongsang_Jaesan = {
+					province = 9977
+
+					color = { 205 125 115 }
+				}
+			}
+
+			c_sangju = {
+				color = { 235 90 80 }
+
+				b_Goryeo_Gyeongsang_Sangju = {
+					province = 9984
+
+					color = { 235 90 80 }
+				}
+				b_Goryeo_Gyeongsang_Dain = {
+					province = 9985
+
+					color = { 235 90 80 }
+				}
+				b_Goryeo_Gyeongsang_Giju = {
+					province = 9986
+
+					color = { 235 90 80 }
+				}
+			}
+
+			c_ilseon = {
+				color = { 180 60 55 }
+
+				b_Goryeo_Gyeongsang_Ilseon = {
+					province = 9991
+
+					color = { 180 60 55 }
+				}
+				b_Goryeo_Gyeongsang_Gaeryeong = {
+					province = 9992
+
+					color = { 180 60 55 }
+				}
+				b_Goryeo_Gyeongsang_Yeongju = {
+					province = 9993
+
+					color = { 180 60 55 }
+				}
+			}
+		}
+		
+		d_jinju = {
+			color = { 52 15 8 }
+
+			capital = c_jinju
+			
+			c_jinju = {
+				color = { 70 35 28 }
+				
+				b_Goryeo_Gyeongsang_Jinju = {
+					province = 9981
+
+					color = { 70 35 28 }
+				}
+				b_Goryeo_Gyeongsang_Hadong = {
+					province = 9980
+
+					color = { 70 35 28 }
+				}
+				b_Goryeo_Gyeongsang_Geoje = {
+					province = 9982
+
+					color = { 70 35 28 }
+				}
+			}
+
+			c_ulju = {
+				color = { 80 20 10 }
+
+				b_Goryeo_Gyeongsang_Ulju = {
+					province = 9974
+
+					color = { 80 20 10 }
+				}
+				b_Goryeo_Gyeongsang_Gijang = {
+					province = 9975
+
+					color = { 80 20 10 }
+				}
+				b_Goryeo_Gyeongsang_Milseong = {
+					province = 9976
+
+					color = { 80 20 10 }
+				}
+			}
+			
+			c_hamyang = {
+				color = { 70 55 50 }
+
+				b_Goryeo_Gyeongsang_Hamyang = {
+					province = 9987
+
+					color = { 70 55 50 }
+				}
+				b_Goryeo_Gyeongsang_Geochang = {
+					province = 9988
+
+					color = { 70 55 50 }
+				}
+				b_Goryeo_Gyeongsang_Gyeongsanbu = {
+					province = 9989
+
+					color = { 70 55 50 }
+				}
+				b_Goryeo_Gyeongsang_Hapcheon = {
+					province = 9990
+
+					color = { 70 55 50 }
+				}
+			}
+			
+			c_guemju = {
+				color = { 80 45 15 }
+
+				b_Goryeo_Gyeongsang_Guemju = {
+					province = 9995
+
+					color = { 80 45 15 }
+				}
+				b_Goryeo_Gyeongsang_Yeongsan = {
+					province = 9994
+
+					color = { 80 45 15 }
+				}
+			}
+		}
+		
+		d_donggye = {
+			color = { 178 69 17 }
+
+			capital = c_myeongju
+
+			c_myeongju = {
+				color = { 160 45 5 }
+
+				b_Goryeo_Donggye_Myeongju = {
+					province = 9858
+
+					color = { 160 45 5 }
+				}
+				b_Goryeo_Donggye_Samcheok = {
+					province = 9859
+
+					color = { 160 45 5 }
+				}
+				b_Goryeo_Donggye_Ingnyeong = {
+					province = 9860
+
+					color = { 160 45 5 }
+				}
+				b_Goryeo_Gyeongsang_Uljin = {
+					province = 9971
+
+					color = { 150 75 70 }
+				}
+			}
+
+			c_goseong = {
+				color = { 136 81 19 }
+
+				b_Goryeo_Donggye_Goseong = {
+					province = 9862
+
+					color = { 136 81 19 }
+				}
+				b_Goryeo_Donggye_Ganseong = {
+					province = 9861
+
+					color = { 136 81 19 }
+				}
+				b_Goryeo_Donggye_Tongcheon = {
+					province = 9863
+
+					color = { 136 81 19 }
+				}
+				b_Goryeo_Donggye_Heupgok = {
+					province = 9864
+
+					color = { 136 81 19 }
+				}
+			}
+
+			c_deungju = {
+				color = { 170 125 15 }
+
+				b_Goryeo_Donggye_Deungju = {
+					province = 9865
+
+					color = { 170 125 15 }
+				}
+				b_Goryeo_Donggye_Yeju = {
+					province = 9868
+
+					color = { 170 125 15 }
+				}
+				b_Goryeo_Donggye_Uiju = {
+					province = 9866
+
+					color = { 170 125 15 }
+				}
+				b_Goryeo_Donggye_Hwaju = {
+					province = 9867
+
+					color = { 170 125 15 }
+ 				}
+			}
+
+			c_wonju = {
+				color = { 105 190 205 }
+
+				b_Goryeo_Yanggwan_Wonju = {
+					province = 9926
+
+					color = { 105 190 205 }
+				}
+				b_Goryeo_Yanggwan_Yeongwol = {
+					province = 9931
+
+					color = { 115 85 10 }
+				}
+				b_Goryeo_Yanggwan_Pyeongchang = {
+					province = 9930
+
+					color = { 115 85 10 }
+				}
+				b_Goryeo_Yanggwan_Jecheon = {
+					province = 9932
+
+					color = { 115 85 10 }
+				}
+				b_Goryeo_Gyoju_Girin = {
+					province = 9871
+
+					color = { 115 85 10 }
+				}
+			}
+
+			c_ulleong = {
+				color = { 120 110 45 }
+
+				b_Goryeo_Donggye_Ulleung = {
+					province = 9869
+
+				    color = { 120 110 45 }
+				}
+			}
+		}
+	}
+	
+	k_baekje = {
+		color = { 90 160 115 }
+
+		capital = c_jeonju
+
+		cultural_names = {
+			name_list_yamato = cn_kudara
+			name_list_emishi = cn_kudara
+		}
+
+		can_create = {
+			# Cannot be created by Goryeo after it is formed
+			custom_tooltip = {
+				text = unify_goryeo_decision_blocker_tt
+				NOT = {
+					top_liege = {
+						has_title = title:e_goryeo
+						has_government = meritocratic_government
+					}
+				}
+			}
+		}
+		
+		d_chungju = {
+			color = { 13 150 65 }
+
+			capital = c_chungju
+
+			c_chungju = {
+				color = { 33 170 85 }
+
+				b_Goryeo_Yanggwan_Chungju = {
+					province = 9933
+
+					color = { 33 170 85 }
+				}
+				b_Goryeo_Yanggwan_Goeju = {
+					province = 9934
+
+					color = { 33 170 85 }
+				}
+				b_Goryeo_Yanggwan_Jangyeon = {
+					province = 9935
+
+					color = { 33 170 85 }
+				}
+				b_Goryeo_Gyeongsang_Boryeong = {
+					province = 9983
+
+					color = { 33 170 85 }
+				}
+			}
+
+			c_hongju = {
+				color = { 40 135 100 }
+
+				b_Goryeo_Yanggwan_Hongju = {
+					province = 9943
+
+					color = { 40 135 100 }
+				}
+				b_Goryeo_Yanggwan_Buseong = {
+					province = 9942
+
+					color = { 40 135 100 }
+				}
+			}
+
+			c_gongju = {
+				color = { 60 115 80 }
+
+				b_Goryeo_Yanggwan_Gongju = {
+					province = 9937
+
+					color = { 9 150 95 }
+				}
+				b_Goryeo_Yanggwan_Nampo = {
+					province = 9941
+
+					color = { 40 135 100 }
+				}
+				b_Goryeo_Yanggwan_Cheonan = {
+					province = 9927
+
+					color = { 40 135 100 }
+				}
+				b_Goryeo_Yanggwan_Yesan = {
+					province = 9944
+
+					color = { 40 135 100 }
+				}
+			}
+
+			c_cheongju = {
+				color = { 9 150 95 }
+
+				b_Goryeo_Yanggwan_Cheongju = {
+					province = 9936
+
+					color = { 9 150 95 }
+				}
+				b_Goryeo_Yanggwan_Yeonsan = {
+					province = 9938
+
+					color = { 9 150 95 }
+				}
+				b_Goryeo_Yanggwan_Seorim = {
+					province = 9940
+
+					color = { 9 150 95 }
+				}
+			}
+		}
+		
+		d_naju = {
+            color = { 25 100 5 }
+
+            capital = c_naju
+
+			c_naju = {
+				color = { 45 120 25 }
+
+				b_Goryeo_Jeolla_Naju = {
+					province = 9949
+
+					color = { 45 120 25 }
+				}
+				b_Goryeo_Jeolla_Yeongam = {
+					province = 9950
+
+					color = { 45 120 25 }
+				}
+				b_Goryeo_Jeolla_Neungseong = {
+					province = 9966
+
+					color = { 45 120 25 }
+				}
+				b_Goryeo_Jeolla_Haeyang = {
+					province = 9967
+
+					color = { 45 120 25 }
+				}
+			}
+
+			c_jangheung = {
+				color = { 40 150 10 }
+
+				b_Goryeo_Jeolla_Jangheung = {
+					province = 9954
+
+					color = { 40 150 10 }
+				}
+				b_Goryeo_Jeolla_Donggang = {
+					province = 9955
+
+					color = { 40 150 10 }
+				}
+				b_Goryeo_Jeolla_Jindo = {
+					province = 9956
+
+					color = { 40 150 10 }
+				}
+			}
+
+			c_boseong = {
+				color = { 120 215 60 }
+
+				b_Goryeo_Jeolla_Boseong = {
+					province = 9964
+
+					color = { 120 215 60 }
+				}
+				b_Goryeo_Jeolla_Seungpyeong = {
+					province = 9963
+
+					color = { 120 215 60 }
+				}
+				b_Goryeo_Jeolla_Namyang = {
+					province = 9965
+
+					color = { 120 215 60 }
+				}
+			}
+		}
+
+		d_tamna = {
+            color = { 45 245 135 }
+
+            capital = c_tamna
+
+			c_tamna = {
+				color = { 45 245 135 }
+
+				b_Goryeo_Tamna_Tamna = {
+					province = 9856
+
+					color = { 45 245 135 }
+				}
+				b_Goryeo_Tamna_WestTamna = {
+					province = 9969
+
+					color = { 45 245 135 }
+				}
+			}
+		}
+		
+		d_jeonju = {
+			color = { 30 90 70 }
+
+			capital = c_jeonju
+			
+			c_jeonju = {
+				color = { 50 110 90 }
+
+				b_Goryeo_Jeolla_Jeonju = {
+					province = 9953
+
+					color = { 50 110 90 }
+				}
+				b_Goryeo_Jeolla_Yeonggwang = {
+					province = 9951
+
+					color = { 50 110 90 }
+				}
+				b_Goryeo_Jeolla_Gangseong = {
+					province = 9952
+
+					color = { 50 110 90 }
+				}
+			}
+			
+			c_jillye = {
+				color = { 25 65 40 }
+
+				b_Goryeo_Jeolla_Jillye = {
+					province = 9958
+
+					color = { 25 65 40 }
+				}
+				b_Goryeo_Jeolla_Jindong = {
+					province = 9957
+
+					color = { 25 65 40 }
+				}
+				b_Goryeo_Jeolla_Mupung = {
+					province = 9959
+
+					color = { 25 65 40 }
+				}
+			}
+
+			c_namwon = {
+				color = { 50 70 60 }
+
+				b_Goryeo_Jeolla_Namwon = {
+					province = 9961
+
+					color = { 50 70 60 }
+				}
+				b_Goryeo_Jeolla_Imsil = {
+					province = 9962
+
+					color = { 50 70 60 }
+				}
+				b_Goryeo_Jeolla_Jinan = {
+					province = 9960
+
+					color = { 50 70 60 }
+				}
+			}
+		}
+	}
+}
+
+# Korean King
+k_yongson_throne = {
+	color = { 220 205 250 }
+
+	capital = c_gaeseong
+	can_be_named_after_dynasty = no
+	landless = yes
+	figurehead = yes
+	allow_domicile = no
+	always_follows_primary_heir = yes
+	definite_form = yes
+
+	can_create = { always = no }
+
+	# Ceremonial Liege/Regent in personal relation summary
+	# (reminder: the ceremonial liege if mechanically a vassal of the ceremonial regent)
+	#
+	# Scopes
+	# ------
+	# root: Inspected character (who holds this title).
+	# target: Character we are evaluating relationships to (usually local player).
+	# title: This title (held by inspected character).
+	# liege: Inspected characters liege.
+	# vassal: Vassal who matches the trigger below, if any.
+	#
+	# Alternate descriptions are provided to trim the extra "Your" before this entry in the summary.
+	#
+	personal_relation_entry = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					exists = scope:target
+					scope:liege ?= scope:target
+				}
+				desc = japan_personal_relation_ceremonial_liege_same
+			}
+			triggered_desc = {
+				trigger = { exists = scope:liege }
+				desc = japan_personal_relation_ceremonial_liege_other
+			}
+		}
+	}
+
+	ai_primary_priority = {
+		if = {
+			limit = {
+				culture = { has_cultural_pillar = heritage_korean }
+			}
+			add = @correct_culture_primary_score
+		}
+	}
+}

--- a/localization/replace/english/unop_new_keys_l_english.yml
+++ b/localization/replace/english/unop_new_keys_l_english.yml
@@ -1,5 +1,8 @@
 ﻿l_english:
 
+ # Lets a Samhanic/Korean administrative ruler recreate e_goryeo after it was destroyed, once the one-time formation decision is no longer available
+ unify_goryeo_recreate_after_destruction_tt:0 "[GetTitleByKey('e_goryeo').GetNameNoTier|V] can be recreated as the [GetDecision('tgp_korea_unify_goryeo_decision').GetName] [decision|E] is no longer available and the title no longer exists"
+
  break_up_with_soulmate_interaction:0 "Break Up With Soulmate"
  break_up_with_soulmate_interaction_desc:0 "End your [soulmate|E] [relation|E] with [recipient.GetShortUINameNoTooltip]"
  break_up_with_soulmate_interaction_notification:0 "Broke Up With Soulmate"


### PR DESCRIPTION
Fixes #556

**fixer:** `e_goryeo` (Samhan/Goryeo) can only be formed by the one-time `tgp_korea_unify_goryeo_decision`, which permanently removes itself via `unavailable_unique_decisions`. Its `can_create` then blocks the intended formers — a Korean/Samhanic **administrative** ruler — from creating it directly (`NOT = { government_allows = administrative }`). So once the empire is destroyed (e.g. by taking Hegemony of China, as reported), there is no path left to recreate it.

Mirroring the #440 / Germania precedent, this relaxes `e_goryeo.can_create`: an administrative Korean-heritage ruler may now create `e_goryeo` directly **only after** the formation decision is no longer available *and* the title currently has no holder — i.e. exactly the post-destruction lockout. The normal pre-formation flow (use the decision) and its one-time rewards are untouched, and a second concurrent `e_goryeo` is still prevented by the `NOT = { exists = title:e_goryeo.holder }` guard.

Adds vanilla `05_goryeo.txt` (unmodified, separate commit) and a new loc key `unify_goryeo_recreate_after_destruction_tt`. `make tiger` clean.