### PR TITLE
Block Demand Submission or Ruin when target is imprisoned by the actor

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -597,11 +597,6 @@ filter = {
 			text = "expects root to be character but root seems to be faith"
 			file = common/scripted_triggers/07_frankokratia_triggers.txt
 		}
-		NAND = { # Pre-existing vanilla bug: mpo_war_of_defiance_notified_player_trigger uses root as a character but is called from a casus belli on_victory block (09_mpo_wars.txt); a separate fix, out of scope here
-			key = scopes
-			text = "expects root to be character but root seems to be casus belli"
-			file = common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
-		}
 		NAND = { # Ignore scope warnings in event backgrounds, too difficult to fix
 			key = scopes
 			OR = {
@@ -652,6 +647,11 @@ filter = {
 			key = missing-item
 			text = "e_mongolia has no title history"
 			file = history/titles/k_dzungaria.txt
+		}
+		NAND = { # Pre-existing vanilla data quirk: attacker_wargoal_percentage = 1.5 (>1) in a Domination war; unrelated to this fix, clamping it would change war pacing - own issue
+			key = range
+			text = "should be between 0 (inclusive) and 1 (inclusive)"
+			file = common/casus_belli_types/09_mpo_wars.txt
 		}
 	}
 }

--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -648,7 +648,7 @@ filter = {
 			text = "e_mongolia has no title history"
 			file = history/titles/k_dzungaria.txt
 		}
-		NAND = { # Pre-existing vanilla data quirk: attacker_wargoal_percentage = 1.5 (>1) in a Domination war; unrelated to this fix, clamping it would change war pacing - own issue
+		NAND = { # Intended vanilla design: attacker_wargoal_percentage = 1.5 (>1) makes the attacker never tick warscore from occupation; vanilla uses the same value for nomadic conquest CBs (00_nomadic_conquest.txt), so clamping it would change intended war pacing
 			key = range
 			text = "should be between 0 (inclusive) and 1 (inclusive)"
 			file = common/casus_belli_types/09_mpo_wars.txt

--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -597,6 +597,11 @@ filter = {
 			text = "expects root to be character but root seems to be faith"
 			file = common/scripted_triggers/07_frankokratia_triggers.txt
 		}
+		NAND = { # Pre-existing vanilla bug: mpo_war_of_defiance_notified_player_trigger uses root as a character but is called from a casus belli on_victory block (09_mpo_wars.txt); a separate fix, out of scope here
+			key = scopes
+			text = "expects root to be character but root seems to be casus belli"
+			file = common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
+		}
 		NAND = { # Ignore scope warnings in event backgrounds, too difficult to fix
 			key = scopes
 			OR = {

--- a/common/casus_belli_types/09_mpo_wars.txt
+++ b/common/casus_belli_types/09_mpo_wars.txt
@@ -1,0 +1,5758 @@
+﻿#migration_cb
+#mpo_nomad_invasion_cb
+#humiliation_cb
+#retaliation_cb
+#sovereignty_cb
+#mpo_great_war_of_defiance_cb
+#mpo_gok_onslaught_cb
+
+##########
+# Special CB used for migrating
+##########
+
+# Used in code - the only legal way to start a migration war
+#
+migration_cb = {
+	icon = migration_cb
+	group = migration
+
+	allow_hostages = no
+	white_peace_possible = no
+	target_de_jure_regions_above = yes
+	allowed_for_character = {
+		government_has_flag = government_is_nomadic
+	}
+
+	ignore_effect = change_title_holder
+	valid_to_start = { always = no }
+
+	should_invalidate = {}
+
+	on_invalidated_desc = msg_remove_migration_cb_invalidated_message
+
+	cost = {}
+
+	on_declaration = {
+		on_declared_war = yes
+		scope:attacker = {
+			every_in_list = {
+			 	variable = obedient_vassals
+			 	limit = { is_ai = yes }
+				scope:war = { add_attacker = prev }
+			}
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = migration_cb_victory_desc_attacker
+			}
+			desc = migration_cb_victory_desc
+		}
+	}
+
+	on_victory = {
+		scope:attacker = { 
+			save_scope_as = duchy_war
+			show_pow_release_message_effect = yes 
+			if = {
+				limit = {
+					is_ai = yes
+				}
+				set_variable = {
+					name = migration_cooldown
+					years = migration_cooldown_value
+				}
+			}
+		}
+
+		# Legitimacy
+		add_legitimacy_attacker_victory_effect = yes
+
+		#EP2 accolade glory gain for winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+
+		scope:attacker = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_positive" }
+		scope:defender = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_negative" }
+
+		create_title_and_vassal_change = {
+			type = conquest
+			save_scope_as = change
+			add_claim_on_loss = yes
+		}
+
+		# go through the dejure hierarchy under target titles, transfer eligible vassals and sieze counties from ineligible ones
+		every_in_list = {
+			list = target_titles
+			custom_tooltip = MIGRATION_CB_TITLE
+
+			conquest_cb_title_transfer = {
+				RELIGIOUS_WAR = no
+			}
+		}
+
+		show_as_tooltip = {
+			every_in_list = {
+				list = vassals_taken
+				change_liege = {
+					liege = scope:attacker
+					change = scope:change
+				}
+			}
+			
+			every_in_list = {
+				list = titles_taken
+				change_title_holder = {
+					holder = scope:attacker
+					change = scope:change
+					take_baronies = yes
+				}
+			}
+		}
+
+		resolve_title_and_vassal_change = scope:change
+
+		# Prestige Progress for the Attacker
+		every_in_list = {
+			list = target_titles
+			scope:attacker = {
+				add_prestige_experience = medium_prestige_value
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		# Truce
+		add_truce_attacker_victory_effect = yes
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+
+		# Move into new lands
+		scope:attacker = {
+			domicile ?= {
+				move_domicile = scope:attacker.capital_province
+			}
+		}
+
+		scope:war = { set_variable = migration_victory }
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = migration_cb_white_peace_desc_defender
+			}
+			desc = migration_cb_white_peace_desc
+		}
+	}
+
+	on_white_peace = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 accolade glory gain for doing pretty good against higher ranked enemy
+		scope:defender = { accolade_defender_war_end_glory_gain_low_effect = yes }
+
+		scope:attacker = {
+			add_prestige = {
+				value = minor_prestige_value
+				multiply = -1.0
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker # not impactful as the scale are identical
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		add_truce_white_peace_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = migration_cb_defeat_desc_defender
+			}
+			desc = migration_cb_defeat_desc
+		}
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		scope:attacker = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_negative" }
+		scope:defender = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_positive" }
+
+		# Legitimacy
+		add_legitimacy_attacker_defeat_effect = yes
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			#EP2 accolade glory gain for winning against higher ranked enemy
+			accolade_defender_war_end_glory_gain_high_effect = yes
+			# Prestige for Defender
+			add_prestige_war_defender_effect = {
+				PRESTIGE_VALUE = medium_prestige_value
+			}
+		}
+
+		# Prestige loss for the attacker
+		scope:attacker = {
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 3
+			}
+			add_prestige = {
+				value = major_prestige_value
+				multiply = -1.0
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:defender
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		add_truce_attacker_defeat_effect = yes
+
+		scope:attacker = {
+			save_temporary_scope_as = loser
+		}
+		on_lost_aggression_war_discontent_loss = yes
+	}
+
+	transfer_behavior = transfer
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	war_name = "MIGRATION_WAR_NAME"
+	war_name_base = "MIGRATION_WAR_NAME_BASE"
+	cb_name = "MIGRATION_WAR_CB_NAME"
+
+	interface_priority = 79
+
+	attacker_wargoal_percentage = 0.8
+
+	defender_score_from_battles_scale = 300
+	attacker_score_from_battles_scale = 300
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+}
+
+
+###################################
+# NOMAD INVASION
+###################################
+
+mpo_nomad_invasion_cb = {
+	icon = migration_cb
+	group = invasion
+
+	combine_into_one = yes
+	should_show_war_goal_subview = yes
+	mutually_exclusive_titles = { always = yes }
+	allow_hostages = no
+
+	defender_score_from_occupation_scale = 50
+	attacker_score_from_occupation_scale = 150
+
+	allowed_for_character = {
+		is_independent_ruler = yes
+		government_has_flag = government_is_nomadic
+		trigger_if = {
+			limit = {
+				is_ai = yes
+			}
+			OR = {
+				is_landed = no
+				capital_county = {
+					any_county_situation_sub_region = {
+						sub_region_current_phase = situation_steppe_havsarsan_zud_season
+					}
+				}
+				AND = {
+					ai_boldness >= 50
+					capital_county = {
+						has_bad_season_nomadic_capital_root_trigger = yes
+					}
+				}
+				mpo_nomad_invasion_war_ai_trigger = { NOMAD = root }
+			}
+			trigger_if = {
+				limit = {
+					NOT = {
+						capital_county = {
+							any_county_situation_sub_region = {
+								sub_region_current_phase = situation_steppe_havsarsan_zud_season
+							}
+						}
+					}
+				}
+				NOT = {
+					sub_realm_size > 40
+				}
+			}
+		}
+	}
+
+	allowed_for_character_display_regardless = {
+		custom_tooltip = {
+			text = mpo_nomad_invasion_cb_tt
+			OR = {
+				has_realm_law = nomadic_authority_3
+				has_realm_law = nomadic_authority_4
+				has_realm_law = nomadic_authority_5
+			}
+		}
+		mpo_has_gok_mongol_empire_trigger = no
+	}
+
+	target_titles = all
+	target_title_tier = kingdom
+	target_de_jure_regions_above = yes
+
+	ai_can_target_all_titles = {
+		always = yes
+	}
+
+	max_ai_diplo_distance_to_title = 1000
+	ai_score = {
+		value = {
+			add = {
+				if = {
+					limit = {
+						scope:attacker = {
+							capital_county = {
+								any_county_situation_sub_region = {
+									sub_region_current_phase = situation_steppe_havsarsan_zud_season
+								}
+							}
+						}
+					}
+					every_in_list = {
+						list = target_titles
+						every_in_de_jure_hierarchy = {
+							limit = {
+								tier = tier_county
+								title_province = { has_holding_type = castle_holding }
+							}
+							add = 1000
+						}
+					}
+				}
+				else_if = {
+					limit = {
+						scope:attacker = {
+							OR = {
+								is_landed = no
+								AND = {
+									ai_boldness >= 50
+									capital_county = {
+										any_county_situation_sub_region = {
+											OR = {
+												sub_region_current_phase = situation_steppe_white_zud_season
+												sub_region_current_phase = situation_steppe_cold_zud_season
+												sub_region_current_phase = situation_steppe_severe_drought_season
+												sub_region_current_phase = situation_steppe_havsarsan_zud_season
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					every_in_list = {
+						list = target_titles
+						every_in_de_jure_hierarchy = {
+							limit = {
+								tier = tier_county
+								title_province = { has_holding_type = castle_holding }
+							}
+							add = 100
+						}
+					}
+				}
+				#IF THERE IS A SHOT ON ANATOLIA, TAKE IT TURKS!
+				if = {
+					limit = {
+						scope:attacker = {
+							culture = {
+								has_cultural_pillar = heritage_turkic
+							}
+						}
+						any_in_list = {
+							list = target_titles
+							tier = tier_kingdom
+							this = title:k_anatolia
+							OR = {
+								scope:defender.culture = {
+									has_cultural_pillar = heritage_byzantine
+								}
+								scope:defender = {
+									primary_title = title:e_byzantium
+								}
+								NOT = {
+									any_de_jure_county = {
+										culture = {
+											has_cultural_pillar = heritage_turkic
+										}
+									}
+								}
+							}
+						}
+					}
+					multiply = 20
+				}
+				if = {
+					limit = {
+						scope:attacker = {
+							any_character_situation = {
+								this = situation:the_great_steppe
+							}
+						}
+						any_in_list = {
+							list = target_titles
+							tier = tier_kingdom
+							OR = {
+								this = title:k_anatolia
+								this = title:k_pontus
+								this = title:k_delhi
+								this = title:k_bulgaria
+								this = title:k_syria
+								this = title:k_nikaea
+								this = title:k_georgia
+								this = title:k_armenia
+								this = title:k_galicia-volhynia
+								this = title:k_goguryeo
+								this = title:k_ruthenia
+								empire = {
+									OR = {
+										this = title:e_persia
+										this = title:e_turan
+										this = title:e_yongliang
+										this = title:e_zhongyuan
+										this = title:e_carpathia
+										this = title:e_great_yuan
+										this = title:e_chagatai
+										this = title:e_ilkhanate
+										this = title:e_golden_horde
+										this = title:e_tartaria
+										this = title:e_andong
+										this = title:e_caspian-pontic_steppe
+									}
+								}
+							}
+						}
+					}
+					multiply = 5
+				}
+				#weigh down non-neighboring states
+				if = {
+					limit = {
+						NOT = {
+							scope:attacker = {
+								any_land_neighboring_realm_with_tributaries_owner = {
+									this = scope:defender
+								}
+							}
+						}
+					}
+					multiply = 0.1
+				}
+				if = {
+					limit = {
+						scope:attacker = {
+							any_character_situation = {
+								this = situation:the_great_steppe
+							}
+						}
+						scope:defender = {
+							OR = {
+								is_roman_emperor_trigger = yes
+								sub_realm_size >= 150
+							}
+						}
+					}
+					multiply = 1.5
+				}
+				if = {
+					limit = {
+						scope:defender = {
+							culture = {
+								OR = {
+									has_cultural_pillar = heritage_turkic
+									has_cultural_pillar = heritage_mongolic
+									has_cultural_pillar = heritage_berber
+								}
+							}
+						}
+					}
+					multiply = 0.25
+				}
+				if = {
+					limit = {
+						scope:defender = {
+							any_character_war = {
+								using_cb = mpo_nomad_invasion_cb
+							}
+						}
+					}
+					multiply = 0.33
+				}
+				if = {
+					limit = {
+						any_in_list = {
+							list = target_titles
+							has_variable = was_overrun
+						}
+					}
+					multiply = 0.2
+				}
+				#Should not target islands... ever
+				if = {
+					limit = {
+						any_in_list = {
+							list = target_titles
+							tier = tier_duchy
+							OR = {
+								this = title:k_hitakami
+								this = title:k_aynumosir
+								this = title:k_sardinia
+								this = title:k_krete
+								this = title:k_cyprus
+								empire ?= {
+									OR = {
+										this = title:e_japan
+										this = title:e_britannia
+										this = title:e_nusantara
+										this = title:e_srivijaya
+									}
+								}
+							}
+						}
+					}
+					multiply = 0
+				}
+				if = {
+					limit = {
+						scope:defender = {
+							current_military_strength > scope:attacker.eighty_percent_of_current_military_strength
+						}
+					}
+					multiply = 0.1
+				}
+			}
+			if = {
+				limit = {
+					scope:attacker = {
+						any_owned_story = {
+							OR = {
+								story_type = story_mongol_invasion
+								story_type = story_greatest_of_khans
+							}
+						}
+					}
+				}
+				multiply = 0
+			}
+		}
+	}
+	ai_score_mult = {
+		value = 1
+
+		# HOUSE RELATIONS
+		add = house_relation_ai_score_value
+
+		# AI in struggles act insularly for wars that don't have a familial or legal basis.
+		multiply = struggle_wars_prioritise_struggle_targets_value
+		# Tell the Romans to stop going adventuring into the steppe for no gods-damned reason.
+		multiply = byzantium_conquests_ai_score_value
+		multiply = muslim_invasions_prefer_nonmuslims_ai_score_value
+
+		add = frankokratia_leader_protection_value #Set back to 0. Declaring war on the frankokratia leader can really ruin the whole thing
+	}
+
+	valid_to_start = {
+		scope:target = {
+			trigger_if = {
+				limit = {
+					scope:attacker = {
+						is_ai = yes
+					}
+				}
+				any_in_de_jure_hierarchy = {
+					continue = { tier > tier_county }
+					count >= 6
+					tier = tier_county
+					title_province = {
+						NOR = {
+							has_holding_type = nomad_holding
+							has_holding_type = herder_holding
+						}	
+					}
+					holder ?= {
+						OR = {
+							this = scope:defender
+							is_vassal_or_below_of = scope:defender
+						}
+					}
+				}
+				scope:defender = {
+					NOT = {
+						government_has_flag = government_is_nomadic
+					}
+					NOT = {
+						any_character_war = {
+							using_cb = mpo_nomad_invasion_cb
+						}
+					}
+				}
+			}
+			#At least one settled county, y'know
+			custom_tooltip = {
+				text = at_least_one_non_nomad_county_tt
+				any_de_jure_county = {
+					holder.top_liege = scope:defender
+					NOT = {
+						title_province = {
+							OR = {
+								has_holding_type = nomad_holding
+								has_holding_type = herder_holding
+							}	
+						}
+					}
+				}
+			}
+			
+		}
+	}
+
+	should_invalidate = {
+		NOT = {
+			any_in_list = {
+				list = target_titles
+				any_in_de_jure_hierarchy = {
+					tier = tier_county
+					holder = {
+						target_is_same_character_or_above = scope:defender
+					}
+				}
+			}
+		}
+	}
+
+	on_invalidated_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:attacker = { is_alive = no }
+				}
+				desc = msg_claim_war_invalidated_claimant_unavailable_dead_attacker_message
+			}
+			desc = msg_claim_war_invalidated_message
+		}
+	}
+
+	on_invalidated = {
+	}
+
+	cost = {
+		piety = {
+			value = 0
+			add = common_cb_impious_piety_cost
+			multiply = 1.5
+		}
+		prestige = {
+			value = nomad_invasion_cb_prestige_cost
+		}
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+		random_in_list = {
+			list = target_titles
+			limit = {
+				tier = tier_kingdom
+			}
+			save_scope_as = target
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = overrunning_war_victory_desc_attacker
+			}
+			desc = overrunning_war_victory_desc
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					
+					mpo_overrunner_becomes_tribal_desc_trigger = yes
+				}
+				desc = overrunning_war_victory_desc_tribal
+			}
+			triggered_desc = {
+				trigger = {
+					mpo_overrunner_becomes_clan_desc_trigger = yes
+				}
+				desc = overrunning_war_victory_desc_clan
+			}
+			desc = overrunning_war_victory_desc_feudal
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = overrunning_war_victory_warning_desc_attacker
+			}
+			desc = overrunning_war_victory_warning_desc
+		}
+	}
+
+	on_victory = {
+		#GoK stops really being GoK
+		scope:attacker = {
+			gok_government_change_story_end_effect = yes
+		}
+		# MPO ACHIEVEMENT Nobody's Business
+		if = {
+			limit = {
+				scope:attacker = { is_ai = no }
+			}
+			scope:attacker = {
+				add_achievement_global_variable_effect = {
+					VARIABLE = mpo_nobodys_business_achievement_unlocked
+					VALUE = yes
+				}
+			}
+		}
+		scope:attacker = {
+			domicile.domicile_culture = { save_scope_as = invading_culture }
+			domicile.domicile_faith = { save_scope_as = invading_faith }
+			save_scope_value_as = {
+				name = invading_herd_value
+				value = domicile.herd
+			}
+			if = {
+				limit = {
+					exists = confederation
+				}
+				confederation = {
+					remove_confederation_member = scope:attacker
+				}
+			}
+		}
+	
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		# Legitimacy and gold
+		scope:attacker = {
+			if = {
+				limit = {
+					scope:defender = {
+						government_has_flag = government_is_tribal
+					}
+				}
+				add_short_term_gold = medium_gold_value
+			}
+			else = {
+				add_short_term_gold = major_gold_value
+			}
+			add_legitimacy = medium_legitimacy_gain
+		}
+
+		#EP2 accolade glory gain for winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_high_effect = yes }
+
+		scope:defender = {
+			every_vassal = {
+				add_to_list = defender_vassals
+			}
+		}
+
+		random_in_list = {
+			list = target_titles
+			limit = {
+				tier = tier_kingdom
+			}
+			save_scope_as = target
+			set_variable = {
+				name = was_overrun
+				years = 20
+			}
+		}
+		scope:attacker = {
+			if = {
+				limit = {
+					mpo_overrunner_becomes_tribal_trigger = yes
+				}
+				save_scope_as = becoming_tribal
+			}
+			else_if = {
+				limit = {
+					mpo_overrunner_becomes_clan_trigger = yes
+				}
+				save_scope_as = becoming_clan
+			}
+		}
+
+		scope:target = {
+			every_in_de_jure_hierarchy = {
+				limit = {
+					tier = tier_duchy
+					holder.top_liege = scope:defender
+					NOT = {
+						is_in_list = target_titles
+					}
+				}
+				add_to_list = target_titles
+			}
+		}
+
+		scope:attacker = { save_scope_as = overrunner }
+
+		#Add vassals to a list - they may move with attacker
+		scope:attacker = {
+			every_vassal = {
+				limit = {
+					mpo_overrunning_willing_vassal_trigger = yes
+				}
+				add_to_list = potential_overrunning_vassals
+			}
+		}
+
+		#Wrap up being a nomad
+		scope:attacker = {
+			mpo_overrunning_ending_nomadism_effect = yes
+			every_tributary = {
+				custom = custom.every_tributary
+				end_tributary = yes
+			}
+		}
+
+		#Tooltip that defender will lose vassals after losing title
+		scope:defender = {
+			if = {
+				limit = {
+					scope:target = {
+						holder = scope:defender
+					}
+					NOT = {
+						any_held_title = {
+							tier >= tier_kingdom
+							this = scope:target
+						}
+					}
+				}
+				custom_tooltip = overrunning_defender_lose_vassals_tt
+			}
+		}
+		#If defender loses rank, make sure vassals become independent instead of going under attacker
+		hidden_effect = {
+			scope:defender = {
+				#being demoted to duke
+				if = {
+					limit = {
+						NOT = {
+							any_held_title = {
+								tier >= tier_kingdom
+								NOT = {
+									is_in_list = target_titles
+								}
+							}
+						}
+					}
+					every_vassal = {
+						limit = {
+							highest_held_title_tier >= tier_duchy
+							NOT = {
+								any_held_title = {
+									OR = {
+										kingdom = scope:target
+										this = scope:target
+									}
+								}
+							}
+						}
+						create_title_and_vassal_change = {
+							type = independency
+							save_scope_as = change_9
+						}
+						becomes_independent = { change = scope:change_9 }
+						resolve_title_and_vassal_change = scope:change_9
+					}
+				}
+				#being demoted to count
+				if = {
+					limit = {
+						NOT = {
+							any_held_title = {
+								tier >= tier_duchy
+								NOT = {
+									is_in_list = target_titles
+								}
+							}
+						}
+					}
+					every_vassal = {
+						limit = {
+							highest_held_title_tier >= tier_county
+							NOT = {
+								any_held_title = {
+									OR = {
+										kingdom = scope:target
+										this = scope:target
+									}
+								}
+							}
+							
+						}
+						create_title_and_vassal_change = {
+							type = independency
+							save_scope_as = change_9
+						}
+						becomes_independent = { change = scope:change_9 }
+						resolve_title_and_vassal_change = scope:change_9
+					}
+				}
+			}
+		}
+
+		scope:target = {
+			custom_tooltip = invasion_title_transfer_tt
+		}
+
+		hidden_effect = {
+			create_title_and_vassal_change = {
+				type = conquest
+				save_scope_as = change
+				add_claim_on_loss = yes
+			}
+			setup_invasion_cb = {
+				titles = target_titles
+				attacker = scope:attacker
+				defender = scope:defender
+				change = scope:change
+				take_occupied = no
+			}
+			every_in_list = {
+				list = target_titles
+				if = {
+					limit = {
+						tier = tier_duchy
+						OR = {
+							NOT = { exists = holder }
+							holder.top_liege = scope:defender
+						}
+					}
+					change_title_holder = {
+						holder = scope:attacker
+						change = scope:change
+					}
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						holder.top_liege = scope:defender
+						tier = tier_county
+					}
+					change_title_holder = {
+						holder = scope:attacker
+						change = scope:change
+					}
+				}
+			}
+	
+			resolve_title_and_vassal_change = scope:change
+		}
+		
+
+		#Should gain target title, if possible
+		scope:attacker = {
+			if = {
+				limit = {
+					scope:target = {
+						OR = {
+							NOT = {
+								exists = holder
+							}
+							holder.top_liege = scope:defender
+						}
+					}
+				}
+				create_title_and_vassal_change = {
+					type = conquest
+					save_scope_as = change_0
+					add_claim_on_loss = yes
+				}
+				scope:target = {
+					save_scope_as = new_primary
+					change_title_holder = {
+						holder = scope:attacker
+						change = scope:change_0
+					}
+				}
+				resolve_title_and_vassal_change = scope:change_0
+			}
+			else = {
+				#Gain capital duchy, if possible
+				if = {
+					limit = {
+						scope:target.title_capital_county.duchy = {
+							OR = {
+								NOT = {
+									exists = holder
+								}
+								holder.top_liege = scope:defender
+							}
+						}
+					}
+					hidden_effect = {
+						create_title_and_vassal_change = {
+							type = conquest
+							save_scope_as = change_1
+							add_claim_on_loss = yes
+						}
+						scope:target.title_capital_county.duchy = {
+							change_title_holder = {
+								holder = scope:attacker
+								change = scope:change_1
+							}
+						}
+						resolve_title_and_vassal_change = scope:change_1
+					}
+				}
+				#Gain titular kingdom
+				if = {
+					limit = {
+						highest_held_title_tier < tier_kingdom
+					}
+					custom_tooltip = overrunning_gain_titular_kingdom_tt
+					hidden_effect = {
+						create_dynamic_title = {
+							tier = kingdom
+							name = FORMER_NOMAD_KINGDOM_NAME
+							adj = FORMER_NOMAD_KINGDOM_NAME_ADJ
+						}
+						scope:new_title = {
+							save_scope_as = new_primary
+						}
+						create_title_and_vassal_change = {
+							type = created
+							save_scope_as = change_2
+							add_claim_on_loss = no
+						}
+						scope:new_title = {
+							set_destroy_on_gain_same_tier = yes
+							set_no_automatic_claims = yes
+							set_can_be_named_after_dynasty = yes
+							change_title_holder = {
+								holder = scope:attacker
+								change = scope:change_2
+							}
+							set_color_from_title = scope:target
+						}
+						resolve_title_and_vassal_change = scope:change_2
+						scope:new_title = { generate_coa = yes }
+					}
+				}
+			}
+
+			#Make this their primary title, if highest tier
+			hidden_effect = {
+				if = {
+					limit = {
+						exists = scope:new_primary
+						NOT = {
+							highest_held_title_tier > scope:new_primary.tier
+						}
+					}
+					set_primary_title_to = scope:new_primary
+				}
+			}
+		}
+
+		#Change attacker's government
+		scope:attacker = {
+			if = {
+				limit = {
+					exists = scope:becoming_tribal
+				}
+				nomad_convert_people_to_tribe_effect = yes
+			}
+			else_if = {
+				limit = {
+					exists = scope:becoming_clan
+				}
+				nomad_convert_people_to_clan_effect = yes
+			}
+			else = {
+				nomad_convert_people_to_feudal_effect = yes
+			}
+		}
+
+		#Change capital to somewhere in new lands
+		scope:target = {
+			custom_tooltip = overrunning_move_capital_tt
+		}
+
+		hidden_effect = {
+			scope:attacker = {
+				#Capital of kingdom, if available
+				if = {
+					limit = {
+						scope:target.title_capital_county = {
+							holder = scope:attacker
+							NOT = {
+								any_county_province = {
+									OR = {
+										has_holding_type = nomad_holding
+										has_holding_type = herder_holding
+									}
+								}
+							}
+						}
+					}
+					scope:target.title_capital_county = {
+						culture = { save_scope_as = expelled_culture }
+					}
+					scope:attacker = {
+						set_realm_capital = scope:target.title_capital_county
+					}
+				}
+				#Most developed duchy capital available
+				else_if = {
+					limit = {
+						scope:attacker = {
+							any_realm_de_jure_duchy = {
+								kingdom = scope:target
+								title_capital_county = {
+									holder = scope:attacker
+									NOT = {
+										any_county_province = {
+											OR = {
+												has_holding_type = nomad_holding
+												has_holding_type = herder_holding
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					scope:attacker = {
+						every_realm_de_jure_duchy = {
+							limit = {
+								kingdom = scope:target
+								title_capital_county = {
+									holder = scope:attacker
+									NOT = {
+										any_county_province = {
+											OR = {
+												has_holding_type = nomad_holding
+												has_holding_type = herder_holding
+											}
+										}
+									}
+								}
+							}
+							title_capital_county = {
+								add_to_list = duchy_capitals
+							}
+						}
+					}
+					ordered_in_list = {
+						list = duchy_capitals
+						order_by = development_level
+						culture = { save_scope_as = expelled_culture }
+						scope:attacker = {
+							set_realm_capital = prev
+						}
+					}
+				}
+				#Most developed county
+				else = {
+					ordered_realm_county = {
+						order_by = development_level
+						limit = {
+							kingdom = scope:target
+							NOT = {
+								any_county_province = {
+									OR = {
+										has_holding_type = nomad_holding
+										has_holding_type = herder_holding
+									}
+								}
+							}
+						}
+						culture = { save_scope_as = expelled_culture }
+						scope:attacker = {
+							set_realm_capital = prev
+						}
+					}
+				}
+				capital_county.duchy = {
+					save_scope_as = new_capital_duchy
+				}
+			}
+		}
+
+		#Vassals gain titles
+		hidden_effect = {
+			scope:attacker = {
+				mpo_overrunning_vassal_title_distribution_effect = yes
+			}
+		}
+
+		#Make sure defender vassals who should be independent... are
+		hidden_effect = {
+			if = {
+				limit = {
+					any_in_list = {
+						list = defender_vassals
+						liege = scope:attacker
+					}
+				}
+				every_in_list = {
+					list = defender_vassals
+					limit = {
+						liege = scope:attacker
+					}
+					create_title_and_vassal_change = {
+						type = independency
+						save_scope_as = change_10
+					}
+					becomes_independent = { change = scope:change_10 }
+					resolve_title_and_vassal_change = scope:change_10
+				}
+			}
+		}
+
+		scope:target = {
+			#Vassals tooltip
+			custom_tooltip = overrunning_vassals_gain_titles_tt
+			#We have the capital duchy and are ready to convert
+			custom_tooltip = overrunning_convert_capital_duchy_tt
+			custom_tooltip = overrunning_convert_dukes_capitals_tt
+			custom_tooltip = overrunning_convert_tribal_counties_tt
+		}
+		hidden_effect = {
+			scope:attacker.capital_county = {
+				duchy = {
+					save_scope_as = target_duchy
+				}
+			}
+			scope:attacker.capital_county = {
+				set_county_culture = scope:invading_culture
+				set_county_faith = scope:invading_faith
+			}
+			scope:attacker = {
+				every_vassal = {
+					limit = {
+						capital_county.kingdom = scope:target
+						highest_held_title_tier >= tier_duchy
+					}
+					#Convert capital to their culture
+					capital_county = {
+						set_county_culture = scope:invading_culture
+						set_county_faith = scope:invading_faith
+					}
+				}
+				while = {
+					limit = {
+						scope:invading_herd_value >= 5000
+						any_sub_realm_county = {
+							NOT = {
+								culture = scope:invading_culture
+							}
+						}
+					}
+					random_sub_realm_county = {
+						limit = {
+							NOT = {
+								culture = scope:invading_culture
+							}
+						}
+						weight = {
+							base = 1
+							modifier = {
+								add = {
+									every_neighboring_county = {
+										limit = {
+											culture = scope:invading_culture
+										}
+										add = 100
+									}
+								}
+								any_neighboring_county = {
+									culture = scope:invading_culture
+								}
+							}
+							modifier = {
+								add = 10000
+								any_neighboring_county = {
+									this = scope:attacker.capital_county
+								}
+							}
+							modifier = {
+								factor = 10
+								is_coastal_county = yes
+							}
+						}
+						set_county_culture = scope:invading_culture
+						set_county_faith = scope:invading_faith
+						#Convert additional tribal county if possible
+						ordered_neighboring_county = {
+							order_by = {
+								value = development_level
+								multiply = -1
+							}
+							limit = {
+								NOT = { culture = scope:invading_culture }
+								title_province = {
+									has_holding_type = tribal_holding
+								}
+								OR = {
+									holder = scope:attacker
+									holder = {
+										any_liege_or_above = {
+											this = scope:attacker
+										}
+									}
+								}
+							}
+							set_county_culture = scope:invading_culture
+							set_county_faith = scope:invading_faith
+						}
+					}
+					save_scope_value_as = {
+						name = invading_herd_value
+						value = {
+							add = scope:invading_herd_value
+							subtract = 5000
+						}
+					}
+				}
+			}
+		}
+		#Counties lose development levels
+		scope:target = {
+			custom_tooltip = attackers_counties_lose_development
+		}
+		hidden_effect = {
+			scope:attacker = {
+				every_held_title = {
+					limit = {
+						tier = tier_county
+						kingdom = scope:target
+					}
+					if = {
+						limit = {
+							title_province = {
+								OR = {
+									has_holding_type = tribal_holding
+									has_holding_type = nomad_holding
+									has_holding_type = herder_holding
+								}
+							}
+						}
+						change_development_level = -1
+					}
+					else_if = {
+						limit = {
+							current_year < 1065
+						}
+						change_development_level = -2
+					}
+					else_if = {
+						limit = {
+							current_year < 1250
+						}
+						change_development_level = -3
+					}
+					else = {
+						change_development_level = -5
+					}
+				}
+			}
+		}
+
+		# Attacker gets Prestige Experience, Defender loses Prestige, all other participants gain Prestige based on their war contribution.
+		modify_all_participants_fame_values = {
+			WINNER = scope:attacker
+			LOSER = scope:defender
+			FAME_BASE = scope:cb_prestige_factor # Set by 'setup_invasion_cb'
+			IS_RELIGIOUS_WAR = no
+			WINNER_FAME_SCALE = 10
+			LOSER_FAME_SCALE = -10
+			WINNER_ALLY_FAME_SCALE = 10
+			LOSER_ALLY_FAME_SCALE = 10
+		}
+
+		# Truce
+		add_truce_attacker_victory_effect = yes
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		#Event for attacker
+		scope:attacker = {
+			trigger_event = {
+				id = mpo_nomad_events.1040
+				days = 1
+			}
+		}
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = invasion_war_white_peace_desc_defender
+			}
+			desc = invasion_war_white_peace_desc
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = overrunning_war_white_peace_desc_attacker
+			}
+			desc = overrunning_war_white_peace_desc
+		}
+	}
+
+	on_white_peace = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 accolade glory gain for doing ok against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_low_effect = yes }
+		scope:defender = { accolade_defender_war_end_glory_gain_med_effect = yes }
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker # Not important as the scales are identical
+			FAME_BASE = major_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		# Truce
+		add_truce_white_peace_effect = yes
+
+		scope:attacker = {
+			add_dread = minor_dread_loss
+			add_legitimacy = minor_legitimacy_loss
+			add_prestige = mongol_invasion_cb_prestige_white_peace
+			stress_impact = {
+				ambitious = medium_stress_impact_gain
+				arrogant = medium_stress_impact_gain
+			}
+		}
+
+		scope:defender = {
+			stress_impact = {
+				arrogant = medium_stress_impact_gain
+			}
+		}
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = invasion_war_white_peace_desc_defender
+			}
+			desc = invasion_war_white_peace_desc
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = overrunning_war_surrender_desc_attacker
+			}
+			desc = overrunning_war_surrender_desc
+		}
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		# Legitimacy
+		add_legitimacy_attacker_defeat_effect = yes
+
+		# Influence
+		add_influence_attacker_defeat_effect = yes
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			#EP2 accolade glory gain for winning against higher ranked enemy
+			accolade_defender_war_end_glory_gain_high_effect = yes
+		}
+
+		# Prestige loss for the attacker
+		scope:attacker = {
+			add_dread = major_dread_loss
+			add_legitimacy = major_legitimacy_loss
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 5
+			}
+			add_prestige = {
+				value = massive_prestige_value
+				multiply = -1.0
+			}
+			switch = {
+			   trigger = has_realm_law
+			   nomadic_authority_5 = { add_realm_law = nomadic_authority_4 }
+			   nomadic_authority_4 = { add_realm_law = nomadic_authority_3 }
+			   nomadic_authority_3 = { add_realm_law = nomadic_authority_2 }
+			}
+		}
+
+		setup_invasion_cb = {
+			titles = target_titles
+			attacker = scope:attacker
+			defender = scope:defender
+			claimant = scope:claimant
+			victory = no
+		}
+
+		# Attacker loses Prestige, all other war participants gain Prestige (Defender gains full prestige, all allies on both sides gain based on war contribution).
+		modify_all_participants_fame_values = {
+			WINNER = scope:defender
+			LOSER = scope:attacker
+			FAME_BASE = scope:cb_prestige_factor # Set by 'setup_claim_cb'
+			IS_RELIGIOUS_WAR = no
+			WINNER_FAME_SCALE = scale_10_war_defender_win
+			LOSER_FAME_SCALE = -10
+			WINNER_ALLY_FAME_SCALE = 10
+			LOSER_ALLY_FAME_SCALE = 10
+		}
+
+		add_truce_attacker_defeat_effect = yes
+
+		scope:attacker = {
+			save_temporary_scope_as = loser
+		}
+		on_lost_aggression_war_discontent_loss = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	transfer_behavior = transfer
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	war_name = "MPO_NOMAD_INVASION_WAR_NAME"
+	war_name_base = "MPO_NOMAD_INVASION_WAR_NAME_BASE"
+	cb_name = "MPO_NOMAD_INVASION_CB_NAME"
+
+	interface_priority = 100
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 0.8
+
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+}
+
+mpo_nomad_duchy_invasion_cb = {
+	icon = migration_cb
+	group = invasion
+
+	combine_into_one = yes
+	should_show_war_goal_subview = yes
+	mutually_exclusive_titles = { always = yes }
+	allow_hostages = no
+
+	defender_score_from_occupation_scale = 50
+	attacker_score_from_occupation_scale = 150
+
+	allowed_for_character = {
+		is_independent_ruler = yes
+		government_has_flag = government_is_nomadic
+		trigger_if = {
+			limit = {
+				is_ai = yes
+			}
+			highest_held_title_tier < tier_kingdom
+			#Are not capable of kingdom-level invasion
+			has_realm_law = nomadic_authority_2
+			OR = {
+				is_landed = no
+				capital_county = {
+					has_bad_season_nomadic_capital_root_trigger = yes
+				}
+				mpo_nomad_duchy_invasion_war_ai_trigger = { NOMAD = root }
+			}
+			trigger_if = {
+				limit = {
+					NOT = {
+						capital_county = {
+							any_county_situation_sub_region = {
+								sub_region_current_phase = situation_steppe_havsarsan_zud_season
+							}
+						}
+					}
+				}
+				sub_realm_size < 12
+			}
+		}
+	}
+
+	allowed_for_character_display_regardless = {
+		custom_tooltip = {
+			text = mpo_nomad_invasion_duchy_cb_tt
+			NOT = {
+				has_realm_law = nomadic_authority_1
+			}
+		}
+		mpo_has_gok_mongol_empire_trigger = no
+	}
+
+	target_titles = all
+	target_title_tier = duchy
+	target_de_jure_regions_above = yes
+
+	ai_can_target_all_titles = {
+		has_character_flag = nomad_duchy_invasion_all_target_override
+	}
+
+	max_ai_diplo_distance_to_title = 850
+	ai_score = {
+		value = {
+			add = {
+				if = {
+					limit = {
+						scope:attacker = {
+							capital_county = {
+								any_county_situation_sub_region = {
+									sub_region_current_phase = situation_steppe_havsarsan_zud_season
+								}
+							}
+						}
+					}
+					every_in_list = {
+						list = target_titles
+						every_in_de_jure_hierarchy = {
+							limit = {
+								tier = tier_county
+								title_province = { has_holding_type = castle_holding }
+							}
+							add = 1000
+						}
+					}
+				}
+				else_if = {
+					limit = {
+						scope:attacker = {
+							OR = {
+								is_landed = no
+								AND = {
+									ai_boldness >= 50
+									capital_county = {
+										any_county_situation_sub_region = {
+											OR = {
+												sub_region_current_phase = situation_steppe_white_zud_season
+												sub_region_current_phase = situation_steppe_cold_zud_season
+												sub_region_current_phase = situation_steppe_severe_drought_season
+												sub_region_current_phase = situation_steppe_havsarsan_zud_season
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+					every_in_list = {
+						list = target_titles
+						every_in_de_jure_hierarchy = {
+							limit = {
+								tier = tier_county
+								title_province = { has_holding_type = castle_holding }
+							}
+							add = 100
+						}
+					}
+				}
+				if = {
+					limit = {
+						scope:attacker = {
+							any_character_situation = {
+								this = situation:the_great_steppe
+							}
+						}
+						any_in_list = {
+							list = target_titles
+							tier = tier_duchy
+							OR = {
+								kingdom ?= title:k_anatolia
+								kingdom ?= title:k_pontus
+								kingdom ?= title:k_delhi
+								kingdom ?= title:k_bulgaria
+								kingdom ?= title:k_syria
+								kingdom ?= title:k_nikaea
+								kingdom ?= title:k_georgia
+								kingdom ?= title:k_armenia
+								kingdom ?= title:k_galicia-volhynia
+								kingdom ?= title:k_goguryeo
+								kingdom ?= title:k_ruthenia
+								empire ?= {
+									OR = {
+										this = title:e_persia
+										this = title:e_turan
+										this = title:e_yongliang
+										this = title:e_zhongyuan
+										this = title:e_carpathia
+										this = title:e_great_yuan
+										this = title:e_chagatai
+										this = title:e_ilkhanate
+										this = title:e_golden_horde
+										this = title:e_tartaria
+										this = title:e_andong
+										this = title:e_caspian-pontic_steppe
+									}
+								}
+							}
+						}
+					}
+					multiply = 5
+				}
+				#weigh down non-neighboring states, nomadic heritage, already invaded targets
+				if = {
+					limit = {
+						scope:defender = {
+							OR = {
+								NOT = {
+									any_land_neighboring_realm_with_tributaries_owner = {
+										this = scope:attacker
+									}
+								}
+								culture = {
+									OR = {
+										has_cultural_pillar = heritage_turkic
+										has_cultural_pillar = heritage_mongolic
+										has_cultural_pillar = heritage_berber
+									}
+								}
+								any_character_war = {
+									OR = {	
+										using_cb = mpo_nomad_duchy_invasion_cb
+										using_cb = mpo_nomad_invasion_cb
+									}
+								}
+								current_military_strength > scope:attacker.eighty_percent_of_current_military_strength
+							}
+						}
+					}
+					multiply = 0.1
+				}
+				if = {
+					limit = {
+						any_in_list = {
+							list = target_titles
+							has_variable = was_overrun
+						}
+					}
+					multiply = 0.2
+				}
+				#Should not target islands... ever
+				if = {
+					limit = {
+						any_in_list = {
+							list = target_titles
+							tier = tier_duchy
+							OR = {
+								this = title:d_iceland
+								this = title:d_mallorca
+								this = title:d_canarias
+								this = title:d_socotra
+								this = title:d_tamna
+								this = title:d_northern_isles
+								kingdom ?= title:k_hitakami
+								kingdom ?= title:k_aynumosir
+								kingdom ?= title:k_sardinia
+								kingdom ?= title:k_krete
+								kingdom ?= title:k_cyprus
+								empire ?= {
+									OR = {
+										this = title:e_japan
+										this = title:e_britannia
+										this = title:e_nusantara
+										this = title:e_srivijaya
+									}
+								}
+							}
+						}
+					}
+					multiply = 0
+				}
+			}
+			if = {
+				limit = {
+					scope:attacker = {
+						any_owned_story = {
+							OR = {
+								story_type = story_mongol_invasion
+								story_type = story_greatest_of_khans
+							}
+						}
+					}
+				}
+				multiply = 0
+			}
+		}
+	}
+	ai_score_mult = {
+		value = 1
+
+		# HOUSE RELATIONS
+		add = house_relation_ai_score_value
+
+		# AI in struggles act insularly for wars that don't have a familial or legal basis.
+		multiply = struggle_wars_prioritise_struggle_targets_value
+		# Tell the Romans to stop going adventuring into the steppe for no gods-damned reason.
+		multiply = byzantium_conquests_ai_score_value
+		multiply = muslim_invasions_prefer_nonmuslims_ai_score_value
+
+		add = frankokratia_leader_protection_value #Set back to 0. Declaring war on the frankokratia leader can really ruin the whole thing
+	}
+
+	valid_to_start = {
+		scope:target = {
+			#At least one settled county, y'know
+			custom_tooltip = {
+				text = at_least_one_non_nomad_county_tt
+				any_de_jure_county = {
+					holder.top_liege = scope:defender
+					NOT = {
+						title_province = {
+							OR = {
+								has_holding_type = nomad_holding
+								has_holding_type = herder_holding
+							}	
+						}
+					}
+				}
+			}
+			
+		}
+	}
+
+	should_invalidate = {
+		NOT = {
+			any_in_list = {
+				list = target_titles
+				any_in_de_jure_hierarchy = {
+					tier = tier_county
+					holder = {
+						target_is_same_character_or_above = scope:defender
+					}
+				}
+			}
+		}
+	}
+
+	on_invalidated_desc = msg_invasion_war_invalidated_message
+
+	on_invalidated = {
+	}
+
+	cost = {
+		piety = {
+			value = common_cb_impious_piety_cost
+		}
+		prestige = {
+			add = {
+				value = 800
+
+				desc = CB_BASE_COST
+			}
+			multiply = common_cb_prestige_cost_multiplier
+			if = {
+				limit = {
+					scope:attacker = { is_ai = yes }
+				}
+				multiply = 0.5
+			}
+		}
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+		random_in_list = {
+			list = target_titles
+			limit = {
+				tier = tier_duchy
+			}
+			save_scope_as = target
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = overrunning_duchy_war_victory_desc_attacker
+			}
+			desc = overrunning_duchy_war_victory_desc
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					
+					mpo_overrunner_becomes_tribal_desc_trigger = yes
+				}
+				desc = overrunning_war_victory_desc_tribal
+			}
+			triggered_desc = {
+				trigger = {
+					mpo_overrunner_becomes_clan_desc_trigger = yes
+				}
+				desc = overrunning_war_victory_desc_clan
+			}
+			desc = overrunning_war_victory_desc_feudal
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = overrunning_war_victory_warning_desc_attacker
+			}
+			desc = overrunning_war_victory_warning_desc
+		}
+	}
+
+	on_victory = {
+		#GoK stops really being GoK
+		scope:attacker = {
+			gok_government_change_story_end_effect = yes
+		}
+
+		scope:attacker = {
+			domicile.domicile_culture = { save_scope_as = invading_culture }
+			domicile.domicile_faith = { save_scope_as = invading_faith }
+			save_scope_value_as = {
+				name = invading_herd_value
+				value = domicile.herd
+			}
+			if = {
+				limit = {
+					exists = confederation
+				}
+				confederation = {
+					remove_confederation_member = scope:attacker
+				}
+			}
+		}
+	
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		# Legitimacy and gold
+		scope:attacker = {
+			if = {
+				limit = {
+					scope:defender = {
+						government_has_flag = government_is_tribal
+					}
+				}
+				add_short_term_gold = minor_gold_value
+			}
+			else = {
+				add_short_term_gold = medium_gold_value
+			}
+			add_legitimacy = minor_legitimacy_gain
+		}
+
+		#EP2 accolade glory gain for winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_high_effect = yes }
+
+		scope:defender = {
+			every_vassal = {
+				add_to_list = defender_vassals
+			}
+		}
+
+		random_in_list = {
+			list = target_titles
+			limit = {
+				tier = tier_duchy
+			}
+			save_scope_as = target
+			set_variable = {
+				name = was_overrun
+				years = 20
+			}
+		}
+		scope:attacker = {
+			if = {
+				limit = {
+					mpo_overrunner_becomes_tribal_trigger = yes
+				}
+				save_scope_as = becoming_tribal
+			}
+			else_if = {
+				limit = {
+					mpo_overrunner_becomes_clan_trigger = yes
+				}
+				save_scope_as = becoming_clan
+			}
+		}
+
+		scope:target = {
+			every_in_de_jure_hierarchy = {
+				limit = {
+					tier = tier_county
+					holder.top_liege = scope:defender
+					NOT = {
+						is_in_list = target_titles
+					}
+				}
+				add_to_list = target_titles
+			}
+		}
+
+		scope:attacker = { save_scope_as = overrunner }
+
+		#Add vassals to a list - they may move with attacker
+		scope:attacker = {
+			every_vassal = {
+				limit = {
+					mpo_overrunning_willing_vassal_trigger = yes
+				}
+				add_to_list = potential_overrunning_vassals
+			}
+		}
+
+		#Wrap up being a nomad
+		scope:attacker = {
+			mpo_overrunning_ending_nomadism_effect = yes
+			every_tributary = {
+				custom = custom.every_tributary
+				end_tributary = yes
+			}
+		}
+
+		#Tooltip that defender will lose vassals after losing title
+		scope:defender = {
+			if = {
+				limit = {
+					scope:target = {
+						holder = scope:defender
+					}
+					NOT = {
+						any_held_title = {
+							tier >= tier_duchy
+							this = scope:target
+						}
+					}
+				}
+				custom_tooltip = overrunning_defender_lose_vassals_tt
+			}
+		}
+		#If defender loses rank, make sure vassals become independent instead of going under attacker
+		hidden_effect = {
+			scope:defender = {
+				#being demoted to duke
+				if = {
+					limit = {
+						NOT = {
+							any_held_title = {
+								tier >= tier_duchy
+								NOT = {
+									is_in_list = target_titles
+								}
+							}
+						}
+					}
+					every_vassal = {
+						limit = {
+							highest_held_title_tier >= tier_county
+							NOT = {
+								any_held_title = {
+									OR = {
+										kingdom = scope:target
+										this = scope:target
+									}
+								}
+							}
+						}
+						create_title_and_vassal_change = {
+							type = independency
+							save_scope_as = change_9
+						}
+						becomes_independent = { change = scope:change_9 }
+						resolve_title_and_vassal_change = scope:change_9
+					}
+				}
+			}
+		}
+		
+		scope:target = {
+			custom_tooltip = overrunning_title_transfer_tt
+		}
+
+		hidden_effect = {
+			create_title_and_vassal_change = {
+				type = conquest
+				save_scope_as = change
+				add_claim_on_loss = yes
+			}
+			setup_invasion_cb = {
+				titles = target_titles
+				attacker = scope:attacker
+				defender = scope:defender
+				change = scope:change
+				take_occupied = no
+			}
+			every_in_list = {
+				list = target_titles
+				if = {
+					limit = {
+						tier = tier_duchy
+						OR = {
+							NOT = { exists = holder }
+							holder.top_liege = scope:defender
+						}
+					}
+					change_title_holder = {
+						holder = scope:attacker
+						change = scope:change
+					}
+				}
+				every_in_de_jure_hierarchy = {
+					limit = {
+						holder.top_liege = scope:defender
+						tier = tier_county
+					}
+					change_title_holder = {
+						holder = scope:attacker
+						change = scope:change
+					}
+				}
+			}
+
+			resolve_title_and_vassal_change = scope:change
+		}
+
+		#Should gain target title, if possible
+		scope:attacker = {
+			if = {
+				limit = {
+					scope:target = {
+						OR = {
+							NOT = {
+								exists = holder
+							}
+							holder.top_liege = scope:defender
+						}
+					}
+				}
+				create_title_and_vassal_change = {
+					type = conquest
+					save_scope_as = change_0
+					add_claim_on_loss = yes
+				}
+				scope:target = {
+					save_scope_as = new_primary
+					change_title_holder = {
+						holder = scope:attacker
+						change = scope:change_0
+					}
+				}
+				resolve_title_and_vassal_change = scope:change_0
+			}
+			else = {
+				#Gain titular duchy
+				if = {
+					limit = {
+						highest_held_title_tier < tier_duchy
+					}
+					custom_tooltip = overrunning_gain_titular_duchy_tt
+					hidden_effect = {
+						create_dynamic_title = {
+							tier = duchy
+							name = FORMER_NOMAD_DUCHY_NAME
+							adj = FORMER_NOMAD_DUCHY_NAME_ADJ
+						}
+						scope:new_title = {
+							save_scope_as = new_primary
+						}
+						create_title_and_vassal_change = {
+							type = created
+							save_scope_as = change_2
+							add_claim_on_loss = no
+						}
+						scope:new_title = {
+							set_destroy_on_gain_same_tier = yes
+							set_no_automatic_claims = yes
+							set_can_be_named_after_dynasty = yes
+							change_title_holder = {
+								holder = scope:attacker
+								change = scope:change_2
+							}
+							set_color_from_title = scope:target
+						}
+						resolve_title_and_vassal_change = scope:change_2
+						scope:new_title = { generate_coa = yes }
+					}
+				}
+			}
+
+			#Make this their primary title, if highest tier
+			hidden_effect = {
+				if = {
+					limit = {
+						exists = scope:new_primary
+						NOT = {
+							highest_held_title_tier > scope:new_primary.tier
+						}
+					}
+					set_primary_title_to = scope:new_primary
+				}
+			}
+		}
+
+		#Change attacker's government
+		scope:attacker = {
+			if = {
+				limit = {
+					exists = scope:becoming_tribal
+				}
+				nomad_convert_people_to_tribe_effect = yes
+			}
+			else_if = {
+				limit = {
+					exists = scope:becoming_clan
+				}
+				nomad_convert_people_to_clan_effect = yes
+			}
+			else = {
+				nomad_convert_people_to_feudal_effect = yes
+			}
+		}
+
+		#Change capital to somewhere in new lands
+		scope:target = {
+			custom_tooltip = overrunning_move_capital_tt
+		}
+
+		hidden_effect = {
+			scope:attacker = {
+				#Capital of duchy, if available
+				if = {
+					limit = {
+						scope:target.title_capital_county = {
+							holder = scope:attacker
+							NOT = {
+								any_county_province = {
+									OR = {
+										has_holding_type = nomad_holding
+										has_holding_type = herder_holding
+									}
+								}
+							}
+						}
+					}
+					scope:target.title_capital_county = {
+						culture = { save_scope_as = expelled_culture }
+					}
+					scope:attacker = {
+						set_realm_capital = scope:target.title_capital_county
+					}
+				}
+				#Most developed county
+				else = {
+					ordered_realm_county = {
+						order_by = development_level
+						limit = {
+							kingdom = scope:target
+							NOT = {
+								any_county_province = {
+									OR = {
+										has_holding_type = nomad_holding
+										has_holding_type = herder_holding
+									}
+								}
+							}
+						}
+						culture = { save_scope_as = expelled_culture }
+						scope:attacker = {
+							set_realm_capital = prev
+						}
+					}
+				}
+				capital_county.duchy = {
+					save_scope_as = new_capital_duchy
+				}
+			}
+		}
+
+		#Vassals gain titles
+		hidden_effect = {
+			scope:attacker = {
+				mpo_duchy_overrunning_vassal_title_distribution_effect = yes
+			}
+		}
+
+		#Make sure defender vassals who should be independent... are
+		hidden_effect = {
+			if = {
+				limit = {
+					any_in_list = {
+						list = defender_vassals
+						liege = scope:attacker
+					}
+				}
+				every_in_list = {
+					list = defender_vassals
+					limit = {
+						liege = scope:attacker
+					}
+					create_title_and_vassal_change = {
+						type = independency
+						save_scope_as = change_10
+					}
+					becomes_independent = { change = scope:change_10 }
+					resolve_title_and_vassal_change = scope:change_10
+				}
+			}
+		}
+
+		scope:target = {
+			#Vassals tooltip
+			custom_tooltip = overrunning_vassals_gain_titles_duchy_tt
+		}
+		#Counties lose development levels if not tribal
+		if = {
+			limit = {
+				scope:attacker = {
+					any_held_title = {
+						tier = tier_county
+						duchy = scope:target
+						NOT = {
+							title_province = {
+								OR = {
+									has_holding_type = tribal_holding
+									has_holding_type = nomad_holding
+									has_holding_type = herder_holding
+								}
+							}
+						}
+					}
+				}
+			}
+			scope:target = {
+				custom_tooltip = attackers_counties_lose_development
+			}
+		}
+		
+		hidden_effect = {
+			scope:attacker = {
+				every_held_title = {
+					limit = {
+						tier = tier_county
+						duchy = scope:target
+						NOT = {
+							title_province = {
+								OR = {
+									has_holding_type = tribal_holding
+									has_holding_type = nomad_holding
+									has_holding_type = herder_holding
+								}
+							}
+						}
+					}
+					if = {
+						limit = {
+							current_year < 1065
+						}
+						change_development_level = -1
+					}
+					else_if = {
+						limit = {
+							current_year < 1250
+						}
+						change_development_level = -2
+					}
+					else = {
+						change_development_level = -4
+					}
+				}
+			}
+		}
+
+		#Leave tributaries that don't border you
+		scope:attacker = {
+			every_tributary = {
+				limit = {
+					NOR = {
+						top_liege = scope:attacker.top_liege
+						any_realm_border_county = {
+							any_neighboring_county = {
+								holder = scope:attacker
+							}
+						}
+					}
+				}
+				custom = custom.every_no_longer_neighbor_tributary
+				end_tributary = yes
+			}
+		}
+
+		# Attacker gets Prestige Experience, Defender loses Prestige, all other participants gain Prestige based on their war contribution.
+		modify_all_participants_fame_values = {
+			WINNER = scope:attacker
+			LOSER = scope:defender
+			FAME_BASE = scope:cb_prestige_factor # Set by 'setup_invasion_cb'
+			IS_RELIGIOUS_WAR = no
+			WINNER_FAME_SCALE = 10
+			LOSER_FAME_SCALE = -10
+			WINNER_ALLY_FAME_SCALE = 10
+			LOSER_ALLY_FAME_SCALE = 10
+		}
+
+		# Truce
+		add_truce_attacker_victory_effect = yes
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		#Event for attacker
+		scope:attacker = {
+			trigger_event = {
+				id = mpo_nomad_events.1040
+				days = 1
+			}
+		}
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = invasion_war_white_peace_desc_defender
+			}
+			desc = invasion_war_white_peace_desc
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = overrunning_war_white_peace_desc_attacker
+			}
+			desc = overrunning_war_white_peace_desc
+		}
+	}
+
+	on_white_peace = {
+
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 accolade glory gain for doing ok against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_low_effect = yes }
+		scope:defender = { accolade_defender_war_end_glory_gain_med_effect = yes }
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker # Not important as the scales are identical
+			FAME_BASE = major_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		# Truce
+		add_truce_white_peace_effect = yes
+
+		scope:attacker = {
+			add_dread = minor_dread_loss
+			add_legitimacy = minor_legitimacy_loss
+			add_prestige = mongol_invasion_cb_prestige_white_peace
+			stress_impact = {
+				ambitious = medium_stress_impact_gain
+				arrogant = medium_stress_impact_gain
+			}
+		}
+
+		scope:defender = {
+			stress_impact = {
+				arrogant = medium_stress_impact_gain
+			}
+		}
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = invasion_war_white_peace_desc_defender
+			}
+			desc = invasion_war_white_peace_desc
+		}
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = overrunning_war_surrender_desc_attacker
+			}
+			desc = overrunning_war_surrender_desc
+		}
+	}
+
+	on_defeat = {
+
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		# Legitimacy
+		add_legitimacy_attacker_defeat_effect = yes
+
+		# Influence
+		add_influence_attacker_defeat_effect = yes
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			#EP2 accolade glory gain for winning against higher ranked enemy
+			accolade_defender_war_end_glory_gain_high_effect = yes
+		}
+
+		# Prestige loss for the attacker
+		scope:attacker = {
+			add_dread = major_dread_loss
+			add_legitimacy = major_legitimacy_loss
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 2
+			}
+			add_prestige = {
+				value = massive_prestige_value
+				multiply = -1.0
+			}
+			switch = {
+			   trigger = has_realm_law
+			   nomadic_authority_5 = { add_realm_law = nomadic_authority_4 }
+			   nomadic_authority_4 = { add_realm_law = nomadic_authority_3 }
+			   nomadic_authority_3 = { add_realm_law = nomadic_authority_2 }
+			}
+		}
+
+		setup_invasion_cb = {
+			titles = target_titles
+			attacker = scope:attacker
+			defender = scope:defender
+			claimant = scope:claimant
+			victory = no
+		}
+
+		# Attacker loses Prestige, all other war participants gain Prestige (Defender gains full prestige, all allies on both sides gain based on war contribution).
+		modify_all_participants_fame_values = {
+			WINNER = scope:defender
+			LOSER = scope:attacker
+			FAME_BASE = scope:cb_prestige_factor # Set by 'setup_claim_cb'
+			IS_RELIGIOUS_WAR = no
+			WINNER_FAME_SCALE = scale_10_war_defender_win
+			LOSER_FAME_SCALE = -10
+			WINNER_ALLY_FAME_SCALE = 10
+			LOSER_ALLY_FAME_SCALE = 10
+		}
+
+		add_truce_attacker_defeat_effect = yes
+
+		scope:attacker = {
+			save_temporary_scope_as = loser
+		}
+		on_lost_aggression_war_discontent_loss = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	transfer_behavior = transfer
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	war_name = "MPO_NOMAD_DUCHY_INVASION_WAR_NAME"
+	war_name_base = "MPO_NOMAD_DUCHY_INVASION_WAR_NAME_BASE"
+	cb_name = "MPO_NOMAD_DUCHY_INVASION_CB_NAME"
+
+	interface_priority = 100
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 0.8
+
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+}
+
+##########
+# Humiliation CB
+##########
+
+humiliation_cb = {
+	icon = humiliation_cb
+	group = humiliation
+	
+	ai_only_against_neighbors = yes
+
+	allow_hostages = no
+	allowed_for_character = {
+		government_has_flag = government_is_nomadic
+		is_landed = yes
+	}
+
+	allowed_against_character = {
+		scope:defender = {
+			government_has_flag = government_is_nomadic
+			is_landed = yes
+			NOT = { has_realm_law = nomadic_authority_5 } # If they've become Genghis it's too late for this
+		}
+		OR = {
+			# You have lower Dominance than them
+			scope:attacker = {
+				mpo_lower_nomad_authority_trigger = { CHARACTER = scope:defender }
+			}
+			# They're the Gurkhan
+			scope:defender = { is_gurkhan = yes }
+		}
+	}
+
+	ignore_effect = change_title_holder
+
+	should_invalidate = {
+		OR = {
+			scope:attacker = { NOT = { government_has_flag = government_is_nomadic } }
+			scope:defender = { NOT = { government_has_flag = government_is_nomadic } }
+			scope:defender = { is_landed = no }
+		}
+	}
+
+	on_invalidated_desc = msg_remove_humiliation_cb_invalidated_message
+
+	cost = {
+		prestige = {
+			add = {
+				value = 75
+				desc = CB_BASE_COST
+			}
+			multiply = common_cb_prestige_cost_multiplier
+			if = {
+				limit = {
+					scope:attacker = {
+						any_character_situation = {
+							any_situation_sub_region = {
+								has_sub_region_phase_parameter = the_great_steppe_free_humiliation
+								any_situation_sub_region_participant_group = {
+									participant_group_type = nomad_rulers_capital
+									participant_group_has_character = scope:attacker
+								}
+							}
+						}
+					}
+				}
+				multiply = {
+					value = 0
+					desc = CB_STEPPE_SEASON_DISCOUNT
+				}
+			}
+		}
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+		scope:attacker = {
+			every_in_list = {
+			 	variable = obedient_vassals
+			 	limit = { is_ai = yes }
+				scope:war = { add_attacker = prev }
+			}
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = humiliation_cb_victory_desc_attacker
+			}
+			desc = humiliation_cb_victory_desc
+		}
+	}
+
+	on_victory = {
+		# Lowers the Dominance leavel of the Defender
+		scope:defender = {
+			lower_dominance_level_effect = yes
+			if = {
+				limit = { is_independent_ruler = yes }
+				# They will lose some land to Herders
+				custom_tooltip = humiliation_cb_release_herder_land_tt
+				mpo_release_herder_land_effect = yes
+			}
+		}
+		
+		scope:defender = {
+			pay_herd = {
+				target = scope:attacker
+				value = {
+					add = domicile.massive_herd_value
+					if = {
+						limit = {
+							scope:defender.primary_title.tier <= tier_duchy
+						}
+						multiply = 0.5
+					}
+				}
+			}
+		}
+		
+		# You "take" some of their Prestige
+		scope:defender = {
+			add_prestige = major_prestige_loss
+		}
+		scope:attacker = {
+			add_prestige = major_prestige_gain
+		}
+		
+		scope:defender = {
+			# Some of their obedient vassals become not obedient
+			custom_tooltip = humiliation_cb_not_obedient_tt
+			every_vassal = {
+				limit = {
+					is_obedient_to = scope:defender
+				}
+				add_to_list = obedient_vassals
+			}
+		}
+		ordered_in_list = {
+			list = obedient_vassals
+			order_by = prowess
+			max = {
+				value = list_size:obedient_vassals
+				multiply = 0.5
+			}
+			set_variable = {
+				name = not_obedient_humiliation_var
+				value = scope:defender
+				years = 5
+			}
+		}
+	
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		# Legitimacy
+		add_legitimacy_attacker_victory_effect = yes
+
+		#EP2 accolade glory gain for winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+
+		scope:attacker = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_positive" }
+		scope:defender = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_negative" }
+
+		# Prestige Progress for the Attacker
+		scope:attacker = {
+			add_prestige_experience = {
+				every_in_list = {
+					list = target_titles
+					add = medium_prestige_value
+				}
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		# Truce
+		add_truce_attacker_victory_effect = yes
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = humiliation_cb_white_peace_desc_defender
+			}
+			desc = humiliation_cb_white_peace_desc
+		}
+	}
+
+	on_white_peace = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 accolade glory gain for doing pretty good against higher ranked enemy
+		scope:defender = { accolade_defender_war_end_glory_gain_low_effect = yes }
+
+		scope:attacker = {
+			add_prestige = {
+				value = minor_prestige_value
+				multiply = -1.0
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker # not impactful as the scale are identical
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		add_truce_white_peace_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = humiliation_cb_defeat_desc_defender
+			}
+			desc = humiliation_cb_defeat_desc
+		}
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		scope:attacker = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_negative" }
+		scope:defender = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_positive" }
+
+		# Legitimacy
+		add_legitimacy_attacker_defeat_effect = yes
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			#EP2 accolade glory gain for winning against higher ranked enemy
+			accolade_defender_war_end_glory_gain_high_effect = yes
+			# Prestige for Defender
+			add_prestige_war_defender_effect = {
+				PRESTIGE_VALUE = medium_prestige_value
+			}
+		}
+
+		# Prestige loss for the attacker
+		scope:attacker = {
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 3
+			}
+			add_prestige = {
+				value = major_prestige_value
+				multiply = -1.0
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:defender
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		add_truce_attacker_defeat_effect = yes
+
+		scope:attacker = {
+			save_temporary_scope_as = loser
+		}
+		on_lost_aggression_war_discontent_loss = yes
+	}
+
+	transfer_behavior = transfer
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	war_name = "HUMILIATION_WAR_CB_NAME"
+	war_name_base = "HUMILIATION_WAR_CB_NAME_BASE"
+	cb_name = "HUMILIATION_WAR_CB_NAME"
+
+	interface_priority = 79
+
+	attacker_wargoal_percentage = 0.8
+
+	max_defender_score_from_battles = 150
+	max_attacker_score_from_battles = 150
+
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	ai_score = {
+		value = {
+			value = 25
+			multiply = scope:attacker.ai_boldness
+		}
+	}
+}
+
+##########
+# Retaliation CB
+##########
+
+retaliation_cb = {
+	icon = retaliation_cb
+	group = humiliation
+
+	allow_hostages = no
+	allowed_for_character = {
+		government_allows = obedience
+		has_variable_list = retaliation_cb_var_list
+		exists = scope:defender
+		is_target_in_variable_list = {
+			name = retaliation_cb_var_list
+			target = scope:defender
+		}
+		is_landed = yes
+	}
+	
+	allowed_for_character_display_regardless = { # They're already your Tributary
+		scope:defender = {
+			NOT = { is_tributary_of = scope:attacker }
+			is_landed = yes
+		}
+	}
+
+	allowed_against_character = {
+		scope:defender = {
+			government_has_flag = government_is_nomadic
+		}
+	}
+	
+	ai_score = {
+		value = {
+			value = 100
+			scope:defender = {
+				every_sub_realm_county = {
+					add = 100
+				}
+			}
+			scope:attacker = {
+				if = {
+					limit = {
+						domain_size >= domain_limit
+					}
+					multiply = 5
+				}
+			}
+			if = {
+				limit = {
+					scope:attacker.ai_vengefulness > 0
+				}
+				multiply = scope:attacker.ai_vengefulness
+			}
+		}
+	}
+	
+	ai_score_mult = {
+		value = 3
+	}
+
+	ignore_effect = change_title_holder
+
+	should_invalidate = {
+		OR = {
+			scope:attacker = { is_landed = no }
+			scope:defender = { is_landed = no }
+		}
+	}
+
+	on_invalidated_desc = msg_remove_retaliation_cb_invalidated_message
+
+	cost = {
+		prestige = {
+			add = {
+				value = 75
+				desc = CB_BASE_COST
+			}
+			multiply = common_cb_prestige_cost_multiplier
+			if = {
+				limit = {
+					scope:attacker = {
+						any_character_situation = {
+							any_situation_sub_region = {
+								has_sub_region_phase_parameter = the_great_steppe_free_retaliation
+								any_situation_sub_region_participant_group = {
+									participant_group_type = nomad_rulers_capital
+									participant_group_has_character = scope:attacker
+								}
+							}
+						}
+					}
+				}
+				multiply = {
+					value = 0
+					desc = CB_STEPPE_SEASON_DISCOUNT
+				}
+			}
+		}
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+		scope:attacker = {
+			every_in_list = {
+			 	variable = obedient_vassals
+			 	limit = { is_ai = yes }
+				scope:war = { add_attacker = prev }
+			}
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = retaliation_cb_victory_desc_attacker
+			}
+			desc = retaliation_cb_victory_desc
+		}
+	}
+
+	on_victory = {
+		# Make them a Tributary
+		if = { # This if/else exists for localization purposes, since it could be parsed before the war starts
+			limit = { exists = root.war }
+			start_tributary_from_war_effect = {
+				TRIBUTARY = scope:defender
+				SUZERAIN = scope:attacker
+				WAR = root.war
+			}
+		}
+		else = {
+			start_tributary_interaction_effect = {
+				TRIBUTARY = scope:defender
+				SUZERAIN = scope:attacker
+			}
+		}
+		
+		#If you tributarize a confederate, they leave their confederation
+		if = {
+			limit = {
+				scope:defender = {
+					is_confederation_member = yes
+				}
+			}
+			scope:defender.confederation = {
+				remove_confederation_member = scope:defender
+			}
+		}
+		
+		# They pay you Herd or Gold
+		if = {
+			limit = {
+				scope:defender = { government_has_flag = government_is_nomadic }
+				scope:attacker = { government_has_flag = government_is_nomadic }
+			}
+			scope:defender = {
+				pay_herd = {
+					target = scope:attacker
+					value = domicile.massive_herd_value
+				}
+			}
+		}
+		else = {
+			scope:defender = {
+				pay_short_term_gold = {
+					target = scope:attacker
+					gold = massive_gold_value
+				}
+			}
+		}
+		
+		
+		# You "take" some of their Prestige
+		scope:defender = {
+			if = {
+				limit = {
+					highest_held_title_tier >= tier_kingdom
+				}
+				add_prestige = major_prestige_loss
+			}
+			else_if = {
+				limit = {
+					highest_held_title_tier >= tier_duchy
+				}
+				add_prestige = medium_prestige_loss
+			}
+			else = {
+				add_prestige = minor_prestige_loss
+			}
+		}
+		scope:attacker = {
+			if = {
+				limit = {
+					scope:defender = { highest_held_title_tier >= tier_kingdom }
+				}
+				add_prestige = scope:defender.major_prestige_gain
+			}
+			else_if = {
+				limit = {
+					scope:defender = { highest_held_title_tier >= tier_duchy }
+				}
+				add_prestige = scope:defender.medium_prestige_gain
+			}
+			else = {
+				add_prestige = scope:defender.minor_prestige_gain
+			}
+		}
+	
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		# Legitimacy
+		add_legitimacy_attacker_victory_effect = yes
+
+		#EP2 accolade glory gain for winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+
+		scope:attacker = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_positive" }
+		scope:defender = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_negative" }
+
+		# Prestige Progress for the Attacker
+		every_in_list = {
+			list = target_titles
+			scope:attacker = {
+				add_prestige_experience = medium_prestige_value
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		# Truce
+		add_truce_attacker_victory_effect = yes
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+		
+		# We clean up the CB
+		hidden_effect = {
+			scope:attacker = {
+				remove_list_variable = {
+					name = retaliation_cb_var_list
+					target = scope:defender
+				}
+			}
+		}
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = retaliation_cb_white_peace_desc_defender
+			}
+			desc = retaliation_cb_white_peace_desc
+		}
+	}
+
+	on_white_peace = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 accolade glory gain for doing pretty good against higher ranked enemy
+		scope:defender = { accolade_defender_war_end_glory_gain_low_effect = yes }
+
+		scope:attacker = {
+			add_prestige = {
+				value = minor_prestige_value
+				multiply = -1.0
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker # not impactful as the scale are identical
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		add_truce_white_peace_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = retaliation_cb_defeat_desc_defender
+			}
+			desc = retaliation_cb_defeat_desc
+		}
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		scope:attacker = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_negative" }
+		scope:defender = { play_sound_effect = "event:/DLC/CE2/UI/Notifications/ce2_ui_notifications_migration_positive" }
+
+		# Legitimacy
+		add_legitimacy_attacker_defeat_effect = yes
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			#EP2 accolade glory gain for winning against higher ranked enemy
+			accolade_defender_war_end_glory_gain_high_effect = yes
+			# Prestige for Defender
+			add_prestige_war_defender_effect = {
+				PRESTIGE_VALUE = medium_prestige_value
+			}
+		}
+
+		# Prestige loss for the attacker
+		scope:attacker = {
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 3
+			}
+			add_prestige = {
+				value = major_prestige_value
+				multiply = -1.0
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:defender
+			FAME_BASE = medium_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		add_truce_attacker_defeat_effect = yes
+
+		scope:attacker = {
+			save_temporary_scope_as = loser
+		}
+		on_lost_aggression_war_discontent_loss = yes
+	}
+
+	transfer_behavior = transfer
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	war_name = "RETALIATION_WAR_CB_NAME"
+	war_name_base = "RETALIATION_WAR_CB_NAME_BASE"
+	cb_name = "RETALIATION_WAR_CB_NAME"
+
+	interface_priority = 79
+
+	attacker_wargoal_percentage = 0.8
+	
+	max_defender_score_from_battles = 150
+	max_attacker_score_from_battles = 150
+
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+}
+
+#################
+# Domination CB #
+#################
+domination_cb = {
+	icon = county_conquest_cb
+	group = event
+
+	should_show_war_goal_subview = yes
+
+	allowed_for_character = {
+		always = no
+	}
+
+	ignore_effect = change_title_holder
+	target_titles = all
+	use_de_jure_wargoal_only = yes
+	target_de_jure_regions_above = yes
+	white_peace_possible = no
+	
+	attacker_score_from_occupation_scale = 150
+	attacker_score_from_battles_scale = 150
+	defender_score_from_battles_scale = 150
+	imprisonment_by_attacker_give_war_score = no
+
+	ai_score_mult = {
+		value = 1
+	}
+
+	on_invalidated_desc = msg_county_conquest_war_invalidated_message
+
+	cost = {
+		prestige = {
+			value = 50
+			multiply = common_cb_prestige_cost_multiplier
+		}
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = county_conquest_cb_victory_desc_attacker
+			}
+			desc = county_conquest_cb_victory_desc
+		}
+	}
+
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		# Legitimacy
+		add_legitimacy_attacker_victory_effect = yes
+
+		create_title_and_vassal_change = {
+			type = conquest
+			save_scope_as = change
+			add_claim_on_loss = yes
+		}
+
+		every_in_list = {
+			list = target_titles
+			change_title_holder = {
+				holder = scope:attacker
+				change = scope:change
+			}
+		}
+
+		resolve_title_and_vassal_change = scope:change
+
+		scope:war = {
+			every_war_defender = {
+				custom = every_defender
+				limit = {
+					OR = {
+						government_has_flag = government_is_nomadic
+						government_has_flag = government_is_herder
+					}
+				}
+				if = {
+					limit = {
+						exists = this.confederation
+					}
+					confederation = { remove_confederation_member = prev }
+				}
+
+				if = { # This if/else exists for localization purposes, since it could be parsed before the war starts
+					limit = { exists = root.war }
+					start_tributary_from_war_effect = {
+						TRIBUTARY = this
+						SUZERAIN = scope:attacker
+						WAR = root.war
+					}
+				}
+				else = {
+					start_tributary_interaction_effect = {
+						TRIBUTARY = this
+						SUZERAIN = scope:attacker
+					}
+				}
+
+				add_opinion = {
+					modifier = crushed_opponent_opinion
+					target = scope:attacker
+					opinion = 15
+				}
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker
+			FAME_BASE = minor_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		# Truce
+		add_truce_attacker_victory_effect = yes
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = county_conquest_cb_white_peace_desc_defender
+			}
+			
+		}
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = county_conquest_cb_defeat_desc_defender
+			}
+			triggered_desc = {
+				trigger = {
+					scope:attacker = {
+						is_local_player = yes
+						has_targeting_faction = yes
+					}
+				}
+				desc = county_conquest_cb_defeat_desc_attacker
+			}
+			desc = county_conquest_cb_defeat_desc
+		}
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		# Legitimacy
+		add_legitimacy_attacker_defeat_effect = yes
+
+		# Prestige loss for the attacker
+		scope:attacker = {
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 2
+			}
+			add_prestige = medium_prestige_loss
+			add_dread = -50
+		}
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			# Prestige for Defender
+			add_prestige_war_defender_effect = {
+				PRESTIGE_VALUE = medium_prestige_value
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:defender
+			FAME_BASE = minor_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		add_truce_attacker_defeat_effect = yes
+
+		scope:attacker = {
+			save_temporary_scope_as = loser
+		}
+		on_lost_aggression_war_discontent_loss = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	transfer_behavior = transfer
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	war_name = "DOMINATION_WAR_WAR_NAME"
+	war_name_base = "DOMINATION_WAR_WAR_NAME_BASE"
+	cb_name = "DOMINATION_WAR_CB_NAME"
+
+	interface_priority = 75
+
+	attacker_wargoal_percentage = 1.5
+	
+	max_defender_score_from_battles = 150
+	max_attacker_score_from_battles = 150
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	defender_ticking_warscore = 0.05
+}
+
+
+######################
+# Nomadic De Jure CB #
+######################
+de_jure_cb_nomadic = {
+	icon = individual_duchy_de_jure_cb
+	group = de_jure
+	should_check_for_interface_availability = no
+	
+	combine_into_one = yes
+	should_show_war_goal_subview = yes
+	mutually_exclusive_titles = { always = yes }
+	
+	allowed_for_character = {
+		scope:attacker = {
+			trigger_if = {
+				limit = {
+					is_ai = yes
+				}
+				highest_held_title_tier >= tier_kingdom	
+			}
+			government_has_flag = government_is_nomadic
+			highest_held_title_tier >= tier_duchy
+		}
+	}
+
+	allowed_against_character = {
+		NOR = {
+			scope:defender = { target_is_liege_or_above = scope:attacker }
+			scope:attacker = { target_is_liege_or_above = scope:defender }
+		}
+	}
+	target_titles = neighbor_land
+	target_title_tier = all
+	target_de_jure_regions_above = yes
+	ignore_effect = change_title_holder
+	ai_only_against_neighbors = yes
+	
+	valid_to_start = {
+		scope:target = {
+			trigger_if = {
+				limit = {
+					tier = tier_county
+				}
+				any_county_situation = {
+					any_participant_group = {
+						participant_group_type = nomad_rulers_capital
+					}
+				}
+			}
+			trigger_else = {
+				any_de_jure_county = {
+					any_county_situation = {
+						any_participant_group = {
+							participant_group_type = nomad_rulers_capital
+						}
+					}
+				}
+			}
+			tier = scope:attacker.mpo_de_jure_title_value
+			OR = {
+				# Internal
+				any_this_title_or_de_jure_above = {
+					holder ?= {
+						OR = {
+							this = scope:attacker
+							target_is_liege_or_above = scope:attacker
+						}
+					}
+				}
+				# External 
+				AND = {
+					scope:attacker = {
+						highest_held_title_tier >= tier_kingdom
+					}
+					scope:target = {
+						NOT = { de_jure_liege = scope:attacker.primary_title }
+						switch = {
+							trigger = scope:target.tier
+							tier_empire = {
+								any_title_to_title_neighboring_empire = {
+									any_this_title_or_de_jure_above = {
+										this = scope:attacker.primary_title
+									}
+								}
+							}
+							tier_kingdom = {
+								any_title_to_title_neighboring_kingdom = {
+									any_this_title_or_de_jure_above = {
+										this = scope:attacker.primary_title
+									}
+								}
+							}
+							tier_duchy = {
+								any_title_to_title_neighboring_duchy = {
+									any_this_title_or_de_jure_above = {
+										this = scope:attacker.primary_title
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	cost = {
+		prestige = {
+			value = 0
+			# scale base value based on number of counties x 100
+			add = {
+				every_in_list = {
+					list = target_titles
+					every_in_de_jure_hierarchy = { # goes down, not up
+						limit = {
+							tier = tier_county
+							holder.top_liege = scope:defender
+							NOT = { target_is_de_jure_liege_or_above = scope:attacker.primary_title }
+						}
+						add = 300
+					}
+				}
+				desc = CB_CLAIM_COST_TARGET_TITLES_FOREIGN
+			}
+			add = {
+				every_in_list = {
+					list = target_titles
+					every_in_de_jure_hierarchy = { # goes down, not up
+						limit = {
+							tier = tier_county
+							holder.top_liege = scope:defender
+							target_is_de_jure_liege_or_above = scope:attacker.primary_title
+						}
+						add = 100
+					}
+				}
+				desc = CB_CLAIM_COST_TARGET_TITLES
+			}
+
+			multiply = common_cb_prestige_cost_multiplier
+		}
+	}
+
+	should_invalidate = {
+		NOT = {
+			any_in_list = {
+				list = target_titles
+				any_in_de_jure_hierarchy = {
+					tier = tier_county
+					holder = {
+						OR = {
+							this = scope:defender
+							target_is_liege_or_above = scope:defender
+						}
+					}
+				}
+			}
+		}
+	}
+
+	on_invalidated_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:attacker.liege = {
+						any_character_war = {
+							primary_defender = {
+								save_temporary_scope_as = defender_check
+							}
+						}
+					}
+					scope:defender = scope:defender_check
+				}
+				desc = msg_de_jure_duchy_war_invalidated_liege_war_message
+			}
+			desc = msg_de_jure_duchy_war_invalidated_message
+		}
+	}
+
+	on_invalidated = {
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+	}	
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = de_jure_cb_victory_desc_attacker
+			}
+			desc = de_jure_cb_victory_desc
+		}
+	}
+	
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		# Legitimacy
+		add_legitimacy_attacker_victory_effect = yes
+
+		#EP2 accolade glory gain for winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+
+		mpo_war_vassal_tributary_effect	= { WAR = root.war }
+
+		# Attacker gets Prestige Experience, Defender loses Prestige, all other participants gain Prestige based on their war contribution.
+		modify_all_participants_fame_values = {
+			WINNER = scope:attacker
+			LOSER = scope:defender
+			FAME_BASE = scope:cb_prestige_factor # Set by 'setup_de_jure_cb'
+			IS_RELIGIOUS_WAR = no
+			WINNER_FAME_SCALE = 2
+			LOSER_FAME_SCALE = -2
+			WINNER_ALLY_FAME_SCALE = 20
+			LOSER_ALLY_FAME_SCALE = 20
+		}
+		
+		# truce
+		add_truce_attacker_victory_effect = yes
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = de_jure_cb_white_peace_desc_defender
+			}
+			desc = de_jure_cb_white_peace_desc
+		}
+	}
+	
+	on_white_peace = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 accolade glory gain for doing ok against higher ranked enemy
+		scope:defender = { accolade_defender_war_end_glory_gain_low_effect = yes }
+
+		# Create an 'helper' de jure CB which we won't execute, but can use to determine how much Prestige should be given to war participants.
+		every_in_list = {
+			list = target_titles
+			save_temporary_scope_as = target
+		}
+		setup_de_jure_cb = {
+			attacker = scope:attacker
+			defender = scope:defender
+			victory = no
+			title = scope:target
+		}
+		# Prestige loss for the attacker
+		scope:attacker = {
+			add_prestige = {
+				value = scope:cb_prestige_factor # Set by 'setup_de_jure_cb'
+				multiply = -5.0
+			}
+		}
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker
+			FAME_BASE = scope:cb_prestige_factor # Set by 'setup_de_jure_cb'
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 100
+			LOSER_ALLY_FAME_SCALE = 100
+		}
+		# Defender neither gains nor loses any prestige.
+		
+		# Truce
+		add_truce_white_peace_effect = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = de_jure_cb_defeat_desc_defender
+			}
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = de_jure_cb_defeat_desc_attacker
+			}
+			desc = de_jure_cb_defeat_desc
+		}
+	}
+	
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		# Legitimacy
+		add_legitimacy_attacker_defeat_effect = yes
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			#EP2 accolade glory gain for winning against higher ranked enemy
+			accolade_defender_war_end_glory_gain_high_effect = yes
+		}
+
+		# Attacker must pay the defender war reparations.
+		scope:attacker = {
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 3
+			}
+		}
+
+		# Create an 'helper' de jure CB which we won't execute, but can use to determine how much Prestige should be given to war participants.
+		every_in_list = {
+			list = target_titles
+			save_temporary_scope_as = target
+		}
+		setup_de_jure_cb = {
+			attacker = scope:attacker
+			defender = scope:defender
+			victory = no
+			title = scope:target
+		}
+		# Attacker loses Prestige, all other participants gain Prestige based on their war contribution (Defender gets full Prestige).
+		modify_all_participants_fame_values = {
+			WINNER = scope:defender
+			LOSER = scope:attacker
+			FAME_BASE = scope:cb_prestige_factor # Set by 'setup_de_jure_cb'
+			IS_RELIGIOUS_WAR = no
+			WINNER_FAME_SCALE = scale_10_war_defender_win
+			LOSER_FAME_SCALE = -10
+			WINNER_ALLY_FAME_SCALE = 100
+			LOSER_ALLY_FAME_SCALE = 100
+		}
+	
+		# Truce
+		add_truce_attacker_defeat_effect = yes
+		
+		scope:attacker = {
+			save_temporary_scope_as = loser
+		}
+		on_lost_aggression_war_discontent_loss = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+	
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+	
+	transfer_behavior = transfer
+	
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+	
+	war_name = "NOMAD_DEJURE_CB_WAR_NAME"
+	war_name_base = "NOMAD_DEJURE_CB_WAR_NAME_BASE"
+	cb_name = NOMAD_DEJURE_CB_NAME
+	cb_name_no_target = NOMAD_DEJURE_CB_NAME_GENERIC
+	interface_priority = 99 # Below the "take all" one
+	
+	attacker_wargoal_percentage = 0.8
+	
+	max_defender_score_from_battles = 100
+	max_attacker_score_from_battles = 100
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	defender_ticking_warscore = 0.05
+	
+	max_ai_diplo_distance_to_title = 500
+
+	ai_score_mult = {
+		value = 3
+		if = {
+			limit = {
+				scope:attacker = {
+					OR = {
+						is_landed = no
+						capital_county = {
+							any_county_situation_sub_region = {
+								sub_region_current_phase = situation_steppe_havsarsan_zud_season
+							}
+						}
+					}
+				}
+			}
+			multiply = 0.33
+		}
+		if = {
+			limit = {
+				scope:defender = {
+					any_owned_story = {
+						story_type = frankokratia_story
+						NOT = { has_variable = franko_war_complete }
+					}
+				}
+			}
+			multiply = 0
+		}
+	}
+}
+
+##################
+# Sovereignty CB #
+##################
+sovereignty_cb = {
+	icon = retaliation_cb
+	group = subjugation
+	should_check_for_interface_availability = no
+	
+	allowed_for_character = {
+		scope:attacker = {
+			is_landed = yes
+			trigger_if = {
+				limit = {
+					is_ai = yes
+				}
+				highest_held_title_tier >= tier_kingdom	
+			}
+			government_has_flag = government_is_nomadic
+		}
+	}
+
+	allowed_against_character = {
+		scope:defender = {
+			is_landed = yes
+			government_has_flag = government_is_nomadic
+		}
+		NOR = {
+			scope:defender = { target_is_liege_or_above = scope:attacker }
+			scope:attacker = { target_is_liege_or_above = scope:defender }
+		}
+	}
+	target_titles = none
+	ignore_effect = change_title_holder
+	
+	valid_to_start = {
+		scope:defender = {
+			any_tributary = {
+				any_neighboring_top_liege_realm_owner = {
+					OR = {
+						this = scope:attacker
+						suzerain ?= scope:attacker
+					}
+				}
+			}
+		}
+	}
+
+	cost = {
+		prestige = {
+			value = 250
+
+			multiply = common_cb_prestige_cost_multiplier
+		}
+	}
+
+	should_invalidate = {
+		NOT = {
+			scope:defender = {
+				any_tributary = {
+					any_neighboring_top_liege_realm_owner = {
+						OR = {
+							this = scope:attacker
+							suzerain ?= scope:attacker
+						}
+					}
+				}
+			}
+		}
+	}
+
+	on_invalidated_desc = must_neighbor_or_neighbor_tributary_tt
+
+	on_invalidated = {
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+	}	
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = sovereignty_cb_victory_desc_attacker
+			}
+			desc = sovereignty_cb_victory_desc
+		}
+	}
+	
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		# Legitimacy
+		add_legitimacy_attacker_victory_effect = yes
+
+		#EP2 accolade glory gain for winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+
+		custom_tooltip = sovereignty_war_tributary_switch
+		hidden_effect = {
+			scope:defender = {
+				while = {
+					limit = {
+						any_tributary = {
+							any_neighboring_top_liege_realm_owner = {
+								OR = {
+									this = scope:attacker
+									suzerain ?= scope:attacker
+								}
+							}
+						}
+					}
+					random_tributary = {
+						limit = {
+							any_neighboring_top_liege_realm_owner = {
+								OR = {
+									this = scope:attacker
+									suzerain ?= scope:attacker
+								}
+							}
+						}
+						save_scope_as = current_tributary
+						start_tributary_from_war_effect = {
+							TRIBUTARY = scope:current_tributary
+							SUZERAIN = scope:attacker
+							WAR = root.war
+						}
+					}
+				}
+			}
+		}
+
+		# Attacker gets Prestige Experience, Defender loses Prestige, all other participants gain Prestige based on their war contribution.
+		modify_all_participants_fame_values = {
+			WINNER = scope:attacker
+			LOSER = scope:defender
+			FAME_BASE = 50 # Set by 'setup_de_jure_cb'
+			IS_RELIGIOUS_WAR = no
+			WINNER_FAME_SCALE = 2
+			LOSER_FAME_SCALE = -2
+			WINNER_ALLY_FAME_SCALE = 20
+			LOSER_ALLY_FAME_SCALE = 20
+		}
+		
+		# truce
+		add_truce_attacker_victory_effect = yes
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = sovereignty_cb_white_peace_desc_defender
+			}
+			desc = sovereignty_cb_white_peace_desc
+		}
+	}
+	
+	on_white_peace = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 accolade glory gain for doing ok against higher ranked enemy
+		scope:defender = { accolade_defender_war_end_glory_gain_low_effect = yes }
+
+		# Create an 'helper' de jure CB which we won't execute, but can use to determine how much Prestige should be given to war participants.
+		every_in_list = {
+			list = target_titles
+			save_temporary_scope_as = target
+		}
+
+		# Prestige loss for the attacker
+		scope:attacker = {
+			add_prestige = {
+				value = 100
+				multiply = -5.0
+			}
+		}
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker
+			FAME_BASE = 100
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 100
+			LOSER_ALLY_FAME_SCALE = 100
+		}
+		# Defender neither gains nor loses any prestige.
+		
+		# Truce
+		add_truce_white_peace_effect = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = sovereignty_cb_defeat_desc_defender
+			}
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = sovereignty_cb_defeat_desc_attacker
+			}
+			desc = sovereignty_cb_defeat_desc
+		}
+	}
+	
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		
+		# Legitimacy
+		add_legitimacy_attacker_defeat_effect = yes
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			#EP2 accolade glory gain for winning against higher ranked enemy
+			accolade_defender_war_end_glory_gain_high_effect = yes
+		}
+
+		# Attacker must pay the defender war reparations.
+		scope:attacker = {
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 3
+			}
+		}
+
+		# Create an 'helper' de jure CB which we won't execute, but can use to determine how much Prestige should be given to war participants.
+		every_in_list = {
+			list = target_titles
+			save_temporary_scope_as = target
+		}
+		# Attacker loses Prestige, all other participants gain Prestige based on their war contribution (Defender gets full Prestige).
+		modify_all_participants_fame_values = {
+			WINNER = scope:defender
+			LOSER = scope:attacker
+			FAME_BASE = 10
+			IS_RELIGIOUS_WAR = no
+			WINNER_FAME_SCALE = scale_10_war_defender_win
+			LOSER_FAME_SCALE = -10
+			WINNER_ALLY_FAME_SCALE = 100
+			LOSER_ALLY_FAME_SCALE = 100
+		}
+	
+		# Truce
+		add_truce_attacker_defeat_effect = yes
+		
+		scope:attacker = {
+			save_temporary_scope_as = loser
+		}
+		on_lost_aggression_war_discontent_loss = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+	
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+	
+	transfer_behavior = transfer
+	
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+	
+	war_name = "SOVEREIGNTY_WAR_CB_NAME"
+	war_name_base = "SOVEREIGNTY_WAR_WAR_NAME_BASE"
+	#cb_name = NOMAD_DEJURE_CB_NAME
+	#cb_name_no_target = NOMAD_DEJURE_CB_NAME_GENERIC
+	interface_priority = 99 # Below the "take all" one
+	
+	attacker_wargoal_percentage = 0.8
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	defender_ticking_warscore = 0.05
+	
+	max_ai_diplo_distance_to_title = 500
+
+	ai_score = {
+		value = {
+			value = 50
+			scope:defender = {
+				every_tributary = {
+					limit = {
+						any_neighboring_top_liege_realm_owner = {
+							OR = {
+								this = scope:attacker
+								suzerain ?= scope:attacker
+							}
+						}
+					}
+					every_sub_realm_county = {
+						add = 50
+					}
+				}
+			}
+			scope:attacker = {
+				if = {
+					limit = {
+						domain_size >= domain_limit
+					}
+					multiply = 5
+				}
+			}
+		}
+	}
+
+	ai_score_mult = {
+		value = 1
+		add = frankokratia_leader_protection_value #Set back to 0. Declaring war on the frankokratia leader can really ruin the whole thing
+	}
+}
+
+
+#THE WAR THAT FORGES THE GREATEST OF KHANS
+mpo_great_war_of_defiance_cb = {
+	icon = migration_cb
+	group = event
+
+	full_occupation_by_defender_gives_victory = no
+	attacker_capital_gives_war_score = no
+	check_all_defenders_for_ticking_war_score = yes
+	defender_ticking_warscore_delay = { months = 4 }
+	defender_ticking_warscore = 0.125
+	imprisonment_by_defender_give_war_score = no
+	defender_score_from_occupation_scale = 50
+	attacker_score_from_occupation_scale = 50
+	defender_score_from_battles_scale = 125
+	attacker_score_from_battles_scale = 125
+	ticking_war_score_targets_entire_realm = yes
+
+	occupation_participation_mult = 0.5
+	siege_participation_mult = 1
+	battle_participation_mult = 7.5
+
+	allow_hostages = no
+
+	allowed_against_character = {
+		is_landed = yes
+		any_character_situation = {
+			any_participant_group = {
+				participant_group_type = nomad_rulers_capital
+			}
+		}
+		government_has_flag = government_is_nomadic
+		highest_held_title_tier >= tier_empire
+	}
+
+	white_peace_possible = no
+
+	cost = {
+	}
+
+	target_titles = claim
+	target_title_tier = all
+
+	on_declaration = {
+		on_declared_war = yes
+	}
+
+	should_invalidate = {
+		scope:defender = {
+			OR = {
+				#Is vassal for some reason
+				is_independent_ruler = no
+				#Is landless nobody for some reason
+				NOR = {
+					is_landed = yes
+					is_landless_ruler = yes
+				}
+			}
+			
+		}
+	}
+
+	on_invalidated_desc = {
+		desc = msg_great_war_of_defiance_war_invalidated_message
+	}
+	
+	on_invalidated = {
+		scope:attacker = {
+			random_character_war = {
+				limit = {
+					using_cb = mpo_great_war_of_defiance_cb
+				}
+				every_war_attacker = {
+					add_to_list = anti_gok_attackers
+				}
+			}
+		}
+		every_in_list = {
+			list = anti_gok_attackers
+			add_prestige = medium_prestige_gain
+			add_piety = medium_piety_gain
+		}
+		scope:defender = {
+			add_prestige = medium_prestige_gain
+			remove_decision_cooldown = mpo_become_greatest_of_khans_decision
+			remove_character_modifier = aspiring_great_khan_modifier
+		}
+		mpo_gok_war_of_defiance_cleanup_effect = yes
+		remove_global_variable = mpo_gok_war_ongoing
+
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = mpo_war_of_defiance_gok_loses_defender
+			}
+			triggered_desc = {
+				trigger = { scope:attacker = { is_local_player = yes } }
+				desc = mpo_war_of_defiance_gok_loses_attacker
+			}
+			desc = mpo_war_of_defiance_gok_loses_other
+		}
+	}
+
+	on_victory = {
+		scope:attacker = {
+			random_character_war = {
+				limit = {
+					using_cb = mpo_great_war_of_defiance_cb
+				}
+				save_scope_as = gok_war
+				every_war_attacker = {
+					add_to_list = anti_gok_attackers
+				}
+				every_war_defender = {
+					add_to_list = anti_gok_defenders
+				}
+			}
+		}
+		mpo_gok_war_of_defiance_cleanup_effect = yes
+
+		# Legitimacy
+		add_legitimacy_attacker_victory_effect = yes
+
+
+		scope:defender = {
+			#Vassals all become independent...
+			every_vassal = {
+				custom = custom.every_defender_vassal
+				limit = {
+					highest_held_title_tier >= tier_county
+				}
+				create_title_and_vassal_change = {
+					type = independency
+					save_scope_as = change
+					add_claim_on_loss = no
+				}
+				becomes_independent = { change = scope:change }
+				resolve_title_and_vassal_change = scope:change
+			}
+			#Tributaries piss off
+			every_tributary = {
+				custom = custom.every_defender_tributary
+				end_tributary = yes
+			}
+			#You lose your titles to... herders
+			give_domain_to_herders = yes
+			add_legitimacy = monumental_legitimacy_loss
+			if = {
+				limit = {
+					government_has_flag = government_is_nomadic 
+					exists = domicile
+				}
+				domicile = {
+					change_herd = negative_seventy_five_percent_herd_value
+				}
+			}
+			remove_short_term_gold = ninety_percent_gold_value
+			add_prestige = negative_seventy_five_percent_prestige_value
+			if = {
+				limit = {
+					government_has_flag = government_is_nomadic
+					has_realm_law = nomadic_authority_2
+					NOT = {
+						has_realm_law = nomadic_authority_1
+					}
+				}
+				add_realm_law = nomadic_authority_1
+			}
+			else_if = {
+				limit = {
+					government_has_flag = government_is_nomadic
+					NOT = {
+						has_realm_law = nomadic_authority_1
+					}
+				}
+				add_realm_law = nomadic_authority_2
+			}
+		}
+
+		custom_tooltip = mpo_war_of_defiance_gold_herd_tt
+		custom_tooltip = accolade_attackers_all_gain_glory_tt
+		hidden_effect = {
+			every_in_list = {
+				list = anti_gok_attackers
+				add_short_term_gold = medium_gold_value
+				if = {
+					limit = {
+						government_has_flag = government_is_nomadic
+						exists = domicile
+					}
+					domicile = {
+						change_herd = medium_herd_gain
+					}
+				}
+				if = {
+					limit = {
+						has_dlc_feature = accolades
+					}
+					accolade_attacker_war_end_glory_gain_very_high_effect = yes
+				}
+			}
+		}
+		scope:attacker = {
+			hidden_effect = {
+				add_opinion = {
+					modifier = tried_to_become_gok_opinion
+					target = scope:defender
+				}
+			}
+			rightfully_imprison_character_less_verbose_effect = { 
+				TARGET = scope:defender
+				IMPRISONER = scope:attacker
+			}
+		}
+
+		# Prestige level progress for the attacker
+		scope:attacker = {
+			add_prestige_experience = {
+				value = major_prestige_value
+			}
+		}
+
+		# Prestige loss for the defender
+		scope:defender = {
+			add_prestige_level = -1
+		}
+
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#Memories
+		#Memory for Gurkhan
+		scope:defender = {
+			create_character_memory = {
+				type = gok_defeated_defiance_war
+				participants = {
+					opponent = scope:attacker
+				}
+			}
+		}
+		#Memory for Gurkhan vassals
+		every_in_list = {
+			list = anti_gok_defenders
+			limit = {
+				NOT = {
+					this = scope:defender
+				}
+			}
+			create_character_memory = {
+				type = gok_defeated_defiance_war_defenders
+				participants = {
+					gurkhan = scope:defender
+				}
+			}
+		}
+		#Memory for coalition
+		every_in_list = {
+			list = anti_gok_attackers
+			create_character_memory = {
+				type = gok_defeated_defiance_war_attackers
+				participants = {
+					gurkhan = scope:defender
+				}
+			}
+		}
+		
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker
+			FAME_BASE = major_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 10
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+		remove_global_variable = mpo_gok_war_ongoing
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		# Truce
+		add_truce_attacker_victory_effect = yes
+
+		#Notification event that Gurkhan is defeated
+		every_player = {
+			limit = {
+				OR = {
+					any_character_war = {
+						this = scope:gok_war
+					}
+					scope:defender = {
+						save_temporary_scope_as = root
+					}
+					mpo_war_of_defiance_notified_player_trigger = yes
+				}
+			}
+			trigger_event = {
+				id = mpo_greatest_of_khans.0103
+				days = 2
+			}
+		}
+	}
+
+	on_white_peace_desc = {}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = mpo_war_of_defiance_gok_wins_defender
+			}
+			desc = mpo_war_of_defiance_gok_wins_other
+		}
+		
+	}
+
+	on_defeat = {
+		scope:defender = {
+			random_character_war = {
+				limit = {
+					using_cb = mpo_great_war_of_defiance_cb
+				}
+				every_war_attacker = {
+					add_to_list = anti_gok_attackers
+				}
+				every_war_defender = {
+					add_to_list = anti_gok_defenders
+				}
+			}
+		}
+		
+		scope:defender = {
+			custom_tooltip = will_become_greatest_of_khans_tt
+			primary_title = {
+				save_scope_as = defender_title
+			}
+			custom_tooltip = every_new_vassal_becomes_obedient_tt
+			every_in_list = {
+				list = anti_gok_attackers
+				limit = {
+					OR = {
+						government_has_flag = government_is_nomadic
+						government_has_flag = government_is_herder
+					}
+					is_independent_ruler = yes
+				}
+				hidden_effect = {
+					add_opinion = {
+						modifier = obedience_opinion
+						target = scope:defender
+						years = 10
+					}
+				}
+				if = {
+					limit = {
+						highest_held_title_tier < scope:defender.highest_held_title_tier
+					}
+					create_title_and_vassal_change = {
+						type = swear_fealty
+						save_scope_as = change
+						add_claim_on_loss = no
+					}
+					change_liege = {
+						liege = scope:defender
+						change = scope:change
+					}
+					resolve_title_and_vassal_change = scope:change
+				}
+				#They're the same rank... which is annoying 
+				else_if = {
+					limit = {
+						highest_held_title_tier = scope:defender.highest_held_title_tier
+					}
+					hidden_effect = {
+						#Vassalize their vassals that are one rank lower than them
+						every_vassal = {
+							limit = {
+								highest_held_title_tier = prev.highest_held_title_tier_minus_one
+							}
+							hidden_effect = {
+								add_opinion = {
+									modifier = obedience_opinion
+									target = scope:defender
+									years = 10
+								}
+							}
+							create_title_and_vassal_change = {
+								type = swear_fealty
+								save_scope_as = change
+								add_claim_on_loss = no
+							}
+							change_liege = {
+								liege = scope:defender
+								change = scope:change
+							}
+							resolve_title_and_vassal_change = scope:change
+						}
+						#Destroy all their same tier titles
+						every_held_title = {
+							limit = {
+								tier = scope:defender_title.tier
+							}
+							scope:attacker = { destroy_title = prev }
+						}
+					}
+					#Vassalize them
+					create_title_and_vassal_change = {
+						type = swear_fealty
+						save_scope_as = change
+						add_claim_on_loss = no
+					}
+					change_liege = {
+						liege = scope:defender
+						change = scope:change
+					}
+					resolve_title_and_vassal_change = scope:change
+				}
+			}
+			
+			add_legitimacy = monumental_legitimacy_gain
+			add_prestige = monumental_prestige_gain
+			
+			custom_tooltip = great_war_of_defiance_attackers_gold_tt
+			hidden_effect = {
+				every_in_list = {
+					list = anti_gok_attackers
+					limit = {
+						NOT = {
+							this = scope:attacker
+						}
+					}
+					pay_short_term_gold_reparations_effect = {
+						GOLD_VALUE = 2
+					}
+				}
+			}
+			trigger_event = {
+				id = mpo_greatest_of_khans.0001
+				days = 1
+			}
+		}
+		# Truce
+		add_truce_attacker_defeat_effect = yes
+
+		#Now uh... remove truces
+		scope:defender = {
+			custom_tooltip = gok_delete_all_truces_tt
+			hidden_effect = {
+				every_truce_target = {
+					scope:defender = { cancel_truce_one_way = prev }
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				has_dlc_feature = accolades
+			}
+			custom_tooltip = accolade_defenders_all_gain_glory_tt
+			hidden_effect = {
+				scope:defender = {
+					every_active_accolade = {
+						custom = custom.every_active_accolade
+						add_glory = massive_glory_gain
+					}
+				}
+				every_in_list = {
+					list = anti_gok_defenders
+					limit = {
+						NOT = {
+							this = scope:defender
+						}
+					}
+					every_active_accolade = {
+						add_glory = major_glory_gain
+					}
+				}
+			}
+		}
+
+		# Legitimacy
+		scope:attacker = {
+			add_legitimacy = medium_legitimacy_loss
+			pay_short_term_gold_reparations_effect = {
+				GOLD_VALUE = 5
+			}
+		}
+
+		#Memories
+		#Memory for Gurkhan
+		scope:defender = {
+			create_character_memory = {
+				type = gok_won_defiance_war
+				participants = {
+					opponent = scope:attacker
+				}
+			}
+		}
+		#Memory for Gurkhan vassals
+		every_in_list = {
+			list = anti_gok_defenders
+			limit = {
+				NOT = {
+					this = scope:defender
+				}
+			}
+			create_character_memory = {
+				type = gok_won_defiance_war_defenders
+				participants = {
+					gurkhan = scope:defender
+				}
+			}
+		}
+		#Memory for coalition
+		every_in_list = {
+			list = anti_gok_attackers
+			create_character_memory = {
+				type = gok_won_defiance_war_attackers
+				participants = {
+					gurkhan = scope:defender
+				}
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:defender
+			FAME_BASE = major_prestige_value
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 10
+			LOSER_ALLY_FAME_SCALE = 1
+		}
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		remove_global_variable = mpo_gok_war_ongoing
+	}
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+	#This should sometimes invalidate, reflecting some reqs from decision
+	check_defender_inheritance_validity = yes
+
+	transfer_behavior = transfer
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	war_name = "MPO_GREAT_WAR_OF_DEFIANCE_NAME"
+	my_war_name = "MPO_GREAT_WAR_OF_DEFIANCE_NAME_MY"
+	war_name_base = "MPO_GREAT_WAR_OF_DEFIANCE_NAME_BASE"
+	cb_name = "MPO_GREAT_WAR_OF_DEFIANCE_NAME"
+	interface_priority = 60
+
+	should_show_war_goal_subview = yes
+
+	attacker_wargoal_percentage = 0.5
+	
+	max_defender_score_from_occupation = 75
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 10000
+}
+
+#THE NEW WAR OF THE GREATEST OF KHANS
+mpo_gok_onslaught_cb = {
+	icon = migration_cb
+	group = invasion
+
+	allow_hostages = no
+	allowed_for_character = {
+		any_owned_story = {
+			OR = {
+				story_type = story_greatest_of_khans
+				story_type = story_mongol_invasion
+			}
+		}
+		has_mpo_dlc_trigger = yes
+	}
+
+	allowed_for_character_display_regardless = {
+		prestige_level >= 1
+	}
+
+	allowed_against_character_display_regardless = {
+		scope:defender = {
+			is_independent_ruler = yes
+			is_landed = yes
+		}
+	}
+
+	allowed_against_character = {
+		scope:attacker = {
+			ALL_FALSE = {
+				top_liege = scope:defender.top_liege
+				liege = scope:defender
+			}
+		}
+	}
+
+	should_invalidate = {
+		scope:defender = {
+			OR = {
+				is_independent_ruler = no
+				is_landed = no
+			}
+		}
+	}
+
+	on_invalidated_desc = msg_subjugation_war_invalidated_message
+	
+	on_invalidated = {
+	}
+
+	cost = {
+		piety = {
+			value = 0
+			if = {
+				limit = {
+					scope:attacker.faith.religious_head ?= scope:attacker
+					scope:defender.faith = scope:attacker.faith
+				}
+				add = {
+					value = 500
+					desc = CB_BASE_COST
+				}
+			}
+			if = {
+				limit = {
+					scope:attacker = { is_ai = yes }
+				}
+				multiply = 0
+			}
+			add = common_cb_impious_piety_cost
+			multiply = common_cb_piety_cost_multiplier
+		}
+		prestige = {
+			#Should be free for Greatest of Khans, this is for successors
+			add = {
+				value = 500
+				desc = CB_BASE_COST
+			}
+
+			multiply = common_cb_prestige_cost_multiplier
+
+			# Genghis Khan gets it for free
+			if = {
+				limit = { scope:attacker = { has_character_flag = is_temujin } }
+				multiply = 0
+			}
+			if = {
+				limit = {
+					scope:attacker = { is_ai = yes }
+				}
+				multiply = 0
+			}
+		}
+	}
+	
+	on_declaration = {
+		on_declared_war = yes
+	}	
+
+	on_victory_desc = {
+		desc = {			
+			first_valid = {
+				triggered_desc = {
+					trigger = {
+						scope:defender = {
+							AND = {
+								government_allows = administrative
+								any_vassal = {
+									count >= 2
+									government_allows = administrative
+									highest_held_title_tier >= main_administrative_tier
+								}
+							}
+						}
+						scope:attacker = { is_local_player = yes }
+					}
+					desc = mpo_gok_onslaught_victory_attacker_admin
+				}
+				triggered_desc = {
+					trigger = {
+						scope:attacker = { is_local_player = yes }
+					}
+					desc = mpo_gok_onslaught_victory_attacker
+				}
+				triggered_desc = {
+					trigger = {
+						scope:defender = {
+							AND = {
+								government_allows = administrative
+								any_vassal = {
+									count >= 2
+									government_allows = administrative
+									highest_held_title_tier >= main_administrative_tier
+								}
+							}
+						}
+						scope:defender = { is_local_player = yes }
+					}
+					desc = mpo_gok_onslaught_victory_defender_admin
+				}
+				triggered_desc = {
+					trigger = { scope:defender = { is_local_player = yes } }
+					desc = mpo_gok_onslaught_victory_defender
+				}
+				triggered_desc = {
+					trigger = {
+						scope:defender = {
+							AND = {
+								government_allows = administrative
+								any_vassal = {
+									count >= 2
+									government_allows = administrative
+									highest_held_title_tier >= main_administrative_tier
+								}
+							}
+						}
+					}
+					desc = mpo_gok_onslaught_victory_admin
+				}
+				desc = mpo_gok_onslaught_victory
+			}
+		}
+	}
+	
+	on_victory = {
+		#Catalyst if used against China
+		if = {
+			limit = {
+				exists = situation:dynastic_cycle
+				scope:defender = {
+					
+					any_character_situation = {
+						this = situation:dynastic_cycle
+					}
+				}
+			}
+			situation:dynastic_cycle = {
+				if = {
+					limit = {
+						scope:defender = {
+							any_realm_county = {
+								count >= 20
+								any_county_situation = {
+									this = situation:dynastic_cycle
+								}
+							}
+						}
+						situation_top_has_catalyst = catalyst_event_mongol_empire_attacks_major
+					}
+					trigger_situation_catalyst = {
+						catalyst = catalyst_event_mongol_empire_attacks_major
+						character = scope:attacker
+					}
+				}
+				else_if = {
+					limit = {
+						situation_top_has_catalyst = catalyst_event_mongol_empire_attacks_minor
+					}
+					trigger_situation_catalyst = {
+						catalyst = catalyst_event_mongol_empire_attacks_minor
+						character = scope:attacker
+					}
+				}
+			}
+		}
+		scope:attacker = {
+			save_scope_as = gok
+		}
+		scope:defender = {
+			save_scope_as = gok_victim
+			primary_title = {
+				save_scope_as = defender_primary
+			}
+			#Scripted effect that selects acceptable-tier admin vassals to preserve and moves lower tier admin vassals under them
+			if = {
+				limit = {
+					NOT = {
+						scope:attacker = {
+							government_allows = administrative
+						}
+					}
+					any_vassal_or_below = {
+						highest_held_title_tier >= tier_kingdom
+						government_allows = administrative
+					}
+				}
+				hidden_effect = {
+					mpo_gok_onslaught_admin_vassal_reorganization = yes
+				}
+			}
+			every_vassal_or_below = {
+				limit = {
+					is_ai = no
+					highest_held_title_tier > tier_barony
+				}
+				add_to_list = defender_player_vassals
+			}
+			#Make list of defender's vassals eligible for transfer or un-landing
+			every_vassal_or_below = {
+				limit = {
+					trigger_if = {
+						limit = {
+							scope:attacker = {
+								NOT = {
+									government_allows = administrative
+								}
+							}
+						}
+						is_landed = yes
+					}
+					highest_held_title_tier >= tier_county
+				}
+				add_to_list = defender_vassals
+			}
+			#List of all defender's titles
+			every_held_title = {
+				limit = {
+					is_landless_type_title = no
+					tier >= tier_county
+					tier < tier_empire
+				}
+				add_to_list = target_titles
+			}
+
+			every_vassal_or_below = {
+				limit = {
+					is_landed = yes
+					OR = {
+						AND = {
+							NOT = {
+								government_allows = administrative
+							}
+							highest_held_title_tier >= tier_duchy
+							gok_desirable_vassal_trigger = no
+						}
+						is_in_list = vulnerable_admin_vassals
+					}
+				}
+				every_held_title = {
+					limit = {
+						is_landless_type_title = no
+						tier >= tier_county
+						tier < tier_empire
+						is_head_of_faith = no
+					}
+					add_to_list = target_titles
+				}
+			}
+			if = {
+				limit = {
+					scope:defender = {
+						OR = {
+							any_held_title = {
+								has_variable = refused_submission
+							}
+							any_vassal_or_below = {
+								any_held_title = {
+									has_variable = refused_submission
+								}
+							}
+						}
+					}
+				}
+				scope:defender = {
+					save_scope_as = khans_retribution_target
+				}
+			}
+		}
+		scope:attacker = {
+			#Save value that's used to increase submit acceptance - you've successfully waged a war of terror!
+			custom_tooltip = goK_war_gain_all_titles
+			if = {
+				limit = {
+					scope:defender = {
+						NAND = {
+							government_allows = administrative
+							any_vassal = {
+								count >= 2
+								government_allows = administrative
+								highest_held_title_tier >= main_administrative_tier
+							}
+						}
+					}
+				}
+				custom_tooltip = goK_war_gain_vassal_titles
+			}
+			custom_tooltip = gok_offer_submission_acceptance_bonus_tt
+			if = {
+				limit = {
+					NOT = {
+						has_variable = gok_terror_war_value
+					}
+				}
+				#Higher value if defender refused submission, causing this war
+				if = {
+					limit = {
+						exists = scope:khans_retribution_target
+					}
+					set_variable = {
+						name = gok_terror_war_value
+						value = {
+							value = scope:defender.highest_held_title_tier
+							multiply = 2
+						}
+					}
+				}
+				else = {
+					set_variable = {
+						name = gok_terror_war_value
+						value = {
+							value = scope:defender.highest_held_title_tier
+							divide = 2
+							ceiling = yes
+						}
+					}
+				}
+			}
+			else = {
+				if = {
+					limit = {
+						exists = scope:khans_retribution_target
+						#Cap the bonus so that powerful rulers should still resist
+						var:gok_terror_war_value < 60
+					}
+					change_variable = {
+						name = gok_terror_war_value
+						add = {
+							value = scope:defender.highest_held_title_tier
+							multiply = 2
+						}
+					}
+				}
+				else = {
+					change_variable = {
+						name = gok_terror_war_value
+						add = {
+							value = scope:defender.highest_held_title_tier
+							divide = 2
+							ceiling = yes
+						}
+					}
+				}
+			}
+		
+			scope:attacker = {
+				if = {
+					limit = {
+						exists = scope:khans_retribution_target
+					}
+					hidden_effect = {
+						add_opinion = {
+							modifier = refused_the_great_khan_opinion
+							target = scope:defender
+						}
+					}
+					rightfully_imprison_character_less_verbose_effect = { 
+						TARGET = scope:defender
+						IMPRISONER = scope:attacker
+					}
+				}
+			}
+
+			scope:defender = {
+				if = {
+					limit = {
+						government_has_flag = government_is_nomadic
+					}
+					pay_herd = {
+						target = scope:attacker
+						value = domicile.major_herd_value
+					}
+				}
+				else = {
+					pay_short_term_gold = {
+						target = scope:attacker
+						gold = major_gold_value
+					}
+					
+				}
+				gok_realm_devastation_effect = yes
+			}
+
+			gok_retribution_cleanup_effect = yes
+
+			custom_tooltip = gok_cb_event_troops_tt
+			hidden_effect = {
+				if = {
+					limit = {
+						exists = scope:khans_retribution_target
+						exists = scope:requested_siege_army
+					}
+					gok_spawn_subjugated_siege_army_effect = { CHARACTER = scope:defender }
+				}
+				else_if = {
+					limit = {
+						exists = scope:khans_retribution_target
+						exists = scope:requested_quality_army
+					}
+					gok_spawn_subjugated_quality_army_effect = { CHARACTER = scope:defender }
+				}
+				else_if = {
+					limit = {
+						scope:defender = {
+							NOR = {
+								government_has_flag = government_is_nomadic
+								government_has_flag = government_is_herder
+								government_has_flag = government_is_tribal
+							}
+						}
+					}
+					random_list = {
+						1 = {
+							gok_spawn_subjugated_siege_army_effect = { CHARACTER = scope:defender }
+						}
+						1 = {
+							gok_spawn_subjugated_quality_army_effect = { CHARACTER = scope:defender }
+						}
+					}
+				}
+				else = {
+					gok_spawn_subjugated_quality_army_effect = { CHARACTER = scope:defender }
+				}
+			}
+			show_pow_release_message_effect = yes
+		}
+		
+		# Legitimacy
+		add_legitimacy_attacker_victory_effect = yes
+
+		#EP2 accolade glory gain for winning against higher ranked enemy
+		if = {
+			limit = {
+				scope:defender = {
+					sub_realm_size >= 20
+				}
+			}
+			scope:attacker = { accolade_attacker_war_end_glory_gain_high_effect = yes }
+		}
+		else_if = {
+			limit = {
+				scope:defender = {
+					sub_realm_size >= 10
+				}
+			}
+			scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+		}
+		else = {
+			scope:attacker = { accolade_attacker_war_end_glory_gain_low_effect = yes }
+		}
+		
+		#Transfer vassals
+		hidden_effect = {
+			scope:defender = {
+				#If their tier is too high, destroy their empire
+				every_vassal = {
+					limit = {
+						highest_held_title_tier >= tier_empire
+					}
+					every_held_title = {
+						limit = {
+							tier >= tier_empire
+						}
+						add_to_list = defender_vassal_empires
+					}
+					every_in_list = {
+						list = defender_vassal_empires
+						holder = { destroy_title = prev }
+					}
+				}
+
+				#transfer vassals
+				create_title_and_vassal_change = {
+					type = swear_fealty
+					save_scope_as = change
+					add_claim_on_loss = yes
+				}
+				every_in_list = {
+					list = defender_vassals
+					limit = {
+						OR = {
+							is_independent_ruler = yes
+							is_vassal_of = scope:defender
+						}
+					}
+					change_liege = {
+						liege = scope:attacker
+						change = scope:change
+					}
+				}
+				resolve_title_and_vassal_change = scope:change
+			}
+		}
+
+		#destroy defender and vassal empires/hegemony
+		scope:defender = {
+			every_held_title = {
+				limit = { tier >= tier_empire }
+				add_to_list = defender_empires
+			}
+			if = {
+				limit = {
+					any_in_list = {
+						list = defender_empires
+						count >= 1
+					}
+				}
+				every_in_list = {
+					list = defender_empires
+					holder = { destroy_title = prev }
+				}
+			}
+		}
+
+		#Transfer titles and do cleanup
+		hidden_effect = {
+			#Transfer titles
+			scope:defender = {
+				create_title_and_vassal_change = {
+					type = conquest
+					save_scope_as = change
+					add_claim_on_loss = yes
+				}
+				every_in_list = {
+					list = target_titles
+					limit = {
+						tier < tier_empire
+					}
+					change_title_holder = {
+						holder = scope:attacker
+						change = scope:change
+					}
+				}
+				resolve_title_and_vassal_change = scope:change
+			}
+			#If something broke and titles didn't get handed out... we'll still get you
+			if = {
+				limit = {
+					scope:defender = {
+						is_landed = yes
+					}
+				}
+				create_title_and_vassal_change = {
+					type = swear_fealty
+					save_scope_as = change
+					add_claim_on_loss = yes
+				}
+				#Transfer all of defender's vassals
+				scope:defender = {
+					every_vassal = {
+						limit = {
+							highest_held_title_tier >= tier_county
+						}
+						change_liege = {
+							liege = scope:attacker
+							change = scope:change
+						}
+					}
+					#transfer defender
+					change_liege = {
+						liege = scope:attacker
+						change = scope:change
+					}
+					resolve_title_and_vassal_change = scope:change
+				}
+			}
+			#Transfer vassals that ended up independent
+			if = {
+				limit = {
+					any_in_list = {
+						list = defender_vassals
+						highest_held_title_tier >= tier_county
+						is_ruler = yes
+						is_independent_ruler = yes
+					}
+				}
+				every_in_list = {
+					list = defender_vassals
+					limit = {
+						highest_held_title_tier >= tier_county
+						OR = {
+							is_independent_ruler = yes
+							NOT = {
+								top_liege ?= scope:attacker
+							}
+						}
+					}
+					create_title_and_vassal_change = {
+						type = swear_fealty
+						save_scope_as = change
+						add_claim_on_loss = yes
+					}
+					change_liege = {
+						liege = scope:attacker
+						change = scope:change
+					}
+					resolve_title_and_vassal_change = scope:change
+				}
+			}
+		}
+
+		#Send notification event to surviving defender vassals
+		every_in_list = {
+			list = defender_player_vassals
+			limit = {
+				is_ai = no
+				top_liege = scope:attacker
+			}
+			trigger_event = {
+				id = mpo_greatest_of_khans.0050
+				days = 2
+			}
+		}
+		#Send taunt to unlanded losers
+		every_in_list = {
+			list = defender_player_vassals
+			limit = {
+				is_ai = no
+				NOT = { top_liege = scope:attacker }
+			}
+			trigger_event = {
+				id = mpo_greatest_of_khans.0051
+				days = 2
+			}
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker
+			FAME_BASE = mongol_invasion_cb_ally_prestige
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 3
+		}
+		
+		# Prestige level progress for the attacker
+		scope:attacker = {
+			add_prestige_experience = {
+				value = mongol_invasion_cb_prestige_experience_gain
+			}
+		}
+
+		# Prestige loss for the defender
+		scope:defender = {
+			add_prestige = {
+				value = major_prestige_value
+				multiply = -1.0
+			}
+		}
+
+		# FP1: note the victory for future memorialisation via stele (if applicable).
+		scope:attacker = { fp1_remember_recent_conquest_victory_effect = yes }
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_white_peace_desc = {
+		desc = {			
+			first_valid = {
+				triggered_desc = {
+					trigger = { scope:defender = { is_local_player = yes } }
+					desc = mpo_gok_onslaught_white_peace_defender
+				}
+				desc = mpo_gok_onslaught_white_peace
+			}
+		}
+	}
+	
+	on_white_peace = {
+
+		#Attacker gains all occupied counties
+		scope:defender = {
+			every_sub_realm_county = {
+				limit = {
+					county_controller = scope:attacker
+				}
+				add_to_list = occupied_counties
+			}
+			create_title_and_vassal_change = {
+				type = conquest
+				save_scope_as = change
+				add_claim_on_loss = yes
+			}
+			every_in_list = {
+				list = occupied_counties
+				change_title_holder = {
+					holder = scope:attacker
+					change = scope:change
+				}
+			}
+			resolve_title_and_vassal_change = scope:change
+		}
+
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 accolade glory gain for doing ok against higher ranked enemy
+		scope:defender = { accolade_defender_war_end_glory_gain_med_effect = yes }
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:attacker # Not important as the scales are identical
+			FAME_BASE = mongol_invasion_cb_ally_prestige
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 5
+		}
+
+		add_truce_white_peace_effect = yes
+
+		scope:attacker = {
+			add_prestige = major_prestige_loss
+			add_legitimacy = minor_legitimacy_loss
+			stress_impact = {
+				ambitious = minor_stress_impact_gain
+				arrogant = minor_stress_impact_gain
+			}
+		}
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		gok_retribution_cleanup_effect = yes
+	}
+
+	on_defeat_desc = {
+		desc = {			
+			first_valid = {
+				triggered_desc = {
+					trigger = { scope:attacker = { is_local_player = yes } }
+					desc = mpo_gok_onslaught_defeat_attacker
+				}
+				triggered_desc = {
+					trigger = { scope:defender = { is_local_player = yes } }
+					desc = mpo_gok_onslaught_defeat_defender
+				}
+				desc = mpo_gok_onslaught_defeat
+			}
+		}
+	}
+	
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		scope:defender = { 
+			mandala_peacemaker_perk_serenity_effect = yes
+			#EP2 accolade glory gain for winning against higher ranked enemy
+			accolade_defender_war_end_glory_gain_high_effect = yes
+		}
+
+		# Allies on both sides get full prestige value for helping in the war, based on their war participation.
+		modify_allies_of_participants_fame_values = {
+			WINNER = scope:defender # Not important as the scales are identical
+			FAME_BASE = mongol_invasion_cb_ally_prestige
+			IS_RELIGIOUS_WAR = no
+			WINNER_ALLY_FAME_SCALE = 1
+			LOSER_ALLY_FAME_SCALE = 10
+		}
+	
+		# Truce
+		add_truce_attacker_defeat_effect = yes
+			
+		scope:defender = {
+			if = {
+				limit = {
+					OR = {
+						is_ai = no # AI mongols are bound to lose a war against a count or so due to warscore timeout, but that shouldn't slow them down
+						scope:attacker = { is_ai = no } # On the other hand, players shouldn't get away with it
+					}
+				}
+				
+				# Legitimacy
+				add_legitimacy_attacker_defeat_effect = yes
+
+				scope:attacker = {
+					add_prestige = massive_prestige_loss
+					add_legitimacy = major_legitimacy_loss
+					stress_impact = {
+						ambitious = medium_stress_impact_gain
+						arrogant = medium_stress_impact_gain
+					}
+				}
+				
+				add_prestige = mongol_invasion_cb_prestige_gain
+				#They defeated Genghis Khan... maybe they're a worthy foe?
+				if = {
+					limit = {
+						NOR = {
+							exists = global_var:gok_foe_conqueror_cooldown
+							scope:defender = {
+								has_trait = conqueror
+							}
+						}
+					}
+					hidden_effect = {
+						trigger_event = {
+							id = conqueror.0001
+							days = 5
+						}
+					}
+					set_global_variable = {
+						name = gok_foe_conqueror_cooldown
+						value = scope:defender
+						years = 5
+					}
+				}
+				else_if = {
+					limit = {
+						scope:defender = {
+							has_trait = conqueror
+						}
+					}
+					hidden_effect = {
+						add_short_term_gold = major_gold_value
+					}
+				}
+				scope:attacker = {
+					pay_short_term_gold_reparations_effect = {
+						GOLD_VALUE = 5
+					}
+				}
+				
+				scope:attacker = {
+					every_vassal = {
+						custom = custom.every_vassal
+						add_opinion = {
+							modifier = liege_lost_mongol_invasion_war
+							target = prev
+							opinion = -40
+						}
+					}
+				}
+				
+				scope:attacker = {
+					save_temporary_scope_as = loser
+				}
+				on_lost_aggression_war_discontent_loss = yes
+			}
+		}
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		gok_retribution_cleanup_effect = yes
+	}
+	
+	transfer_behavior = transfer
+	
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+	
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+	
+	war_name = "MPO_GOK_ONSLAUGHT_NAME"
+	my_war_name = "MPO_GOK_ONSLAUGHT_NAME_MY"
+	war_name_base = "MPO_GOK_ONSLAUGHT_NAME_BASE"
+	cb_name = "MPO_GOK_ONSLAUGHT_NAME"
+	
+	interface_priority = 200
+	
+	ticking_war_score_targets_entire_realm = yes
+	attacker_wargoal_percentage = 0.8
+	attacker_ticking_warscore = 0
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+	attacker_score_from_occupation_scale = 50
+	defender_score_from_occupation_scale = 50
+	
+	max_ai_diplo_distance_to_title = 500
+
+	ai_score_mult = {
+		value = 10
+		#Declaring war on the frankokratia leader can really ruin the whole thing
+		if = {
+			limit = {
+				scope:defender = {
+					any_owned_story = {
+						story_type = frankokratia_story
+						NOT = { has_variable = franko_war_complete }
+					}
+				}
+			}
+			multiply = 0
+		}
+	}
+}

--- a/common/casus_belli_types/09_mpo_wars.txt
+++ b/common/casus_belli_types/09_mpo_wars.txt
@@ -4555,11 +4555,11 @@ mpo_great_war_of_defiance_cb = {
 					any_character_war = {
 						this = scope:gok_war
 					}
-					#Unop pass the gok explicitly; vanilla tried to bind root via save_temporary_scope_as (a no-op in a trigger), so the connection checks ran against the casus belli instead of the defender
+					#Unop call a unop counterpart taking the gok explicitly; vanilla tried to bind root via save_temporary_scope_as (a no-op in a trigger), so the connection checks ran against the casus belli instead of the defender
 #					scope:defender = {
 #						save_temporary_scope_as = root
 #					}
-					mpo_war_of_defiance_notified_player_trigger = { GOK = scope:defender }
+					unop_war_of_defiance_notified_player_trigger = { GOK = scope:defender }
 				}
 			}
 			trigger_event = {

--- a/common/casus_belli_types/09_mpo_wars.txt
+++ b/common/casus_belli_types/09_mpo_wars.txt
@@ -4555,10 +4555,11 @@ mpo_great_war_of_defiance_cb = {
 					any_character_war = {
 						this = scope:gok_war
 					}
-					scope:defender = {
-						save_temporary_scope_as = root
-					}
-					mpo_war_of_defiance_notified_player_trigger = yes
+					#Unop pass the gok explicitly; vanilla tried to bind root via save_temporary_scope_as (a no-op in a trigger), so the connection checks ran against the casus belli instead of the defender
+#					scope:defender = {
+#						save_temporary_scope_as = root
+#					}
+					mpo_war_of_defiance_notified_player_trigger = { GOK = scope:defender }
 				}
 			}
 			trigger_event = {

--- a/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
+++ b/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
@@ -239,50 +239,6 @@ mpo_war_of_defiance_notified_player_trigger = {
 	}
 }
 
-unop_war_of_defiance_notified_player_trigger = {
-	#Unop counterpart taking the gok as a parameter; the caller is a casus belli on_victory where root is the casus belli, not a character
-	NOT = {
-		this = $GOK$
-	}
-	OR = {
-		top_liege = $GOK$
-		top_suzerain = $GOK$
-		any_character_situation = {
-			this = situation:the_great_steppe
-		}
-		any_relation = {
-			type = rival
-			this = $GOK$
-		}
-		#Those within same de jure empire
-		capital_county ?= {
-			empire = {
-				any_de_jure_county = {
-					holder.top_liege = {
-						this = $GOK$
-					}
-				}
-			}
-		}
-		capital_county ?= {
-			empire = {
-				any_de_jure_county = {
-					holder.top_suzerain = {
-						this = $GOK$
-					}
-				}
-			}
-		}
-		AND = {
-			exists = $GOK$.capital_county
-			realm_to_title_distance_squared = {
-				target = $GOK$.capital_county
-				value <= squared_distance_almost_massive
-			}
-		}
-	}
-}
-
 gok_desirable_vassal_trigger = {
 	OR = {
 		ai_boldness <= low_negative_ai_value

--- a/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
+++ b/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
@@ -197,25 +197,26 @@ mpo_gok_submitting_coward_trigger = {
 }
 
 mpo_war_of_defiance_notified_player_trigger = {
+	#Unop take the gok as a parameter; vanilla used root, but the caller is a casus belli on_victory where root is the casus belli, not a character
 	NOT = {
-		this = root
+		this = $GOK$
 	}
 	OR = {
-		top_liege = root
-		top_suzerain = root
+		top_liege = $GOK$
+		top_suzerain = $GOK$
 		any_character_situation = {
 			this = situation:the_great_steppe
 		}
 		any_relation = {
 			type = rival
-			this = root
+			this = $GOK$
 		}
 		#Those within same de jure empire
 		capital_county ?= {
 			empire = {
 				any_de_jure_county = {
 					holder.top_liege = {
-						this = root
+						this = $GOK$
 					}
 				}
 			}
@@ -224,15 +225,15 @@ mpo_war_of_defiance_notified_player_trigger = {
 			empire = {
 				any_de_jure_county = {
 					holder.top_suzerain = {
-						this = root
+						this = $GOK$
 					}
 				}
 			}
 		}
 		AND = {
-			exists = root.capital_county
+			exists = $GOK$.capital_county
 			realm_to_title_distance_squared = {
-				target = root.capital_county
+				target = $GOK$.capital_county
 				value <= squared_distance_almost_massive
 			}
 		}
@@ -469,7 +470,7 @@ mpo_offer_submission_or_ruin_valid_recipient_trigger = {
 	NOT = {
 		is_at_war_with = scope:actor
 	}
-	NOT = { is_imprisoned_by = scope:actor } #Unop can't demand submission from someone you already hold captive - on rejection the war's defender leader would already be imprisoned, an instant win
+	NOT = { is_imprisoned_by = scope:actor } #Unop don't demand submission from a captive - rejection-war starts with the defender leader imprisoned (instant win)
 	custom_description = {
 		text = was_recently_granted_independence
 		NOT = {

--- a/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
+++ b/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
@@ -1,0 +1,503 @@
+﻿#################################################
+# TRIGGER LIST 									#
+#################################################
+
+mpo_has_greatest_of_khans_nickname_trigger = {
+	OR = {
+		has_nickname = nick_genghis_khan
+		has_nickname = nick_cengiz_khan
+		has_nickname = nick_yekhe_khagan
+		has_nickname = nick_dort_yonlug_khagan
+		has_nickname = nick_tengri_khagan
+		has_nickname = nick_cihangir
+		has_nickname = nick_culture_khagan
+	}
+}
+mpo_has_gok_mongol_empire_trigger = {
+	OR = {
+		has_title = title:e_mongol_empire
+		custom_tooltip = {
+			text = gok_title_trigger
+			exists = global_var:greatest_of_khans_title
+			any_held_title = {
+				title_tier = empire
+				this = global_var:greatest_of_khans_title
+			}
+		}
+	}
+}
+
+mpo_gok_coalition_member_trigger = {
+	save_temporary_scope_as = foe
+	
+	in_diplomatic_range = root
+	is_ai = yes
+	OR = {
+		is_landless_nomad = yes
+		is_landless_adventurer = yes
+		is_landed = yes
+	}
+	NOR = {
+		this = root
+		top_liege = root
+		is_allied_to = root
+		is_tributary_of_suzerain_or_above = root
+		top_liege = {
+			is_tributary_of_suzerain_or_above = root
+		}
+		has_relation_friend = root
+		has_relation_blood_brother = root
+		opinion = {
+			target = root
+			value >= 100
+		}
+		
+		highest_held_title_tier < tier_county
+		government_has_flag = government_is_herder
+		is_imprisoned_by = root
+		is_obedient_to = root
+	}
+	##Only relatively strong non-nomads will mess with you
+	trigger_if = {
+		limit = {
+			NOT = {
+				government_has_flag = government_is_nomadic
+			}
+		}
+		OR = {
+			AND = {
+				highest_held_title_tier >= tier_duchy
+				sub_realm_size >= 8
+			}
+			is_confederation_member = yes
+		}
+	}
+	##Only house members who dislike you will oppose you
+	trigger_if = {
+		limit = {
+			OR = {
+				AND = {
+					exists = house
+					exists = root.house
+					house = {
+						this = root.house
+					}
+				}
+				#also those with direct alliances to root
+				is_allied_to = root
+			}
+			
+		}
+		opinion = {
+			target = root
+			value < 0
+		}
+	}
+	#Lower tier rulers
+	trigger_if = {
+		limit = {
+			highest_held_title_tier < tier_duchy
+		}
+		OR = {
+			NOT = {
+				has_dread_level_towards = {
+					target = root
+					level >= 2
+				}
+			}
+			faith = {
+				faith_hostility_level = {
+					target = root.faith
+					value > faith_astray_level
+				}
+			}
+			opinion = {
+				target = root
+				value <= -40
+			}
+			is_confederation_member = yes
+			root = {
+				any_land_neighboring_realm_with_tributaries_owner = {
+					this = scope:foe
+				}
+			}
+		}
+		
+	}
+}
+
+mpo_gok_submitting_coward_trigger = {
+	is_ai = yes
+	is_confederation_member = no
+	OR = {
+		is_tributary_of = root
+		is_tributary = no
+	}
+	is_landed = yes
+	highest_held_title_tier < tier_duchy
+	NOT = {
+		has_relation_rival = root
+	}
+	OR = {
+		is_imprisoned_by = root
+		government_has_flag = government_is_herder
+		has_relation_friend = root
+		AND = {
+			exists = root.house
+			house ?= root.house
+			NOT = {
+				is_in_list = anti_gok_coalition_members
+			}
+		}
+		opinion = {
+			target = root
+			value >= 100
+		}
+		ai_boldness <= medium_negative_ai_value
+		has_dread_level_towards = {
+			target = root
+			level >= 2
+		}
+		is_tributary_of = root
+		AND = {
+			exists = house
+			exists = root.house
+			house = {
+				this = root.house
+			}
+			opinion = {
+				target = root
+				value >= 0
+			}
+		}
+	}
+	trigger_if = {
+		limit = {
+			current_military_strength > 0
+			root.current_military_strength > 0
+		}
+		current_military_strength < root.current_military_strength
+	}
+	NOT = {
+		any_character_war = {
+			OR = {
+				primary_defender = prev
+				AND = {
+					primary_attacker = prev
+					primary_defender = {
+						top_liege = root
+					}
+				}
+				primary_defender = {
+					is_ai = no
+				}
+			}
+		}
+	}
+}
+
+mpo_war_of_defiance_notified_player_trigger = {
+	NOT = {
+		this = root
+	}
+	OR = {
+		top_liege = root
+		top_suzerain = root
+		any_character_situation = {
+			this = situation:the_great_steppe
+		}
+		any_relation = {
+			type = rival
+			this = root
+		}
+		#Those within same de jure empire
+		capital_county ?= {
+			empire = {
+				any_de_jure_county = {
+					holder.top_liege = {
+						this = root
+					}
+				}
+			}
+		}
+		capital_county ?= {
+			empire = {
+				any_de_jure_county = {
+					holder.top_suzerain = {
+						this = root
+					}
+				}
+			}
+		}
+		AND = {
+			exists = root.capital_county
+			realm_to_title_distance_squared = {
+				target = root.capital_county
+				value <= squared_distance_almost_massive
+			}
+		}
+	}
+}
+
+gok_desirable_vassal_trigger = {
+	OR = {
+		ai_boldness <= low_negative_ai_value
+		has_trait = loyal
+		is_obedient_to = scope:gok
+		has_any_good_relationship_with_character_trigger = { CHARACTER = scope:gok }
+		AND = {
+			exists = scope:gok.dynasty
+			dynasty ?= scope:gok.dynasty
+		}
+		is_allied_to = scope:gok
+		opinion = {
+			target = scope:gok
+			value > 20
+		}
+		#Dukes from pliant cultures are cool
+		AND = {
+			highest_held_title_tier < tier_kingdom
+			culture = {
+				OR = {
+					has_cultural_tradition = tradition_loyal_soldiers
+					has_cultural_tradition = tradition_pacifism
+					has_cultural_tradition = tradition_xenophilic
+					has_cultural_tradition = tradition_modest
+					has_cultural_tradition = tradition_fp2_malleable_subjects
+				}
+			}
+		}
+		trigger_if = {
+			limit = {
+				faith = scope:gok.faith
+			}
+			opinion = {
+				target = scope:gok
+				value >= -20
+			}
+		}
+	}
+}
+mpo_greatest_of_khans_0030_willing_nomad_vassal = {
+	OR = {
+		government_has_flag = government_is_nomadic
+		government_has_flag = government_is_herder
+	}
+	OR = {
+		is_obedient = yes
+		opinion = {
+			target = liege
+			value >= 0
+		}
+		has_dread_level_towards = {
+			target = liege
+			level >= 1
+		}
+	}
+	NOR = {
+		is_at_war_with = liege
+		has_trait = stubborn
+		culture = {
+			has_cultural_tradition = tradition_staunch_traditionalists
+		}
+	}
+}
+
+mpo_greatest_of_khans_0030_dominated_nomad_vassal = {
+	OR = {
+		government_has_flag = government_is_nomadic
+		government_has_flag = government_is_herder
+	}
+	OR = {
+		is_obedient = yes
+		opinion = {
+			target = liege
+			value >= 60
+		}
+		has_dread_level_towards = {
+			target = liege
+			level >= 2
+		}
+	}
+	NOR = {
+		is_at_war_with = liege
+		has_trait = stubborn
+		culture = {
+			OR ={
+				has_cultural_tradition = tradition_staunch_traditionalists
+				has_cultural_tradition = tradition_quarrelsome
+				has_cultural_tradition = tradition_isolationist
+			}
+		}
+	}
+}
+
+mpo_greatest_of_khans_0030_willing_sedentary_vassal = {
+	NOR = {
+		government_has_flag = government_is_nomadic
+		government_has_flag = government_is_herder
+		government_has_flag = government_is_theocracy
+		government_has_flag = government_is_landless_adventurer
+	}
+	OR = {
+		is_obedient = yes
+		opinion = {
+			target = liege
+			value >= 0
+		}
+		has_dread_level_towards = {
+			target = liege
+			level >= 1
+		}
+	}
+	NOR = {
+		is_at_war_with = liege
+		has_trait = stubborn
+		culture = {
+			has_cultural_tradition = tradition_staunch_traditionalists
+		}
+	}
+}
+mpo_greatest_of_khans_0030_dominated_sedentary_vassal = {
+	NOR = {
+		government_has_flag = government_is_nomadic
+		government_has_flag = government_is_herder
+		government_has_flag = government_is_theocracy
+		government_has_flag = government_is_landless_adventurer
+	}
+	OR = {
+		is_obedient = yes
+		opinion = {
+			target = liege
+			value >= 50
+		}
+		has_dread_level_towards = {
+			target = liege
+			level >= 2
+		}
+	}
+	NOR = {
+		is_at_war_with = liege
+		has_trait = stubborn
+		culture = {
+			has_cultural_tradition = tradition_staunch_traditionalists
+		}
+		culture = {
+			has_cultural_tradition = tradition_legalistic
+		}
+	}
+}
+
+gok_gov_switch_valid_vassal_trigger = {
+	highest_held_title_tier >= tier_county
+	is_landed = yes
+	is_ai = yes
+	NOT = {
+		is_at_war_with = root
+	}
+	NOT = {
+		any_liege_or_above = {
+			is_ai = no
+			NOT = {
+				this = root
+			}
+		}
+	}
+	NOR = {
+		government_has_flag = government_is_theocracy 
+		government_has_flag = government_is_landless_adventurer
+	}
+}
+
+gok_willing_new_admin_vassal_trigger = {
+	gok_gov_switch_valid_vassal_trigger = yes
+	OR = {
+		mpo_greatest_of_khans_0030_dominated_nomad_vassal = yes
+		mpo_greatest_of_khans_0030_willing_sedentary_vassal = yes
+		culture = culture:greek
+		culture = {
+			any_parent_culture_or_above = {
+				this = culture:greek
+			}
+		}
+		culture = culture:han
+		culture = {
+			any_parent_culture_or_above = {
+				this = culture:han
+			}
+		}
+	}
+	NOR = {
+		government_has_flag = government_is_administrative
+		government_has_flag = government_is_tribal
+	}
+}
+
+mpo_offer_submission_or_ruin_shown_actor_trigger = {
+	has_mpo_dlc_trigger = yes
+	is_landed = yes
+	any_owned_story = {
+		OR = {
+			story_type = story_greatest_of_khans
+			story_type = story_mongol_invasion
+		}
+	}
+}
+mpo_offer_submission_or_ruin_shown_recipient_trigger = {
+	NOT = { this = scope:actor }
+	is_landed = yes
+	NOT = { government_has_flag = cannot_be_vassal_or_liege }
+}
+mpo_offer_submission_or_ruin_valid_actor_trigger = {
+	prestige_level >= 1
+	trigger_if = {
+		limit = {
+			exists = scope:recipient
+		}
+		custom_description = {
+			text = truce_on_recipient_tt
+			NOT = {
+				any_truce_target = {
+					this = scope:recipient
+				}
+			}
+		}
+	}
+}
+mpo_offer_submission_or_ruin_valid_recipient_trigger = {
+	is_independent_ruler = yes
+	NOT = {
+		is_at_war_with = scope:actor
+	}
+	custom_description = {
+		text = was_recently_granted_independence
+		NOT = {
+			has_opinion_modifier = {
+				modifier = granted_independence_opinion
+				target = scope:actor
+			}
+		}
+	}
+	custom_description = {
+		text = not_recently_offered_submission
+		NOT = {
+			has_character_flag = accepted_gok_submission
+		}
+	}
+}
+
+#Basically just checking they are tribal (and shouldn't provide siege) or have a unique maa that's interesting to have
+#I think this will balance how much siege vs. military strength AI take as GoK
+mpo_gok_auto_cultural_maa_trigger = {
+	OR = {
+		government_has_flag = government_is_tribal
+		government_has_flag = government_is_nomadic
+		culture = {
+			OR = {
+				culture_has_archer_cavalry_maa = yes
+				has_cultural_parameter = unlock_maa_cataphract_archers
+			}
+		}
+		
+	}
+}

--- a/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
+++ b/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
@@ -469,6 +469,7 @@ mpo_offer_submission_or_ruin_valid_recipient_trigger = {
 	NOT = {
 		is_at_war_with = scope:actor
 	}
+	NOT = { is_imprisoned_by = scope:actor } #Unop can't demand submission from someone you already hold captive - on rejection the war's defender leader would already be imprisoned, an instant win
 	custom_description = {
 		text = was_recently_granted_independence
 		NOT = {

--- a/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
+++ b/common/scripted_triggers/09_mpo_greatest_of_khans_triggers.txt
@@ -197,7 +197,50 @@ mpo_gok_submitting_coward_trigger = {
 }
 
 mpo_war_of_defiance_notified_player_trigger = {
-	#Unop take the gok as a parameter; vanilla used root, but the caller is a casus belli on_victory where root is the casus belli, not a character
+	NOT = {
+		this = root
+	}
+	OR = {
+		top_liege = root
+		top_suzerain = root
+		any_character_situation = {
+			this = situation:the_great_steppe
+		}
+		any_relation = {
+			type = rival
+			this = root
+		}
+		#Those within same de jure empire
+		capital_county ?= {
+			empire = {
+				any_de_jure_county = {
+					holder.top_liege = {
+						this = root
+					}
+				}
+			}
+		}
+		capital_county ?= {
+			empire = {
+				any_de_jure_county = {
+					holder.top_suzerain = {
+						this = root
+					}
+				}
+			}
+		}
+		AND = {
+			exists = root.capital_county
+			realm_to_title_distance_squared = {
+				target = root.capital_county
+				value <= squared_distance_almost_massive
+			}
+		}
+	}
+}
+
+unop_war_of_defiance_notified_player_trigger = {
+	#Unop counterpart taking the gok as a parameter; the caller is a casus belli on_victory where root is the casus belli, not a character
 	NOT = {
 		this = $GOK$
 	}

--- a/common/scripted_triggers/unop_triggers.txt
+++ b/common/scripted_triggers/unop_triggers.txt
@@ -15,3 +15,47 @@ unop_is_coup_powerful_vassal_trigger = {
 unop_is_loaded = { #Unop: For other mods to check if unop is there
 	always = yes
 }
+
+# Counterpart of vanilla mpo_war_of_defiance_notified_player_trigger taking the new Gurkhan as a parameter; the vanilla one is called from a casus belli on_victory where root is the casus belli, not a character
+unop_war_of_defiance_notified_player_trigger = {
+	NOT = {
+		this = $GOK$
+	}
+	OR = {
+		top_liege = $GOK$
+		top_suzerain = $GOK$
+		any_character_situation = {
+			this = situation:the_great_steppe
+		}
+		any_relation = {
+			type = rival
+			this = $GOK$
+		}
+		#Those within same de jure empire
+		capital_county ?= {
+			empire = {
+				any_de_jure_county = {
+					holder.top_liege = {
+						this = $GOK$
+					}
+				}
+			}
+		}
+		capital_county ?= {
+			empire = {
+				any_de_jure_county = {
+					holder.top_suzerain = {
+						this = $GOK$
+					}
+				}
+			}
+		}
+		AND = {
+			exists = $GOK$.capital_county
+			realm_to_title_distance_squared = {
+				target = $GOK$.capital_county
+				value <= squared_distance_almost_massive
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #559

**fixer:** The GOK "Offer Submission or Ruin" interaction had no guard against the recipient being the actor's own prisoner. `mpo_offer_submission_or_ruin_valid_recipient_trigger` only checked `is_independent_ruler`, `NOT is_at_war_with`, and the recent-independence/recent-offer flags — so you could demand submission from someone you already hold captive. On rejection the resulting subjugation war starts with the defender's war leader already imprisoned by the attacker → instant win, the reported exploit.

Added `NOT = { is_imprisoned_by = scope:actor }` to the recipient trigger, matching the established vanilla idiom (`00_war.txt` declare-war guards the recipient with `is_imprisoned + NOT imprisoner = scope:actor`; `00_gift.txt`, courtier/guest, revoke-title, diarch, ep3 interactions all use `NOT = { is_imprisoned_by = scope:actor }`). `is_imprisoned_by` carries built-in trigger localization, so the failure tooltip is auto-generated.

Placement: overrides `09_mpo_greatest_of_khans_triggers.txt` (added unmodified first) to keep recipient-validity logic where vanilla put it.

**Tiger:** adding the trigger file surfaced one pre-existing, unrelated vanilla scope warning — `mpo_war_of_defiance_notified_player_trigger` uses `root` as a character but is called from a casus belli `on_victory` block in `09_mpo_wars.txt`. That's a separate vanilla bug; ignored via a precise `ck3-tiger.conf` rule (mirroring the existing frankokratia-faith ignore) and flagged for separate follow-up. `make tiger` clean.