### PR TITLE
Fix reversed Dynastic Cycle expansion catalyst polarity during Expansion phase

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -597,6 +597,11 @@ filter = {
 			text = "expects root to be character but root seems to be faith"
 			file = common/scripted_triggers/07_frankokratia_triggers.txt
 		}
+		NAND = { # Pre-existing vanilla bug: phase on_start root is the situation (per _situations.info), but trigger_situation_catalyst's `character = root` passes the situation where a character is expected; a separate fix, out of scope here
+			key = scopes
+			text = "`root` produces situation but expected character"
+			file = common/situation/situations/tgp_dynastic_cycle.txt
+		}
 		NAND = { # Ignore scope warnings in event backgrounds, too difficult to fix
 			key = scopes
 			OR = {

--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -597,11 +597,6 @@ filter = {
 			text = "expects root to be character but root seems to be faith"
 			file = common/scripted_triggers/07_frankokratia_triggers.txt
 		}
-		NAND = { # Pre-existing vanilla bug: phase on_start root is the situation (per _situations.info), but trigger_situation_catalyst's `character = root` passes the situation where a character is expected; a separate fix, out of scope here
-			key = scopes
-			text = "`root` produces situation but expected character"
-			file = common/situation/situations/tgp_dynastic_cycle.txt
-		}
 		NAND = { # Ignore scope warnings in event backgrounds, too difficult to fix
 			key = scopes
 			OR = {

--- a/common/situation/situations/tgp_dynastic_cycle.txt
+++ b/common/situation/situations/tgp_dynastic_cycle.txt
@@ -1,0 +1,1965 @@
+﻿@gained_mandate_of_heaven = 4000
+@gained_mandate_of_heaven_halved = 2000
+@lost_mandate_of_heaven = 4000
+@lost_mandate_of_heaven_halved = 2000
+@mandate_of_heaven_flavorful_points = @[gained_mandate_of_heaven + 1000]
+
+dynastic_cycle = {
+	window = dynastic_cycle
+	gui_window_name = "window_tgp_dynastic_cycle"
+	gui_tooltip_group_focused = yes
+	map_mode = dynastic_cycle
+	illustration = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_corruption.dds"
+	situation_group_type = major
+
+	is_unique = yes
+	keep_full_history = yes 
+	
+	##################################################
+	# Regions
+	##################################################
+	sub_regions = {
+		core = {
+			icon = "gfx/interface/icons/situation_types/dynastic_cycle.dds"
+		}
+	}
+
+	##################################################
+	# On Actions
+	##################################################
+	on_monthly = {
+		trigger_event = {
+			on_action = dynastic_cycle_monthly_pulse
+		}
+	}
+	on_yearly = {
+		trigger_event = {
+			on_action = dynastic_cycle_yearly_pulse
+		}
+		#update all movement leaders
+		every_participant_group = {
+			save_scope_as = situation_participant_group
+			if = {
+				limit = { # Appoint a new movement leader if no longer alive
+					exists = var:movement_leader
+					var:movement_leader = { is_alive = no }
+				}
+				update_movement_leader_effect = yes
+			}
+			if = {
+				limit = {
+					exists = var:movement_power
+				}
+				every_situation_group_participant = {
+					update_modified_movement_power_effect = yes
+					update_character_movement_power_effect = yes
+				}
+				update_modified_movement_power_effect = yes
+				update_movement_power_effect = yes
+			}
+		}
+		
+		title:h_china.holder ?= {
+			save_scope_as = huangdi
+			# Imperial Examinations tracking
+			if = {
+				limit = {
+					exists = title:h_china.var:years_since_imperial_examination
+					title:h_china.var:years_since_imperial_examination >= 3
+				}
+				ai_attempt_to_host_activity = activity_imperial_examination
+			}
+		}
+		
+		# SILK ROAD
+		tgp_silk_road_china_stability_effect = yes
+
+		#Epidemics
+		if = {
+			limit = {
+				any_epidemic = {
+					outbreak_intensity >= major
+					any_infected_province = {
+						county = {
+							any_county_situation = { this = situation:dynastic_cycle }
+						}
+						county.holder.top_liege = title:h_china.holder
+					}
+				}
+			}
+			ordered_epidemic = {
+				order_by = {
+					if = {
+						limit = {
+							outbreak_intensity = major
+						}
+						add = 1
+					}
+					else_if = {
+						limit = {
+							outbreak_intensity = apocalyptic
+						}
+						add = 2
+					}
+				}
+				limit = {
+					any_infected_province = {
+						county = {
+							any_county_situation = { this = situation:dynastic_cycle }
+						}
+						county.holder.top_liege = title:h_china.holder
+					}
+				}
+				switch = {
+					trigger = outbreak_intensity
+					major = {
+						situation:dynastic_cycle = {
+							trigger_situation_catalyst = catalyst_hegemon_epidemic
+						}
+					}
+					apocalyptic = {
+						situation:dynastic_cycle = {
+							trigger_situation_catalyst = catalyst_hegemon_apocalyptic_epidemic
+						}
+					}
+				}
+			}
+		}
+	}
+
+	##################################################
+	# Groups
+	##################################################
+	participant_groups = {
+		hegemon_ruler = { #just the hegemon
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_emperor.dds"
+			
+			map_color = { 255 234 64 }
+
+			is_character_valid = {
+				has_title = title:h_china
+			}
+			on_join = {
+				if = {
+					limit = {
+						is_ai = no
+						NOT = { has_variable = claimed_the_mandate_of_heaven }
+					}
+					trigger_event = tgp_dynastic_cycle.0051
+				}
+			}
+		}
+		pro_hegemon_movement = { #they are cool with whatever the hegemon wants and does
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_pro.dds"
+			map_color = { 150 20 150 }
+
+			is_character_valid = {
+				exists = title:h_china.holder
+				trigger_if = {
+					limit = {
+						NOR = {
+							exists = var:movement_member
+							top_participant_group:dynastic_cycle.var:movement_leader ?= root
+						}
+					}
+					OR = {
+						is_vassal_or_below_of = title:h_china.holder
+						AND = {
+							is_tributary_of = title:h_china.holder
+							subject_contract_has_flag = celestial_investiture_politics
+						}
+					}
+					should_pick_pro_hegemon_movement_trigger = yes
+				}
+				trigger_else = {
+					var:movement_member ?= flag:pro_hegemon
+				}
+			}
+			on_join = {
+				update_character_movement_power_effect = yes
+				set_movement_leader_and_power_effect = yes
+				if = {
+					limit = { is_ai = no }
+					trigger_event = tgp_dynastic_cycle.0055
+				}
+				# to prevent from bouncing between movements
+				if = {
+					limit = {
+						NOT = { has_variable = movement_member }
+					}
+					set_variable = {
+						name = movement_member
+						value = flag:pro_hegemon
+					}
+				}
+			}
+			on_leave = {
+				scope:situation_participant_group = {
+					update_movement_power_effect = yes
+				}
+				if = {
+					limit = {
+						root = scope:situation_participant_group.var:movement_leader
+					}
+					scope:situation_participant_group = {
+						update_movement_leader_effect = yes
+					}
+				}
+			}
+		}
+		advancement_movement = { #they want to push towards advancement stability phase, if this is the current phase they want to keep it
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_advance.dds"
+			map_color = { 128 255 128 }
+
+			is_character_valid = {
+				exists = title:h_china.holder
+				trigger_if = {
+					limit = {
+						NOR = {
+							exists = var:movement_member
+							top_participant_group:dynastic_cycle.var:movement_leader ?= root
+						}
+					}
+					OR = {
+						is_vassal_or_below_of = title:h_china.holder
+						AND = {
+							is_tributary_of = title:h_china.holder
+							subject_contract_has_flag = celestial_investiture_politics
+						}
+					}
+					should_pick_advancement_movement_trigger = yes
+				}
+				trigger_else = {
+					var:movement_member ?= flag:advancement
+				}
+			}
+			on_join = {
+				update_character_movement_power_effect = yes
+				set_movement_leader_and_power_effect = yes
+				if = {
+					limit = { is_ai = no }
+					trigger_event = tgp_dynastic_cycle.0054
+				}
+				# to prevent from bouncing between movements
+				if = {
+					limit = {
+						NOT = { has_variable = movement_member }
+					}
+					set_variable = {
+						name = movement_member
+						value = flag:advancement
+					}
+				}
+			}
+			on_leave = {
+				scope:situation_participant_group = {
+					update_movement_power_effect = yes
+				}
+				if = {
+					limit = {
+						root = scope:situation_participant_group.var:movement_leader
+					}
+					scope:situation_participant_group = {
+						update_movement_leader_effect = yes
+					}
+				}
+			}
+		}
+		expansion_movement = { #they want to push towards expansion stability phase, if this is the current phase they want to keep it
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_expand.dds"
+			map_color = { 220 20 0 }
+
+			is_character_valid = {
+				exists = title:h_china.holder
+				trigger_if = {
+					limit = {
+						NOR = {
+							exists = var:movement_member
+							top_participant_group:dynastic_cycle.var:movement_leader ?= root
+						}
+					}
+					OR = {
+						is_vassal_or_below_of = title:h_china.holder
+						AND = {
+							is_tributary_of = title:h_china.holder
+							subject_contract_has_flag = celestial_investiture_politics
+						}
+					}
+					should_pick_expansion_movement_trigger = yes
+				}
+				trigger_else = {
+					var:movement_member ?= flag:expansion
+				}
+			}
+			on_join = {
+				update_character_movement_power_effect = yes
+				set_movement_leader_and_power_effect = yes
+				if = {
+					limit = { is_ai = no }
+					trigger_event = tgp_dynastic_cycle.0053
+				}
+				# to prevent from bouncing between movements
+				if = {
+					limit = {
+						NOT = { has_variable = movement_member }
+					}
+					set_variable = {
+						name = movement_member
+						value = flag:expansion
+					}
+				}
+			}
+			on_leave = {
+				scope:situation_participant_group = {
+					update_movement_power_effect = yes
+				}
+				if = {
+					limit = {
+						root = scope:situation_participant_group.var:movement_leader
+					}
+					scope:situation_participant_group = {
+						update_movement_leader_effect = yes
+					}
+				}
+			}
+		}
+		conservative_movement = { #they want to empower nobility, oppose reformation and meritocracy
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_anti.dds"
+			map_color = { 50 120 255 }
+
+			is_character_valid = {
+				exists = title:h_china.holder
+				trigger_if = {
+					limit = {
+						NOR = {
+							exists = var:movement_member
+							top_participant_group:dynastic_cycle.var:movement_leader ?= root
+						}
+					}
+					OR = {
+						is_vassal_or_below_of = title:h_china.holder
+						AND = {
+							is_tributary_of = title:h_china.holder
+							subject_contract_has_flag = celestial_investiture_politics
+						}
+					}
+					should_pick_conservative_movement_trigger = yes
+				}
+				trigger_else = {
+					var:movement_member ?= flag:conservative
+				}
+			}
+			on_join = {
+				update_character_movement_power_effect = yes
+				set_movement_leader_and_power_effect = yes
+				if = {
+					limit = { is_ai = no }
+					trigger_event = tgp_dynastic_cycle.0056
+				}
+				# to prevent from bouncing between movements
+				if = {
+					limit = {
+						NOT = { has_variable = movement_member }
+					}
+					set_variable = {
+						name = movement_member
+						value = flag:conservative
+					}
+				}
+			}
+			on_leave = {
+				scope:situation_participant_group = {
+					update_movement_power_effect = yes
+				}
+				if = {
+					limit = {
+						root = scope:situation_participant_group.var:movement_leader
+					}
+					scope:situation_participant_group = {
+						update_movement_leader_effect = yes
+					}
+				}
+			}
+		}
+		undecided_movement = { #everyone else that didn't fit into the groups above
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_unaligned.dds"
+			map_color = { 240 240 240 }
+
+			is_character_valid = {
+				exists = title:h_china.holder
+				trigger_if = {
+					limit = {
+						NOR = {
+							exists = var:movement_member
+							top_participant_group:dynastic_cycle.var:movement_leader ?= root
+						}
+					}
+					OR = {
+						is_vassal_or_below_of = title:h_china.holder
+						AND = {
+							is_tributary_of = title:h_china.holder
+							subject_contract_has_flag = celestial_investiture_politics
+						}
+					}
+				}
+				trigger_else = {
+					var:movement_member = flag:undecided
+				}
+			}
+			on_join = {
+				update_character_movement_power_effect = yes
+				scope:situation_participant_group = {
+					update_movement_power_effect = yes
+				}
+				if = {
+					limit = { is_ai = no }
+					trigger_event = tgp_dynastic_cycle.0052
+				}
+				# to prevent from bouncing between movements
+				if = {
+					limit = {
+						NOT = { has_variable = movement_member }
+					}
+					set_variable = {
+						name = movement_member
+						value = flag:undecided
+					}
+				}
+			}
+			on_leave = {
+				scope:situation_participant_group = {
+					update_movement_power_effect = yes
+				}
+			}
+		}
+		other_rulers = { #all other independent rulers in the Dynastic Cycle region
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_group_independent.dds"
+			is_character_valid = {
+				trigger_if = {
+					limit = {
+						exists = title:h_china.holder
+					}
+					is_independent_ruler = yes
+					NAND = {
+						is_tributary_of = title:h_china.holder
+						subject_contract_has_flag = celestial_investiture_politics
+					}
+				}
+				trigger_else = {
+					always = yes
+				}
+			}
+			on_join = {
+				if = {
+					limit = { is_ai = no }
+					trigger_event = tgp_dynastic_cycle.0051
+				}
+			}
+		}
+	}
+
+	##################################################
+	# Phases
+	##################################################
+	start_phase = situation_dynastic_cycle_phase_instability
+
+	on_start = {
+		root.situation_sub_region:core = { add_dejure_title_to_sub_region = title:h_china }
+		root.situation_sub_region:core = { add_character_realm_to_sub_region = title:h_china.holder }
+
+		title:h_china.holder = {
+			every_councillor = {
+				# Make sure the minister is participant in the Dynastic Cycle situation
+				if = {
+					limit = {
+						NOT = {
+							any_character_situation = {
+								situation_type = dynastic_cycle
+							}
+						}
+					}
+					root = {
+						add_manual_participant = prev
+					}
+				}
+				# Give them modifier for extra scheme slots
+				add_character_modifier = minister_scheme_slots_modifier
+			}
+		}
+		every_situation_participant = {
+			# Update total movement power for characters
+			update_character_movement_power_individual_effect = yes
+			# Setup elder/disciple relations
+			if = {
+				limit = {
+					government_allows = merit
+				}
+				if = {
+					limit = {
+						merit_level >= merit_level_expected_duchy_value
+						this != title:h_china.holder
+					}
+					add_to_list = potential_elders
+				}
+				else_if = {
+					limit = { this != title:h_china.holder }
+					add_to_list = potential_disciples
+				}
+			}
+		}
+		every_in_list = {
+			list = potential_disciples
+			save_scope_as = disciple
+			random_in_list = {
+				list = potential_elders
+				limit = {
+					top_participant_group:dynastic_cycle ?= scope:disciple.top_participant_group:dynastic_cycle
+					eligible_for_elder_trigger = {
+						DISCIPLE = scope:disciple
+					}
+				}
+				save_scope_as = elder
+			}
+			if = {
+				limit = {
+					exists = scope:elder
+				}
+				random = {
+					chance = 65
+					set_relation_elder = scope:elder
+				}
+			}
+		}
+		every_situation_participant = {
+			update_character_movement_power_disciples_effect = yes
+		}
+		# Update movement power for groups
+		every_participant_group = {
+			save_scope_as = situation_participant_group
+			if = {
+				limit = {
+					exists = var:movement_leader
+				}
+				update_movement_leader_effect = yes
+			}
+			update_movement_power_effect = yes
+		}
+		
+		# Make the most powerful movement empowered
+		if = {
+			limit = {
+				NOT = {
+					any_participant_group = {
+						exists = var:movement_favored
+					}
+				}
+			}
+			ordered_participant_group = {
+				limit = {
+					OR = {
+						participant_group_type = expansion_movement
+						participant_group_type = advancement_movement
+						participant_group_type = pro_hegemon_movement
+						participant_group_type = conservative_movement
+					}
+				}
+				order_by = var:movement_power
+				make_movement_favored_effect = yes
+			}
+		}
+		every_situation_participant = {
+			if = {
+				limit = { is_ai = no }
+				trigger_event = tgp_dynastic_cycle.0051 # Introduction to the dynastic cycle
+				if = {
+					limit = { is_player_tutorial_character = no }
+					trigger_event = tgp_china_career.0001 # Introduction to your starting situation
+				}
+			}
+		}
+	}
+
+	phases = {
+		situation_dynastic_cycle_phase_stability = {
+			on_start = {
+				title:h_china.holder ?= { # Emperor decides what Stable phase to enter
+					if = {
+						limit = {
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = hegemon_ruler
+							}
+						}
+						trigger_event = tgp_dynastic_cycle.0071
+					}
+				}
+				tgp_update_wuking_element_effect = yes
+			}
+
+			parameters = {
+				era_type_stable = yes
+				hide_in_phases_list = yes
+			}
+
+			future_phases = {
+				situation_dynastic_cycle_phase_stability_expansion = {
+					takeover_type = points
+					takeover_points = 1
+				}
+				situation_dynastic_cycle_phase_stability_advancement = {
+					takeover_type = points
+					takeover_points = 1
+				}
+				 situation_dynastic_cycle_phase_instability = {
+					takeover_type = points
+					takeover_points = 1
+				}
+			}
+
+			modifier_sets = {
+				dynastic_cycle_government_effects = {
+					hegemon_ruler = {
+						parameters = {
+							dynastic_cycle_choose_stability_phase = yes
+						}
+					}
+				}
+			}
+		}
+		situation_dynastic_cycle_phase_stability_expansion = {
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_expansion.dds"
+			illustration = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_stability.dds"
+
+			on_start = {
+				set_variable = {
+					name = stability_phase_start_date
+					value = current_date
+				}
+				title:h_china.holder ?= { # Emperor decides what Stable phase to enter
+					if = {
+						limit = {
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = hegemon_ruler
+							}
+						}
+						trigger_event = tgp_dynastic_cycle.0071
+					}
+				}
+				tgp_update_wuking_element_effect = yes
+
+				#host the exam to unlock merit ranks after chaos is over
+				title:h_china.holder ?= {
+					if = {
+						limit = {
+							is_ai = yes
+							root.var:last_recorded_phase_change = 6
+						}
+						add_character_flag = examinations_ai_override
+						ai_attempt_to_host_activity = activity_imperial_examination
+					}
+				}
+				tgp_dynastic_cycle_record_history_phase_change_effect = {
+					PHASE = situation_dynastic_cycle_phase_stability_expansion
+					PHASE_NUMBER = 2
+				}
+
+				if = {
+					limit = { current_date_is_start_date_trigger = no }
+					situation:dynastic_cycle ?= {
+						situation_participant_group:expansion_movement = {
+							var:movement_leader ?= {
+								house.house_head.domicile ?= {
+									set_family_accomplishment_effect = { ACCOMPLISHMENT = family_accomplishment_expansion }
+								}
+							}
+						}
+					}
+				}
+			}
+
+			parameters = {
+				era_type_stable = yes
+				dynastic_cycle_choose_stability_phase = yes
+				dynastic_cycle_hegemon_increased_protectorate_limit = yes
+				dynastic_cycle_hegemon_unlocks_external_casus_belli = yes
+			}
+
+			on_end = {
+				title:h_china.holder ?= {
+					if = {
+						limit = {
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = hegemon_ruler
+							}
+							has_realm_law = celestial_bureaucracy_3
+						}
+						add_realm_law = celestial_bureaucracy_2
+					}
+				}
+			}
+
+			future_phases = {
+				situation_dynastic_cycle_phase_instability = {
+					takeover_type = points
+					takeover_points = @lost_mandate_of_heaven
+					catalysts = {
+
+						### SHARED CORRUPTION CATALYSTS
+
+						# Movement Power
+						catalyst_conservative_movement_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_expansion_movement_yearly = major_situation_catalyst_loss
+						catalyst_movement_gained_power_advancement = major_situation_catalyst_gain
+						catalyst_movement_gained_power_expansion = medium_situation_catalyst_loss
+						catalyst_movement_gained_power_conservative = major_situation_catalyst_gain
+						catalyst_movement_gained_power_pro_hegemon = minimal_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_expansion_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_expansion_negative = massive_plus_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_instability_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_instability_negative = massive_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_expansion_positive = major_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_expansion_negative = major_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_instability_positive = massive_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_instability_negative = massive_plus_situation_catalyst_loss
+						# Calamities
+						catalyst_hegemon_natural_disaster = monumental_situation_catalyst_over_time_gain
+						catalyst_hegemon_natural_disaster_recovered = massive_situation_catalyst_loss
+						catalyst_hegemon_in_civil_war = massive_situation_catalyst_gain
+						catalyst_hegemon_in_defensive_war_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_hegemon_epidemic = massive_situation_catalyst_over_time_gain
+						catalyst_hegemon_apocalyptic_epidemic = monumental_situation_catalyst_over_time_gain
+						# Legitimacy
+						catalyst_hegemon_below_legitimacy_yearly = below_legitimacy_catalyst_over_time_value
+						catalyst_hegemon_lost_mandate_of_heaven = @lost_mandate_of_heaven # Should always go into instability
+						catalyst_hegemon_mandate_of_heaven_at_0 = @lost_mandate_of_heaven
+						catalyst_hegemon_above_legitimacy_yearly = major_situation_catalyst_over_time_loss
+						# Held Lands
+						catalyst_hegemony_too_few_lands = extreme_situation_catalyst_over_time_gain
+						catalyst_hegemony_far_too_few_lands = @lost_mandate_of_heaven
+						# Regency
+						catalyst_diarch_mandate = minimal_situation_catalyst_gain
+						# Merit
+						catalyst_imperial_examinations_gap_long_yearly = major_situation_catalyst_over_time_gain
+
+						# Intrigue
+						catalyst_hegemon_murdered = monumental_situation_catalyst_gain
+						catalyst_imperial_family_member_murdered = medium_situation_catalyst_gain
+						# Imperial Treasury
+						catalyst_imperial_treasury_raided = monumental_situation_catalyst_over_time_gain
+						catalyst_imperial_treasury_debt = massive_situation_catalyst_over_time_gain
+						# Administrative
+						catalyst_governor_embezzlement = medium_situation_catalyst_gain
+						catalyst_dipped_into_treasury = medium_situation_catalyst_gain
+						catalyst_hegemon_influenced_by_interaction = medium_situation_catalyst_gain
+						catalyst_minister_imprison = minor_situation_catalyst_gain
+						catalyst_governor_raided_estate = medium_situation_catalyst_gain
+						catalyst_governor_slander = minimal_situation_catalyst_gain
+						catalyst_governor_challenged_status = minimal_situation_catalyst_gain
+						catalyst_great_project_great_wall_contribution = minor_situation_catalyst_loss
+						catalyst_great_project_establish_control_contribution = minimal_situation_catalyst_gain
+						# Tyranny
+						catalyst_tyrannical_extinguish_noble_family = medium_situation_catalyst_gain
+						
+						# Succession - A new dynasty inherits the throne
+						catalyst_new_dynasty_inherits = @lost_mandate_of_heaven # Should always go into instability
+
+						### EXPANSION CORRUPTION CATALYSTS
+
+						# Movement Power
+						catalyst_advancement_movement_yearly = major_situation_catalyst_over_time_gain
+						catalyst_pro_hegemon_movement_advancement_yearly = massive_situation_catalyst_over_time_gain
+						# Diplomacy
+						catalyst_hegemon_too_few_tributaries_yearly = major_situation_catalyst_over_time_gain
+						# Warfare
+						catalyst_hegemon_outdated_maa_yearly = major_situation_catalyst_over_time_gain
+						catalyst_hegemon_below_maa_limit_yearly = major_situation_catalyst_over_time_gain
+						catalyst_hegemon_hired_mercenary = minor_situation_catalyst_gain
+						catalyst_hegemon_lost_war = massive_plus_situation_catalyst_gain
+						catalyst_hegemon_lost_defensive_territorial_war = massive_situation_catalyst_gain
+						catalyst_hegemon_lost_capital_in_war = monumental_situation_catalyst_gain
+
+						#Events
+						catalyst_event_mongol_empire_appears = massive_situation_catalyst_gain
+						catalyst_event_mongol_empire_attacks_minor = medium_situation_catalyst_gain
+						catalyst_event_mongol_empire_attacks_major = major_situation_catalyst_gain
+
+						# Great Projects
+						catalyst_great_project_great_wall_contribution = minimal_situation_catalyst_loss
+						catalyst_great_project_establish_control_contribution = minimal_situation_catalyst_gain
+						catalyst_minister_train_troops = medium_situation_catalyst_loss
+						catalyst_grand_campaign = major_situation_catalyst_loss
+						catalyst_grand_campaign_lost = major_situation_catalyst_gain
+
+						# Ministers
+						catalyst_find_secrets_bad_outcome = minor_situation_catalyst_gain
+						catalyst_find_secrets_good_outcome = minor_situation_catalyst_loss
+						catalyst_minister_caught_exam_cheater = minimal_situation_catalyst_loss
+						catalyst_minister_blackmailed = minimal_situation_catalyst_loss
+						catalyst_minister_exposed_secret = minor_situation_catalyst_loss
+						catalyst_cleared_treasury_debt = minor_situation_catalyst_loss
+						catalyst_minister_pardoned_known_criminal = minor_situation_catalyst_gain
+						catalyst_minister_pardoned_dangerous_criminal = minimal_situation_catalyst_gain
+						catalyst_requested_incursion = major_situation_catalyst_gain
+					}
+				}
+			}
+			modifier_sets = {
+				dynastic_cycle_government_effects = {
+					hegemon_ruler = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_hegemon_unlocks_external_casus_belli = yes
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							#shared effects
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemony_higher_court_position_salaries = yes
+							dynastic_cycle_hegemony_ignore_merit_for_appointments = yes # Exists for localisation and does not need an actual implementation
+							dynastic_cycle_hegemon_increased_protectorate_limit = yes
+							dynastic_cycle_hegemon_martial_examinations = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					pro_hegemon_movement = {
+						parameters = {
+							#movement defining effects
+							pro_hegemon_interaction_boost = yes
+							#phase defining effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							#shared effects
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemon_legitimacy_increasing_expectations = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					expansion_movement = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							#shared effects
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemon_legitimacy_increasing_expectations = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					advancement_movement = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							#shared effects
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemon_legitimacy_increasing_expectations = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					conservative_movement = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							#shared effects
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemon_legitimacy_increasing_expectations = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					undecided_movement = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							#shared effects
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					other_rulers = {
+						parameters = {
+							dynastic_cycle_no_effects = yes
+						}
+					}
+				}
+				dynastic_cycle_character_effects = {
+					hegemon_ruler = {
+						character_modifier = {
+							men_at_arms_title_cap = 2
+							mercenary_hire_cost_mult = 2.5
+							max_political_schemes_add = 1
+							max_hostile_schemes_add = 1
+							max_personal_schemes_add = 1
+						}
+					}
+					pro_hegemon_movement = {
+						character_modifier = {
+							men_at_arms_cap = 1
+							men_at_arms_maintenance = -0.1
+							liege_opinion = 10
+						}
+					}
+					expansion_movement = {
+						character_modifier = {
+							men_at_arms_cap = 3
+							men_at_arms_maintenance = -0.3
+						}
+					}
+					conservative_movement = {
+						character_modifier = {
+							domicile_build_speed = 0.1
+							domicile_build_gold_cost = -0.1
+							domicile_monthly_influence_add = 1
+							dynasty_house_opinion = 10
+						}
+					}
+				}
+			}
+		}
+
+		situation_dynastic_cycle_phase_stability_advancement = { # Song/Ming
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_advancement.dds"
+			illustration = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_stability.dds"
+
+			on_start = {
+				set_variable = {
+					name = stability_phase_start_date
+					value = current_date
+				}
+				title:h_china.holder ?= { # Emperor decides what Stable phase to enter
+					if = {
+						limit = {
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = hegemon_ruler
+							}
+						}
+						trigger_event = tgp_dynastic_cycle.0071
+					}
+				}
+				tgp_update_wuking_element_effect = yes
+
+				#host the exam to unlock merit ranks after chaos is over
+				title:h_china.holder ?= {
+					if = {
+						limit = {
+							is_ai = yes
+							root.var:last_recorded_phase_change = 6
+						}
+						add_character_flag = examinations_ai_override
+						ai_attempt_to_host_activity = activity_imperial_examination
+					}
+				}
+				tgp_dynastic_cycle_record_history_phase_change_effect = {
+					PHASE = situation_dynastic_cycle_phase_stability_advancement
+					PHASE_NUMBER = 3
+				}
+
+				if = {
+					limit = { current_date_is_start_date_trigger = no }
+					situation:dynastic_cycle ?= {
+						situation_participant_group:advancement_movement = {
+							var:movement_leader ?= {
+								house.house_head.domicile ?= {
+									set_family_accomplishment_effect = { ACCOMPLISHMENT = family_accomplishment_advancement }
+								}
+							}
+						}
+					}
+				}
+			}
+
+			parameters = {
+				era_type_stable = yes
+				dynastic_cycle_choose_stability_phase = yes
+				dynastic_cycle_hegemon_increased_metropolitan_limit = yes
+			}
+
+			on_end = {
+				title:h_china.holder ?= {
+					if = {
+						limit = {
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = hegemon_ruler
+							}
+							has_realm_law = celestial_bureaucracy_3
+						}
+						add_realm_law = celestial_bureaucracy_2
+					}
+				}
+			}
+
+			future_phases = {
+				situation_dynastic_cycle_phase_instability = {
+					takeover_type = points
+					takeover_points = @lost_mandate_of_heaven
+					catalysts = {
+
+						### SHARED CORRUPTION CATALYSTS
+
+						# Movement Power
+						catalyst_conservative_movement_yearly = minor_situation_catalyst_over_time_gain
+						catalyst_advancement_movement_yearly = major_situation_catalyst_loss
+						catalyst_movement_gained_power_advancement = medium_situation_catalyst_loss
+						catalyst_movement_gained_power_expansion = minor_situation_catalyst_gain
+						catalyst_movement_gained_power_conservative = minor_situation_catalyst_gain
+						catalyst_movement_gained_power_pro_hegemon = minimal_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_instability_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_instability_negative = massive_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_instability_positive = major_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_instability_negative = major_plus_situation_catalyst_loss
+						# Calamities
+						catalyst_hegemon_natural_disaster = monumental_situation_catalyst_over_time_gain
+						catalyst_hegemon_natural_disaster_recovered = massive_situation_catalyst_loss
+						catalyst_hegemon_in_civil_war = massive_situation_catalyst_gain
+						catalyst_hegemon_in_defensive_war_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_hegemon_epidemic = massive_situation_catalyst_over_time_gain
+						catalyst_hegemon_apocalyptic_epidemic = monumental_situation_catalyst_over_time_gain
+						# Legitimacy
+						catalyst_hegemon_below_legitimacy_yearly = below_legitimacy_catalyst_over_time_value
+						catalyst_hegemon_lost_mandate_of_heaven = @lost_mandate_of_heaven # Should always go into instability
+						catalyst_hegemon_mandate_of_heaven_at_0 = @lost_mandate_of_heaven
+						catalyst_hegemon_above_legitimacy_yearly = major_situation_catalyst_over_time_loss
+						# Held Lands
+						catalyst_hegemony_too_few_lands = extreme_situation_catalyst_over_time_gain
+						catalyst_hegemony_far_too_few_lands = @lost_mandate_of_heaven
+						# Regency
+						catalyst_diarch_mandate = minimal_situation_catalyst_gain
+						# Merit
+						catalyst_imperial_examinations_gap_long_yearly = major_situation_catalyst_over_time_gain
+
+						# Intrigue
+						catalyst_hegemon_murdered = monumental_situation_catalyst_gain
+						catalyst_imperial_family_member_murdered = major_situation_catalyst_gain
+						# Imperial Treasury
+						catalyst_imperial_treasury_raided = monumental_situation_catalyst_over_time_gain
+						catalyst_imperial_treasury_debt = massive_situation_catalyst_over_time_gain
+						# Administrative
+						catalyst_governor_embezzlement = medium_situation_catalyst_gain
+						catalyst_dipped_into_treasury = medium_situation_catalyst_gain
+						catalyst_hegemon_influenced_by_interaction = medium_situation_catalyst_gain
+						catalyst_minister_imprison = minor_situation_catalyst_gain
+						catalyst_governor_raided_estate = medium_situation_catalyst_gain
+						catalyst_governor_slander = minimal_situation_catalyst_gain
+						catalyst_governor_challenged_status = minimal_situation_catalyst_gain
+						catalyst_hegemon_appointing_low_merit_governor = minor_situation_catalyst_gain
+						catalyst_hegemon_appointing_low_merit_councillor = minor_situation_catalyst_gain
+						# Tyranny
+						catalyst_tyrannical_extinguish_noble_family = medium_situation_catalyst_gain
+
+						# Great Projects
+						catalyst_great_project_great_wall_contribution = minimal_situation_catalyst_gain
+						catalyst_great_project_establish_control_contribution = minimal_situation_catalyst_loss
+						catalyst_minister_project_culture = medium_situation_catalyst_loss
+						catalyst_minister_compel_religious_uniformity = medium_situation_catalyst_loss
+						catalyst_minister_conduct_census = medium_situation_catalyst_loss
+						catalyst_grand_campaign = minor_situation_catalyst_loss
+						catalyst_grand_campaign_lost = major_situation_catalyst_gain
+						
+						# Succession - A new dynasty inherits the throne
+						catalyst_new_dynasty_inherits = @lost_mandate_of_heaven # Should always go into instability
+
+						### ADVANCEMENT CORRUPTION CATALYSTS
+
+						# Movement Power
+						catalyst_expansion_movement_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_pro_hegemon_movement_expansion_yearly = medium_situation_catalyst_over_time_gain
+						# Warfare
+						catalyst_hegemon_above_maa_limit_yearly = minor_situation_catalyst_over_time_gain
+						catalyst_hegemon_lost_war = massive_plus_situation_catalyst_gain
+						catalyst_hegemon_lost_defensive_territorial_war = major_situation_catalyst_gain
+						catalyst_hegemon_lost_capital_in_war = massive_situation_catalyst_gain
+						catalyst_requested_incursion = major_situation_catalyst_gain
+						# Merit
+						catalyst_imperial_examinations_gap_short_yearly = major_situation_catalyst_over_time_gain
+
+						#Events
+						catalyst_event_mongol_empire_appears = massive_situation_catalyst_gain
+						catalyst_event_mongol_empire_attacks_minor = medium_situation_catalyst_gain
+						catalyst_event_mongol_empire_attacks_major = major_situation_catalyst_gain
+						# Ministers
+						catalyst_find_secrets_bad_outcome = minor_situation_catalyst_gain
+						catalyst_find_secrets_good_outcome = minor_situation_catalyst_loss
+						catalyst_minister_caught_exam_cheater = minimal_situation_catalyst_loss
+						catalyst_minister_blackmailed = minimal_situation_catalyst_loss
+						catalyst_minister_exposed_secret = minor_situation_catalyst_loss
+						catalyst_cleared_treasury_debt = minor_situation_catalyst_loss
+						catalyst_minister_pardoned_known_criminal = minor_situation_catalyst_gain
+						catalyst_minister_pardoned_dangerous_criminal = minimal_situation_catalyst_gain
+						catalyst_ministers_abused_privilege_of_office = minor_situation_catalyst_gain
+					}
+				}
+			}
+			modifier_sets = {
+				dynastic_cycle_government_effects = {
+					hegemon_ruler = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_hegemon_legitimacy_increasing_expectations = yes
+							dynastic_cycle_offensive_wars_ban = yes
+							dynastic_cycle_can_build_in_tributaries = yes
+							#shared effects
+							dynastic_cycle_faster_title_integration = yes
+							dynastic_cycle_hegemon_increased_metropolitan_limit = yes
+							dynastic_cycle_hegemon_stewardship_examinations = yes
+							dynastic_cycle_imperial_buildings_increased_build_speed = yes
+						}
+					}
+					pro_hegemon_movement = {
+						parameters = {
+							#movement defining effects
+							pro_hegemon_interaction_boost = yes
+							#shared effects
+							dynastic_cycle_faster_title_integration = yes
+						}
+					}
+					expansion_movement = {
+						parameters = {
+							dynastic_cycle_faster_title_integration = yes
+						}
+					}
+					advancement_movement = {
+						parameters = {
+							dynastic_cycle_faster_title_integration = yes
+							dynastic_cycle_send_treasury_for_merit = yes
+						}
+					}
+					conservative_movement = {
+						parameters = {
+							dynastic_cycle_faster_title_integration = yes
+						}
+					}
+					other_rulers = {
+						parameters = {
+							dynastic_cycle_no_effects = yes
+						}
+					}
+				}
+
+				dynastic_cycle_character_effects = {
+					hegemon_ruler = {
+						character_modifier = {
+							men_at_arms_cap = -2
+							mercenary_hire_cost_mult = 5
+							cultural_head_fascination_mult = 0.2
+							max_political_schemes_add = 1
+							max_hostile_schemes_add = 1
+							max_personal_schemes_add = 1
+						}
+						county_modifier = {
+							build_gold_cost = -0.15
+							build_speed = -0.15
+						}
+					}
+
+					pro_hegemon_movement = {
+						character_modifier = {
+							men_at_arms_cap = -1
+							men_at_arms_maintenance = 0.1
+							cultural_head_fascination_mult = 0.1
+							liege_opinion = 10
+						}
+						county_modifier = {
+							build_gold_cost = -0.1
+							build_speed = -0.1
+						}
+					}
+
+					advancement_movement = {
+						character_modifier = {
+							men_at_arms_cap = -2
+							men_at_arms_maintenance = 0.2
+							cultural_head_fascination_mult = 0.2
+						}
+						county_modifier = {
+							build_gold_cost = -0.2
+							build_speed = -0.2
+						}
+					}
+
+					conservative_movement = {
+						character_modifier = {
+							men_at_arms_cap = -2
+							men_at_arms_maintenance = 0.2
+							domicile_build_speed = 0.1
+							domicile_build_gold_cost = -0.1
+							domicile_monthly_influence_add = 1
+							dynasty_house_opinion = 10
+						}
+					}
+					undecided_movement = {
+						character_modifier = {
+							men_at_arms_cap = -2
+							men_at_arms_maintenance = 0.2
+						}
+					}
+				}
+			}
+		}
+
+		situation_dynastic_cycle_phase_instability_conquest = {
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_conquest.dds"
+			illustration = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_consolidation.dds"
+
+			on_start = {
+				title:h_china.holder ?= { trigger_event = tgp_dynastic_cycle.0061 } # China conquered
+				tgp_update_wuking_element_effect = yes
+				
+				tgp_dynastic_cycle_record_history_phase_change_effect = {
+					PHASE = situation_dynastic_cycle_phase_instability_conquest
+					PHASE_NUMBER = 4
+				}
+				if = {
+					limit = {
+						NOT = { exists = title:h_china.holder }
+					}
+					situation:dynastic_cycle ?= {
+						if = {
+							limit = {
+								situation_top_has_catalyst = catalyst_hegemon_lost_mandate_of_heaven
+							}
+							trigger_situation_catalyst = {
+								catalyst = catalyst_hegemon_lost_mandate_of_heaven
+								character = root
+							}
+						}
+					}
+				}
+			}
+
+			parameters = {
+				era_type_unstable = yes
+				dynastic_cycle_hegemon_unlocks_external_casus_belli = yes
+			}
+
+			on_end = {
+				if = { # Remove any promoted culture if we leave this phase
+					limit = {
+						has_variable = dynastic_cycle_favored_culture
+					}
+					remove_variable = dynastic_cycle_favored_culture
+				}
+				#save all movement leaders - needed to determine tributaries after shattering
+				every_participant_group = {
+					if = {
+						limit = {
+							exists = var:movement_leader
+						}
+						var:movement_leader = {
+							set_variable = {
+								name = former_movement_leader
+								value = prev
+							}
+						}
+					}
+					every_situation_group_participant = {
+						set_variable = {
+							name = former_movement_member
+							value = prev
+						}
+					}
+				}
+			}
+
+			future_phases = {
+				situation_dynastic_cycle_phase_stability_advancement = {
+					takeover_type = points
+					takeover_points = @gained_mandate_of_heaven_halved
+					catalysts = {
+						# Passive gain
+						## Movement Power
+						catalyst_pro_hegemon_movement_advancement_yearly = major_situation_catalyst_over_time_gain
+						catalyst_expansion_movement_yearly = medium_situation_catalyst_loss
+						catalyst_advancement_movement_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_movement_consulted_heaven_advancement_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_advancement_negative = massive_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_advancement_positive = major_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_advancement_negative = major_plus_situation_catalyst_loss
+						## Legitimacy
+						catalyst_hegemon_above_legitimacy_yearly = major_situation_catalyst_over_time_gain
+						catalyst_new_dynasty_inherits = monumental_situation_catalyst_loss
+						# Regency
+						catalyst_diarch_mandate = minimal_situation_catalyst_gain
+						# Active gain
+						## Great Projects
+						catalyst_minister_project_culture = massive_situation_catalyst_gain
+						catalyst_minister_compel_religious_uniformity = massive_situation_catalyst_gain
+						catalyst_minister_conduct_census = massive_situation_catalyst_gain
+						catalyst_great_project_establish_control_contribution = minor_situation_catalyst_loss
+						## Events
+						catalyst_event_advancement_medium_progress = medium_situation_catalyst_gain
+						# Ministers
+						catalyst_find_secrets_bad_outcome = minor_situation_catalyst_loss
+						catalyst_find_secrets_good_outcome = minor_situation_catalyst_gain
+						catalyst_minister_caught_exam_cheater = minor_situation_catalyst_gain
+					}
+				}
+
+				situation_dynastic_cycle_phase_stability_expansion = {
+					takeover_type = points
+					takeover_points = @gained_mandate_of_heaven_halved
+					catalysts = {
+						# Passive gain
+						## Movement Power
+						catalyst_pro_hegemon_movement_expansion_yearly = major_situation_catalyst_over_time_gain
+						catalyst_expansion_movement_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_advancement_movement_yearly = medium_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_expansion_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_expansion_negative = massive_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_expansion_positive = major_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_expansion_negative = major_plus_situation_catalyst_loss
+						## Legitimacy
+						catalyst_hegemon_above_legitimacy_yearly = major_situation_catalyst_over_time_gain
+						catalyst_new_dynasty_inherits = monumental_situation_catalyst_loss
+						# Active gain
+						## Warfare
+						catalyst_hegemon_won_war = massive_situation_catalyst_gain
+						## Great Projects
+						catalyst_great_wall = massive_situation_catalyst_gain
+						catalyst_great_project_great_wall_contribution = minor_situation_catalyst_loss
+						catalyst_grand_campaign = massive_situation_catalyst_gain
+						catalyst_minister_train_troops = massive_situation_catalyst_gain
+						# Ministers
+						catalyst_find_secrets_bad_outcome = minor_situation_catalyst_loss
+						catalyst_find_secrets_good_outcome = minor_situation_catalyst_gain
+					}
+				}
+
+				situation_dynastic_cycle_phase_chaos = {
+					takeover_type = points
+					takeover_points = @lost_mandate_of_heaven_halved
+					catalysts = {
+						# Movement Power
+						catalyst_pro_hegemon_movement_yearly = medium_situation_catalyst_loss
+						catalyst_movement_gained_power_conservative = medium_situation_catalyst_gain
+						catalyst_movement_gained_power_pro_hegemon = minimal_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_chaos_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_chaos_negative = massive_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_chaos_positive = major_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_chaos_negative = major_plus_situation_catalyst_loss
+						# Diplomacy
+						catalyst_hegemon_too_few_tributaries_yearly = medium_situation_catalyst_gain
+						# Held Lands
+						catalyst_hegemony_too_few_lands = extreme_situation_catalyst_over_time_gain
+						catalyst_hegemony_far_too_few_lands = @lost_mandate_of_heaven
+						# Calamities
+						catalyst_hegemon_natural_disaster = monumental_situation_catalyst_over_time_gain
+						catalyst_hegemon_natural_disaster_recovered = massive_situation_catalyst_loss
+						catalyst_hegemon_in_civil_war = massive_situation_catalyst_gain
+						catalyst_hegemon_in_defensive_war_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_hegemon_epidemic = massive_situation_catalyst_over_time_gain
+						catalyst_hegemon_apocalyptic_epidemic = monumental_situation_catalyst_over_time_gain
+						# Intrigue
+						catalyst_hegemon_murdered = monumental_situation_catalyst_gain
+						catalyst_minister_imprison = minor_situation_catalyst_gain
+						# Warfare
+						catalyst_hegemon_below_maa_limit_yearly = major_situation_catalyst_over_time_gain
+						catalyst_hegemon_lost_defensive_territorial_war = major_situation_catalyst_gain
+						catalyst_hegemon_lost_capital_in_war = massive_situation_catalyst_gain
+						catalyst_hegemon_hired_mercenary = medium_situation_catalyst_gain
+						catalyst_hegemon_lost_war = massive_plus_situation_catalyst_gain
+						catalyst_grand_campaign_lost = massive_situation_catalyst_gain
+						catalyst_requested_incursion = major_situation_catalyst_gain
+
+						#Legitimacy
+						catalyst_hegemon_below_legitimacy_yearly = below_legitimacy_catalyst_over_time_value
+						catalyst_hegemon_lost_mandate_of_heaven = @lost_mandate_of_heaven_halved # Should always go into chaotic
+						catalyst_hegemon_mandate_of_heaven_at_0 = @lost_mandate_of_heaven_halved
+						catalyst_hegemon_above_legitimacy_yearly = major_situation_catalyst_over_time_loss
+
+						#Events
+						catalyst_event_mongol_empire_appears = massive_situation_catalyst_gain
+						catalyst_event_mongol_empire_attacks_minor = medium_situation_catalyst_gain
+						catalyst_event_mongol_empire_attacks_major = major_situation_catalyst_gain
+						# Tyranny
+						catalyst_tyrannical_extinguish_noble_family = medium_situation_catalyst_gain
+
+						# Ministers
+						catalyst_minister_blackmailed = minimal_situation_catalyst_loss
+						catalyst_minister_exposed_secret = minor_situation_catalyst_loss
+						catalyst_cleared_treasury_debt = minor_situation_catalyst_loss
+						catalyst_minister_pardoned_known_criminal = minor_situation_catalyst_gain
+						catalyst_minister_pardoned_dangerous_criminal = minimal_situation_catalyst_gain
+						catalyst_ministers_abused_privilege_of_office = minor_situation_catalyst_gain
+					}
+				}
+			}
+			modifier_sets = {
+				dynastic_cycle_government_effects = {
+					hegemon_ruler = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_hegemon_may_favour_own_culture_for_appointments = yes
+							dynastic_cycle_hegemon_unlocks_external_casus_belli = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							#shared effects
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+
+					pro_hegemon_movement = {
+						parameters = {
+							#movement defining effects
+							pro_hegemon_interaction_boost = yes
+							#shared effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemon_may_favour_own_culture_for_appointments = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					expansion_movement = {
+						parameters = {
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemon_may_favour_own_culture_for_appointments = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					advancement_movement = {
+						parameters = {
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemon_may_favour_own_culture_for_appointments = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					conservative_movement = {
+						parameters = {
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							dynastic_cycle_hegemon_legitimacy_from_external_conquest = yes
+							dynastic_cycle_hegemon_may_favour_own_culture_for_appointments = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					undecided_movement = {
+						parameters = {
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					other_rulers = {
+						parameters = {
+							dynastic_cycle_no_effects = yes
+						}
+					}
+				}
+
+				dynastic_cycle_character_effects = {
+					hegemon_ruler = {
+						character_modifier = {
+							men_at_arms_title_cap = 2
+							vassal_tax_contribution_mult = -0.2
+							vassal_opinion = -20
+							legitimacy_gain_mult = 0.2
+							legitimacy_loss_mult = 0.2
+							max_political_schemes_add = 1
+							max_hostile_schemes_add = 1
+							max_personal_schemes_add = 1
+						}
+					}
+					pro_hegemon_movement = {
+						character_modifier = {
+							men_at_arms_title_cap = 1
+							men_at_arms_maintenance = -0.1
+							vassal_tax_contribution_mult = -0.1
+							vassal_opinion = -10
+							liege_opinion = 10
+						}
+					}
+					expansion_movement = {
+						character_modifier = {
+							men_at_arms_title_cap = 2
+							vassal_opinion = 10
+						}
+					}
+					advancement_movement = {
+						character_modifier = {
+							men_at_arms_title_cap = 2
+							men_at_arms_maintenance = -0.2
+							vassal_tax_contribution_mult = -0.2
+							vassal_opinion = -20
+						}
+					}
+					conservative_movement = {
+						character_modifier = {
+							men_at_arms_title_cap = 2
+							men_at_arms_maintenance = -0.2
+							vassal_tax_contribution_mult = -0.2
+							vassal_opinion = -20
+							dynasty_house_opinion = 10
+						}
+					}
+					undecided_movement = {
+						character_modifier = {
+							vassal_tax_contribution_mult = -0.2
+							vassal_opinion = -20
+						}
+					}
+				}
+			}
+		}
+
+		situation_dynastic_cycle_phase_instability = { # Tang
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_instability.dds"
+			illustration = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_consolidation.dds"
+
+			on_start = {
+				title:h_china.holder ?= {
+					if = {
+						limit = {
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = hegemon_ruler
+							}
+						}
+						trigger_event = tgp_dynastic_cycle.0091
+					}
+				}
+
+				tgp_dynastic_cycle_record_history_phase_change_effect = {
+					PHASE = situation_dynastic_cycle_phase_instability
+					PHASE_NUMBER = 5
+				}
+				if = {
+					limit = {
+						NOT = { exists = title:h_china.holder }
+					}
+					situation:dynastic_cycle ?= {
+						if = {
+							limit = {
+								situation_top_has_catalyst = catalyst_hegemon_lost_mandate_of_heaven
+							}
+							trigger_situation_catalyst = {
+								catalyst = catalyst_hegemon_lost_mandate_of_heaven
+								character = root
+							}
+						}
+					}
+				}
+			}
+
+			parameters = {
+				era_type_unstable = yes
+			}
+
+			on_end = {
+				#save all movement leaders - needed to deterimne tributaries after shattering
+				every_participant_group = {
+					if = {
+						limit = {
+							exists = var:movement_leader
+						}
+						var:movement_leader = {
+							set_variable = {
+								name = former_movement_leader
+								value = prev
+							}
+						}
+					}
+					every_situation_group_participant = {
+						set_variable = {
+							name = former_movement_member
+							value = prev
+						}
+					}
+				}
+			}
+			future_phases = {
+				situation_dynastic_cycle_phase_stability_advancement = {
+					takeover_type = points
+					takeover_points = @gained_mandate_of_heaven_halved
+					catalysts = {
+						# Passive gain
+						## Movement Power
+						catalyst_movement_gained_power_advancement = major_situation_catalyst_gain
+						catalyst_pro_hegemon_movement_advancement_yearly = major_situation_catalyst_over_time_gain
+						catalyst_advancement_movement_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_expansion_movement_yearly = medium_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_advancement_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_advancement_negative = massive_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_advancement_positive = major_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_advancement_negative = major_plus_situation_catalyst_loss
+						## Legitimacy
+						catalyst_hegemon_above_legitimacy_yearly = major_situation_catalyst_over_time_gain
+						catalyst_new_dynasty_inherits = monumental_situation_catalyst_loss
+						# Active gain
+						## Great Projects
+						catalyst_minister_project_culture = massive_situation_catalyst_gain
+						catalyst_minister_compel_religious_uniformity = massive_situation_catalyst_gain
+						catalyst_minister_conduct_census = massive_situation_catalyst_gain
+						catalyst_great_project_establish_control_contribution = minor_situation_catalyst_loss
+						## Events
+						catalyst_event_advancement_medium_progress = medium_situation_catalyst_gain
+						# Ministers
+						catalyst_find_secrets_bad_outcome = minor_situation_catalyst_loss
+						catalyst_find_secrets_good_outcome = minor_situation_catalyst_gain
+						catalyst_minister_caught_exam_cheater = minor_situation_catalyst_gain
+					}
+				}
+				situation_dynastic_cycle_phase_stability_expansion = {
+					takeover_type = points
+					takeover_points = @gained_mandate_of_heaven_halved
+					catalysts = {
+						# Passive gain
+						## Movement Power
+						catalyst_movement_gained_power_expansion = major_situation_catalyst_gain
+						catalyst_pro_hegemon_movement_expansion_yearly = major_situation_catalyst_over_time_gain
+						catalyst_expansion_movement_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_advancement_movement_yearly = medium_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_expansion_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_expansion_negative = massive_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_expansion_positive = major_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_expansion_negative = major_plus_situation_catalyst_loss
+						## Legitimacy
+						catalyst_hegemon_above_legitimacy_yearly = major_situation_catalyst_over_time_gain
+						catalyst_new_dynasty_inherits = monumental_situation_catalyst_loss
+						# Active gain
+						## Warfare
+						catalyst_hegemon_won_war = massive_situation_catalyst_gain
+						## Great Projects
+						catalyst_great_wall = massive_situation_catalyst_gain
+						catalyst_great_project_great_wall_contribution = minor_situation_catalyst_gain
+						catalyst_grand_campaign = massive_situation_catalyst_gain
+						catalyst_minister_train_troops = massive_situation_catalyst_gain
+						# Ministers
+						catalyst_find_secrets_bad_outcome = minor_situation_catalyst_loss
+						catalyst_find_secrets_good_outcome = minor_situation_catalyst_gain
+					}
+				}
+				situation_dynastic_cycle_phase_chaos = {
+					takeover_type = points
+					takeover_points = @lost_mandate_of_heaven_halved
+					catalysts = {
+						# Movement Power
+						catalyst_pro_hegemon_movement_yearly = medium_situation_catalyst_loss
+						catalyst_movement_gained_power_conservative = medium_situation_catalyst_gain
+						catalyst_movement_gained_power_pro_hegemon = minimal_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_chaos_positive = massive_situation_catalyst_gain
+						catalyst_movement_consulted_heaven_chaos_negative = massive_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_chaos_positive = major_situation_catalyst_gain
+						catalyst_house_head_consulted_heaven_chaos_negative = major_plus_situation_catalyst_loss
+						# Legitimacy
+						catalyst_hegemon_below_legitimacy_yearly = below_legitimacy_catalyst_over_time_value
+						catalyst_hegemon_lost_mandate_of_heaven = @lost_mandate_of_heaven_halved
+						catalyst_hegemon_mandate_of_heaven_at_0 = @lost_mandate_of_heaven_halved
+						catalyst_hegemon_above_legitimacy_yearly = major_situation_catalyst_over_time_loss
+						# Held Lands
+						catalyst_hegemony_too_few_lands = extreme_situation_catalyst_over_time_gain
+						catalyst_hegemony_far_too_few_lands = @lost_mandate_of_heaven_halved
+						# Intrigue
+						catalyst_hegemon_murdered = monumental_situation_catalyst_gain
+						catalyst_minister_imprison = minor_situation_catalyst_gain
+						# Imperial Treasury
+						catalyst_imperial_treasury_raided = massive_situation_catalyst_gain
+						catalyst_imperial_treasury_debt = major_situation_catalyst_over_time_gain
+						# Calamities
+						catalyst_hegemon_natural_disaster = monumental_situation_catalyst_over_time_gain
+						catalyst_hegemon_natural_disaster_recovered = massive_situation_catalyst_loss
+						catalyst_hegemon_in_civil_war = massive_situation_catalyst_gain
+						catalyst_hegemon_in_defensive_war_yearly = massive_situation_catalyst_over_time_gain
+						catalyst_hegemon_epidemic = massive_situation_catalyst_over_time_gain
+						catalyst_hegemon_apocalyptic_epidemic = monumental_situation_catalyst_over_time_gain
+						# Warfare
+						catalyst_hegemon_lost_war = massive_plus_situation_catalyst_gain
+						catalyst_hegemon_lost_defensive_territorial_war = major_situation_catalyst_gain
+						catalyst_grand_campaign_lost = massive_situation_catalyst_gain
+						catalyst_requested_incursion = major_situation_catalyst_gain
+
+						#Events
+						catalyst_event_mongol_empire_appears = massive_situation_catalyst_gain
+						catalyst_event_mongol_empire_attacks_minor = medium_situation_catalyst_gain
+						catalyst_event_mongol_empire_attacks_major = major_situation_catalyst_gain
+
+						# Tyranny
+						catalyst_tyrannical_extinguish_noble_family = medium_situation_catalyst_gain
+
+						# Ministers
+						catalyst_minister_blackmailed = minimal_situation_catalyst_loss
+						catalyst_minister_exposed_secret = minor_situation_catalyst_loss
+						catalyst_cleared_treasury_debt = minor_situation_catalyst_loss
+						catalyst_minister_pardoned_known_criminal = minor_situation_catalyst_gain
+						catalyst_minister_pardoned_dangerous_criminal = minimal_situation_catalyst_gain
+						catalyst_ministers_abused_privilege_of_office = minor_situation_catalyst_gain
+
+						# Administrative
+						catalyst_hegemon_appointing_low_merit_councillor = minor_situation_catalyst_gain
+						catalyst_hegemon_appointing_low_merit_governor = minor_situation_catalyst_gain
+					}
+				}
+			}
+			modifier_sets = {
+				dynastic_cycle_government_effects = {
+					hegemon_ruler = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_more_peasant_factions = yes
+							#shared effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_internal_vassals_non_admin_war_desire = yes # NOT IMPLEMENTED
+							dynastic_cycle_offensive_wars_ban = yes
+							dynastic_cycle_governor_efficiency_penalty = yes
+							dynastic_cycle_external_tributaries_vassals_increased_independence_desire = yes
+							dynastic_cycle_vassals_reduced_independence_penalties = yes # NOT IMPLEMENTED
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					pro_hegemon_movement = {
+						parameters = {
+							#movement defining effects
+							pro_hegemon_interaction_boost = yes
+							#phase defining effects
+							dynastic_cycle_more_peasant_factions = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							#shared effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_internal_vassals_non_admin_war_desire = yes # NOT IMPLEMENTED
+							dynastic_cycle_governor_efficiency_penalty = yes
+							dynastic_cycle_external_tributaries_vassals_increased_independence_desire = yes
+							dynastic_cycle_vassals_reduced_independence_penalties = yes # NOT IMPLEMENTED
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					expansion_movement = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_more_peasant_factions = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							#shared effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_internal_vassals_non_admin_war_desire = yes # NOT IMPLEMENTED
+							dynastic_cycle_governor_efficiency_penalty = yes
+							dynastic_cycle_external_tributaries_vassals_increased_independence_desire = yes
+							dynastic_cycle_vassals_reduced_independence_penalties = yes # NOT IMPLEMENTED
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					advancement_movement = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_more_peasant_factions = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							#shared effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_internal_vassals_non_admin_war_desire = yes # NOT IMPLEMENTED
+							dynastic_cycle_governor_efficiency_penalty = yes
+							dynastic_cycle_external_tributaries_vassals_increased_independence_desire = yes
+							dynastic_cycle_vassals_reduced_independence_penalties = yes # NOT IMPLEMENTED
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					conservative_movement = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_more_peasant_factions = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							#shared effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_internal_vassals_non_admin_war_desire = yes # NOT IMPLEMENTED
+							dynastic_cycle_governor_efficiency_penalty = yes
+							dynastic_cycle_external_tributaries_vassals_increased_independence_desire = yes
+							dynastic_cycle_vassals_reduced_independence_penalties = yes # NOT IMPLEMENTED
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					undecided_movement = {
+						parameters = {
+							#phase defining effects
+							dynastic_cycle_more_peasant_factions = yes
+							dynastic_cycle_vassal_seize_cb = yes
+							#shared effects
+							dynastic_cycle_vassal_internal_wars_allowed = yes
+							dynastic_cycle_locks_title_integration = yes
+						}
+					}
+					other_rulers = {
+						parameters = {
+							dynastic_cycle_unlocks_cb_for_outsiders = yes # for loc purposes only, to let players know they can be invaded
+						}
+					}
+				}
+
+				dynastic_cycle_character_effects = {
+					hegemon_ruler = {
+						character_modifier = {
+							mercenary_hire_cost_mult = 2.5
+							vassal_tax_mult = -0.2
+							vassal_opinion = -20
+							monthly_treasury_from_vassals = -0.01
+							legitimacy_gain_mult = 0.2
+							legitimacy_loss_mult = 0.2
+							max_political_schemes_add = 1
+							max_hostile_schemes_add = 1
+							max_personal_schemes_add = 1
+						}
+					}
+					pro_hegemon_movement = {
+						character_modifier = {
+							monthly_treasury_from_liege_mult = -0.20
+							vassal_tax_mult = -0.1
+							vassal_opinion = -30
+							liege_opinion = 10
+						}
+					}
+					expansion_movement = {
+						character_modifier = {
+							monthly_treasury_from_liege_mult = -0.20
+							vassal_tax_mult = -0.1
+							vassal_opinion = -20
+						}
+					}
+					advancement_movement = {
+						character_modifier = {
+							monthly_treasury_from_liege_mult = -0.20
+							vassal_tax_mult = -0.1
+							vassal_opinion = -20
+						}
+					}
+					conservative_movement = {
+						character_modifier = {
+							monthly_treasury_from_liege_mult = -0.20
+							dynasty_house_opinion = 10
+						}
+					}
+					undecided_movement = {
+						character_modifier = {
+							monthly_treasury_from_liege_mult = -0.20
+							vassal_tax_mult = -0.1
+							vassal_opinion = -20
+						}
+					}
+				}
+			}
+		}
+
+		situation_dynastic_cycle_phase_chaos = {
+			icon = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_chaos.dds"
+			illustration = "gfx/interface/illustrations/event_story/tgp_dynastic_cycle_corruption.dds"
+
+			on_start = {
+				title:h_china.holder ?= {
+					save_scope_as = huangdi
+					if = {
+						limit = {
+							top_participant_group:dynastic_cycle ?= {
+								participant_group_type = hegemon_ruler
+							}
+						}
+						trigger_event = tgp_dynastic_cycle.0081 # China shatters
+					}
+				}
+				tgp_dynastic_cycle_record_history_phase_change_effect = {
+					PHASE = situation_dynastic_cycle_phase_chaos
+					PHASE_NUMBER = 6
+				}
+				# SILK ROAD
+				tgp_silk_road_china_consolidation_effect = yes
+			}
+			on_end = {
+				every_situation_participant = {
+					remove_variable = former_movement_leader
+					remove_variable = former_movement_member
+				}
+			}
+
+			parameters = {
+				era_type_chaotic = yes
+			}
+
+			future_phases = {
+				situation_dynastic_cycle_phase_stability_advancement = {
+					takeover_type = points
+					takeover_points = @mandate_of_heaven_flavorful_points
+					catalysts = {
+						catalyst_hegemon_gains_mandate_of_heaven = @mandate_of_heaven_flavorful_points
+					}
+				}
+				situation_dynastic_cycle_phase_stability_expansion = {
+					takeover_type = points
+					takeover_points = @mandate_of_heaven_flavorful_points
+					catalysts = {
+						catalyst_hegemon_gains_mandate_of_heaven = @mandate_of_heaven_flavorful_points
+					}
+				}
+			}
+			modifier_sets = {
+				dynastic_cycle_government_effects = {
+					hegemon_ruler = {
+						parameters = {
+							dynastic_cycle_no_movement = yes
+						}
+					}
+					pro_hegemon_movement = {
+						parameters = {
+							dynastic_cycle_no_movement = yes
+						}
+					}
+					expansion_movement = {
+						parameters = {
+							dynastic_cycle_no_movement = yes
+						}
+					}
+					advancement_movement = {
+						parameters = {
+							dynastic_cycle_no_movement = yes
+						}
+					}
+					conservative_movement = {
+						parameters = {
+							dynastic_cycle_no_movement = yes
+						}
+					}
+					undecided_movement = {
+						parameters = {
+							dynastic_cycle_no_movement = yes
+						}
+					}
+					other_rulers = {
+						parameters = {
+							dynastic_cycle_great_projects_increased_legitimacy = yes
+							dynastic_cycle_legitimacy_from_appointments = yes
+							dynastic_cycle_reclaim_mandate_decision = yes
+						}
+						county_modifier = {
+							tax_mult = -0.2
+						}
+					}
+				}
+			}
+		}
+	}
+
+	##################################################
+	# UI
+	##################################################
+	icon = {
+		trigger = {
+			situation_current_phase = situation_dynastic_cycle_phase_chaos
+		}
+		reference = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_chaos.dds"
+	}
+
+	icon = {
+		trigger = {
+			situation_current_phase = situation_dynastic_cycle_phase_stability_advancement
+		}
+		reference = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_advancement.dds"
+	}
+
+	icon = {
+		trigger = {
+			situation_current_phase = situation_dynastic_cycle_phase_instability_conquest
+		}
+		reference = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_conquest.dds"
+	}
+
+	icon = {
+		trigger = {
+			situation_current_phase = situation_dynastic_cycle_phase_stability_expansion
+		}
+		reference = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_expansion.dds"
+	}
+
+	icon = {
+		trigger = {
+			situation_current_phase = situation_dynastic_cycle_phase_instability
+		}
+		reference = "gfx/interface/icons/dynastic_cycle/dynastic_cycle_phase_instability.dds"
+	}
+}

--- a/common/situation/situations/tgp_dynastic_cycle.txt
+++ b/common/situation/situations/tgp_dynastic_cycle.txt
@@ -1211,7 +1211,8 @@ dynastic_cycle = {
 							}
 							trigger_situation_catalyst = {
 								catalyst = catalyst_hegemon_lost_mandate_of_heaven
-								character = root
+								#Unop drop invalid character arg - phase on_start root is the situation, not a character; attribution is optional (cf. epidemic catalysts above)
+								#character = root
 							}
 						}
 					}
@@ -1528,7 +1529,8 @@ dynastic_cycle = {
 							}
 							trigger_situation_catalyst = {
 								catalyst = catalyst_hegemon_lost_mandate_of_heaven
-								character = root
+								#Unop drop invalid character arg - phase on_start root is the situation, not a character; attribution is optional (cf. epidemic catalysts above)
+								#character = root
 							}
 						}
 					}

--- a/common/situation/situations/tgp_dynastic_cycle.txt
+++ b/common/situation/situations/tgp_dynastic_cycle.txt
@@ -712,12 +712,12 @@ dynastic_cycle = {
 						catalyst_movement_gained_power_expansion = medium_situation_catalyst_loss
 						catalyst_movement_gained_power_conservative = major_situation_catalyst_gain
 						catalyst_movement_gained_power_pro_hegemon = minimal_situation_catalyst_loss
-						catalyst_movement_consulted_heaven_expansion_positive = massive_situation_catalyst_gain
-						catalyst_movement_consulted_heaven_expansion_negative = massive_plus_situation_catalyst_loss
+						catalyst_movement_consulted_heaven_expansion_positive = massive_situation_catalyst_loss #Unop reversed polarity: during Expansion, pushing TOWARDS Expansion should resist decay to Instability, not accelerate it
+						catalyst_movement_consulted_heaven_expansion_negative = massive_plus_situation_catalyst_gain #Unop reversed polarity: pushing AWAY from Expansion should accelerate decay to Instability
 						catalyst_movement_consulted_heaven_instability_positive = massive_situation_catalyst_gain
 						catalyst_movement_consulted_heaven_instability_negative = massive_plus_situation_catalyst_loss
-						catalyst_house_head_consulted_heaven_expansion_positive = major_situation_catalyst_gain
-						catalyst_house_head_consulted_heaven_expansion_negative = major_plus_situation_catalyst_loss
+						catalyst_house_head_consulted_heaven_expansion_positive = major_situation_catalyst_loss #Unop reversed polarity: pushing TOWARDS Expansion should resist decay to Instability
+						catalyst_house_head_consulted_heaven_expansion_negative = major_plus_situation_catalyst_gain #Unop reversed polarity: pushing AWAY from Expansion should accelerate decay to Instability
 						catalyst_house_head_consulted_heaven_instability_positive = massive_situation_catalyst_gain
 						catalyst_house_head_consulted_heaven_instability_negative = massive_plus_situation_catalyst_loss
 						# Calamities


### PR DESCRIPTION
Fixes #551

**fixer:** In the **stability_expansion → instability** `future_phases` block of `dynastic_cycle`, the four "consulted Heaven" *expansion* catalysts had reversed polarity:

- `..._expansion_positive` ("push **towards** Expansion") was set to `_gain` — i.e. it accelerated decay *out of* Expansion toward Instability.
- `..._expansion_negative` ("push **away from** Expansion") was set to `_loss` — i.e. it resisted that decay.

Per the catalyst loc and the meaning of `gain` (progress toward the target phase = Instability) vs `loss` (resist), this is backwards while the current era is Expansion. Flipped the direction keyword on those four lines (keeping each line's magnitude tier), so `_expansion_positive` now resists the transition (`_loss`) and `_expansion_negative` accelerates it (`_gain`). This makes them mirror the correctly-polarized `_instability_*` siblings in the same block.

The identical-looking blocks in the *instability → stability_expansion* transitions (where `_expansion_positive = gain` correctly accelerates entering Expansion) are **unchanged** — edited by line position. Advancement era doesn't use these catalysts in its decay block, so it's unaffected (answers the reporter's question).

**Tiger:** adding the situation file surfaced two pre-existing, unrelated vanilla scope warnings (`trigger_situation_catalyst { character = root }` in two phase `on_start` blocks, where `root` is the situation per `_situations.info`). Separate vanilla bug; ignored via a precise `ck3-tiger.conf` rule and flagged for follow-up. `make tiger` clean.