### PR TITLE
Block Japanese governments from assimilating to mandala as tributaries

### DIFF
--- a/common/decisions/dlc_decisions/tgp/tgp_east_asia_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_east_asia_decisions.txt
@@ -1,0 +1,855 @@
+﻿#Decisions for East Asia
+### Restore Mandala Capital ###
+restore_mandala_capital_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_dynasty_house.dds"
+	}
+	desc = restore_mandala_capital_decision_desc
+	selection_tooltip = restore_mandala_capital_decision_tooltip
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 36
+		duchy = 36
+		kingdom = 36
+		empire = 36
+		hegemony = 36
+	}
+
+	is_shown = {
+		government_has_flag = government_is_mandala
+		capital_province.county = { has_county_modifier = mandala_capital_sacked_modifier }
+	}
+
+	is_valid_showing_failures_only = {
+		is_at_war = no
+		is_imprisoned = no
+		NOT = { has_trait = incapable }
+	}
+
+	effect = {
+		remove_short_term_gold = major_gold_value
+		capital_province.county = { 
+			remove_county_modifier = mandala_capital_sacked_modifier
+			add_county_modifier = {
+				modifier = mandala_capital_restored_modifier
+				years = 20
+			}
+		}
+	}
+	
+	ai_potential = {
+		is_at_war = no
+		ai_greed < medium_positive_ai_value
+		ai_should_focus_on_building_in_their_capital = yes
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			short_term_gold < major_gold_value
+			factor = 0
+		}
+	}
+}
+
+### Adopt Mandala Government ###
+convert_to_mandala_government_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_decision_mandala.dds"
+	}
+	decision_group_type = major
+	desc = convert_to_mandala_government_decision_desc
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 36
+		duchy = 36
+		kingdom = 36
+		empire = 36
+		hegemony = 36
+	}
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		is_landed = yes
+		has_mandala_culture_trigger = yes
+		NOT = { government_has_flag = government_is_mandala }
+		#We have a special decision for Mandala subjects...
+		trigger_if = {
+			limit = { is_tributary = yes }
+			NOT = { 
+				overlord = { government_has_flag = government_is_mandala }
+			}
+		}
+		highest_held_title_tier > tier_barony
+	}
+
+	is_valid = {
+		trigger_if = {
+			limit = {
+				has_legitimacy = yes
+				dynasty ?= {
+					NOT = { has_dynasty_perk = tgp_sea_legacy_3 } #Bypasses Tribal Authority Requirement
+				}
+			}
+			legitimacy_level >= 4
+		}
+		has_mandala_faith_trigger = yes
+		is_independent_ruler = yes
+		# This logic is necessary for the triggers in the options in the subsequent event, or else the player will not get the event
+		OR = {
+			any_realm_province = {
+				OR = {
+					custom_tooltip = {
+						text = convert_to_mandala_government_decision_is_temple_citadel_holding_tt
+						has_holding_type = temple_citadel_holding
+					}
+					custom_tooltip = {
+						text = convert_to_mandala_government_decision_has_no_holding_tt
+						has_holding = no
+					}
+				}
+			}
+			any_directly_owned_province = {
+				custom_tooltip = {
+					text = convert_to_mandala_government_decision_is_tribal_holding_tt
+					has_holding_type = tribal_holding
+				}
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		custom_tooltip = {
+			text = not_changed_government_recently_tt
+			NOT = { has_variable = changed_government_recently }
+		}
+		government_is_japanese_trigger = no
+	}
+
+	cost = {
+		prestige = {
+			value = 0
+			if = {
+				limit = { government_has_flag = government_is_tribal }
+				add = convert_to_mandala_government_tribal_value
+			}
+			else = { add = convert_to_mandala_government_nontribal_value }
+			#'s cheap!
+			if = {
+				limit = { has_character_modifier = divine_happenstance_modifier }
+				divide = 2
+			}
+		}
+	}
+
+	effect = {
+		#GoK stops really being GoK
+		gok_government_change_story_end_effect = yes
+		#Out with the old laws, in with the new
+		change_to_mandala_government_decree_effect = yes
+		#No Succession for this character pls
+		set_variable = {
+			name = not_subject_to_succession_trials
+			value = flag:adopted_mandala_government
+		}
+		if = {
+			limit = { var:not_subject_to_succession_trials ?= flag:adopted_mandala_government }
+			#To prevent 'unused except in loc' errors :catto:
+		}
+		show_as_tooltip = {
+			change_government = mandala_government
+		}
+		#Huh, guess you _are_ divine
+		if = {
+			limit = { has_variable = vying_for_mandala_divinity }
+			custom_description_no_bullet = { text = because_of_your_divine_happenstance_tt }
+			show_as_tooltip = { divine_happenstance_adopt_mandala_effect = yes }
+		}
+		if = {
+			limit = {
+				culture = {
+					has_cultural_parameter = mandala_tributaries 
+				}
+				exists = confederation
+			}
+			custom_tooltip = confederates_to_tributaries_tt
+		}
+		trigger_event = tgp_east_asia_decision_events.0010
+		hidden_effect = {
+			every_vassal = {
+				trigger_event = {
+					id = tgp_east_asia_decision_events.0015
+					days = 3
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+		has_mandala_culture_trigger = yes
+		trigger_if = {
+			limit = { government_has_flag = government_is_tribal }
+			has_realm_law = tribal_authority_3
+			prestige >= convert_to_mandala_government_tribal_value
+		}
+		trigger_else = {
+			prestige >= convert_to_mandala_government_nontribal_value
+		}
+		trigger_if = {
+			limit = { 
+				OR = {
+					government_has_flag = government_is_feudal
+					government_has_flag = government_is_clan
+				}
+			}
+			primary_title.tier <= tier_duchy
+		}
+		primary_title.tier > tier_barony
+		NOR = {	
+			government_has_flag = government_is_republic
+			government_has_flag = government_is_theocracy
+			government_has_flag = government_is_mercenary
+			government_has_flag = government_is_holy_order
+			government_has_flag = government_is_administrative
+			government_has_flag = government_is_nomadic
+			government_has_flag = government_is_herder
+			government_has_flag = government_is_celestial
+			government_has_flag = government_is_steppe_admin
+			government_has_flag = government_is_meritocratic
+		}
+		NOT = {
+			any_owned_story = {
+				OR = {
+					story_type = story_greatest_of_khans
+					story_type = story_mongol_invasion
+				}
+			}
+		}
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			NOT = { government_has_flag = government_is_tribal }
+			add = -15
+		}
+	}
+}
+
+### Assimilate to Mandala Rule ###
+assimilate_to_mandala_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_decision_mandala.dds"
+	}
+	decision_group_type = major
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { government_has_flag = government_is_mandala }
+				desc = assimilate_to_mandala_decision_faith_desc
+			}
+			triggered_desc = {
+				trigger = { faith = overlord.faith }
+				desc = assimilate_to_mandala_decision_government_desc
+			}
+			desc = assimilate_to_mandala_decision_desc
+		}
+	}
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 36
+		duchy = 36
+		kingdom = 36
+		empire = 36
+		hegemony = 36
+	}
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		overlord ?= { government_has_flag = government_is_mandala }
+		NAND = { 
+			government_has_flag = government_is_mandala
+			faith = overlord.faith
+		}
+		highest_held_title_tier > tier_barony
+	}
+
+	is_valid_showing_failures_only = {
+		custom_tooltip = {
+			text = not_changed_government_recently_tt
+			NOT = { has_variable = changed_government_recently }
+		}
+	}
+
+	effect = {
+		#GoK stops really being GoK
+		gok_government_change_story_end_effect = yes
+		#No Succession for this character pls
+		set_variable = {
+			name = not_subject_to_succession_trials
+			value = flag:assimilated_to_mandala_government
+		}
+		if = {
+			limit = { var:not_subject_to_succession_trials ?= flag:assimilated_to_mandala_government }
+			#To prevent 'unused except in loc' errors :catto:
+		}
+		#Opinion, if Overlord is AI
+		overlord = {
+			if = {
+				limit = { is_ai = yes }
+				if = {
+					limit = { good_devaraja_quality_trigger = yes }
+					add_opinion = {
+						target = root
+						modifier = assimilated_to_devaraja_rule_opinion
+						opinion = 10
+					}
+				}
+				else_if = {
+					limit = { middling_devaraja_quality_trigger = yes }
+					add_opinion = {
+						target = root
+						modifier = assimilated_to_devaraja_rule_opinion
+						opinion = 30
+					}
+				}
+				else_if = {
+					limit = { poor_devaraja_quality_trigger = yes }
+					root = {
+						progress_towards_friend_effect = {
+							REASON = friend_supported_devaraja
+							CHARACTER = overlord
+							OPINION = 0
+						}
+					}
+					add_opinion = {
+						target = root
+						modifier = assimilated_to_devaraja_rule_opinion
+						opinion = 40
+					}
+				}
+				else_if = {
+					limit = { terrible_devaraja_quality_trigger = yes }
+					root = {
+						progress_towards_friend_effect = {
+							REASON = friend_supported_devaraja
+							CHARACTER = overlord
+							OPINION = 0
+						}
+					}
+					add_opinion = {
+						target = root
+						modifier = assimilated_to_devaraja_rule_opinion
+						opinion = 60
+					}
+				}
+			}
+		}
+		#Also notify the Devaraja of their Piety gain
+		mandala_assimilation_effect = yes
+		if = {
+			limit = {
+				NOR = { 
+					faith = overlord.faith 
+					faith.religious_head ?= root
+				}
+			}
+			custom_tooltip = tgp_east_asia_decision_events.0020.close_family_pre_tt
+		}
+		#You got in early? Good for you!
+		if = {
+			limit = { 
+				overlord = { 
+					OR = { 
+						middling_devaraja_quality_trigger = yes
+						poor_devaraja_quality_trigger = yes
+						terrible_devaraja_quality_trigger = yes
+					}
+				}
+			}
+			if = {
+				limit = { 
+					overlord = { middling_devaraja_quality_trigger = yes }
+				}
+				add_character_flag = assimilation_payout_t1
+				custom_tooltip = { text = assimilation_payout_t1_tt }
+			}
+			else_if = {
+				limit = { 
+					overlord = { poor_devaraja_quality_trigger = yes }
+				}
+				add_character_flag = assimilation_payout_t2
+				custom_tooltip = { text = assimilation_payout_t2_tt }
+			}
+			else_if = {
+				limit = { 
+					overlord = { terrible_devaraja_quality_trigger = yes }
+				}
+				add_character_flag = assimilation_payout_t3
+				custom_tooltip = { text = assimilation_payout_t3_tt }
+			}
+			#Delayed payout event with its own triggers
+			set_variable = {
+				name = mandala_assimilation_devaraja
+				value = overlord
+			}
+			set_variable = {
+				name = mandala_assimilation_devaraja_piety_level
+				value = overlord.piety_level
+			}
+			trigger_event = {
+				id = tgp_east_asia_decision_events.0100
+				years = assimilation_payout_years
+			}
+		}
+		#We actually set the government and faith in the event
+		trigger_event = tgp_east_asia_decision_events.0020
+		#And vassal(s)
+		hidden_effect = {
+			every_vassal = {
+				trigger_event = {
+					id = tgp_east_asia_decision_events.0025
+					days = 3
+				}
+			}
+		}
+		set_variable = {
+			name = changed_government_recently
+			years = 5
+		}
+	}
+
+	ai_potential = {
+		this != top_overlord
+		overlord = { government_has_flag = government_is_mandala }
+		primary_title.tier > tier_barony
+		#Keep the tributaries Wanua
+		trigger_if = {
+			limit = { 
+				government_has_flag = government_is_wanua
+				is_independent_ruler = yes
+			}
+			overlord.mandala_radiance_value >= 50
+		}
+		#... but be more lenient on the Vassals
+		trigger_if = {
+			limit = { 
+				government_has_flag = government_is_wanua
+				is_independent_ruler = no
+			}
+			overlord.mandala_radiance_value >= 10
+		}
+		NOT = {
+			any_owned_story = {
+				OR = {
+					story_type = story_mongol_invasion
+					story_type = story_greatest_of_khans
+				}
+			}
+		}
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			NOT = { government_has_flag = government_is_tribal }
+			add = -50
+		}
+		modifier = {
+			overlord = { terrible_devaraja_quality_trigger = yes }
+			add = -50
+		}
+		modifier = {
+			overlord = { poor_devaraja_quality_trigger = yes }
+			add = -25
+		}
+		modifier = {
+			overlord = { middling_devaraja_quality_trigger = yes }
+			add = 25
+		}
+		modifier = {
+			overlord = { good_devaraja_quality_trigger = yes }
+			add = 25
+		}
+		modifier = {
+			overlord = { great_devaraja_quality_trigger = yes }
+			add = 50
+		}
+		modifier = {
+			overlord = { exalted_devaraja_quality_trigger = yes }
+			add = 100
+		}
+		opinion_modifier = {
+			who = root
+			opinion_target = overlord
+			multiplier = 1
+		}
+		modifier = {
+			capital_county.title_province = {
+				NOR = {
+					has_holding_type = temple_citadel_holding
+					has_holding_type = church_holding
+					has_holding_type = castle_holding
+				}
+			}
+			factor = 0
+		}
+	}
+}
+
+### Adopt Clan Ways ###
+mandala_adopt_clan_government_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_realm.dds"
+	}
+	decision_group_type = major
+	desc = mandala_adopt_clan_government_decision_desc
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 36
+		duchy = 36
+		kingdom = 36
+		empire = 36
+		hegemony = 36
+	}
+
+	is_shown = {
+		has_tgp_dlc_trigger = yes
+		government_has_flag = government_is_mandala
+		is_landed = yes
+		faith.religion = religion:islam_religion
+		highest_held_title_tier > tier_barony
+	}
+
+	is_valid_showing_failures_only = {
+		custom_tooltip = {
+			text = not_changed_government_recently_tt
+			NOT = { has_variable = changed_government_recently }
+		}
+	}
+
+	cost = {
+		piety = {
+			value = convert_to_mandala_government_nontribal_value
+		}
+	}
+
+	effect = {
+		mandala_adopt_clan_government_effect = yes
+	}
+
+	ai_potential = {
+		government_has_flag = government_is_mandala
+		faith.religion = religion:islam_religion
+		piety >= convert_to_mandala_government_nontribal_value
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			OR = {
+				piety_level >= high_piety_level
+				capital_province = {
+					OR = {
+						has_building_with_flag = third_tier_mandala_capital_building
+						has_building_with_flag = fourth_tier_mandala_capital_building
+						has_building_with_flag = final_tier_mandala_capital_building
+					}
+				}
+			}
+			factor = 0
+		}
+	}
+}
+
+### Perform a Ritual Sacrifice ###
+visit_local_shrine_decision = {
+	picture = {
+		trigger = {
+			government_is_japanese_trigger = yes
+		}
+		reference = "gfx/interface/illustrations/holding_types/tgp_shinto_temple.dds"
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/tgp_crossroad_inn_asia.dds"
+	}
+	desc = visit_local_shrine_decision_desc
+	selection_tooltip = sacrifice_to_heaven
+	sort_order = 110
+
+	cooldown = { years = 5 }
+	
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 36
+		duchy = 36
+		kingdom = 36
+		empire = 36
+		hegemony = 36
+	}
+
+	is_shown = {
+		exists = capital_province
+		has_tgp_dlc_trigger = yes
+		highest_held_title_tier >= tier_county
+		faith = { has_doctrine = doctrine_pilgrimage_local_rites }
+		trigger_if = { # Allow a Capital exam to be hosted first.
+			limit = {
+				is_ai = yes
+				highest_held_title_tier = tier_hegemony
+			}
+			years_from_game_start >= 10
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		location = capital_province
+	}
+
+	effect = {
+		custom_tooltip = sacrifice_to_heaven
+		trigger_event = local_rites.1
+	}
+	
+	ai_potential = {
+		is_at_war = no
+		ai_greed < medium_positive_ai_value
+	}
+
+	ai_will_do = {
+		base = 20
+		modifier = {
+			short_term_gold < minor_gold_value
+			factor = 0
+		}
+	}
+}
+
+#One of your subjects has a Mandala Capital and you don't? Well, seize it!
+### Seize Mandala Temple Complex ###
+seize_mandala_capital_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/tgp_decision_mandala.dds"
+	}
+	desc = seize_mandala_capital_decision_desc
+	selection_tooltip = seize_mandala_capital_decision_tooltip
+	decision_group_type = major
+
+	ai_check_interval = 0
+
+	is_shown = {
+		government_has_flag = government_is_mandala
+		has_mandala_capital_trigger = no
+		any_subject = {
+			is_ai = yes
+			any_sub_realm_barony = {
+				kingdom = root.capital_county.kingdom
+				title_province = {
+					has_building_with_flag = mandala_capital_building
+					has_ruined_great_building = no
+				}
+			}
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_imprisoned = no
+		NOT = { has_trait = incapable }
+	}
+
+	effect = {
+		random_subject = {
+			limit = {
+				is_ai = yes
+				any_sub_realm_barony = {
+					kingdom = root.capital_county.kingdom
+					title_province = {
+						has_building_with_flag = mandala_capital_building
+						has_ruined_great_building = no
+					}
+				}
+			}
+			random_sub_realm_barony = {
+				limit = {
+					kingdom = root.capital_county.kingdom
+					title_province = {
+						has_building_with_flag = mandala_capital_building
+						has_ruined_great_building = no
+					}
+				}
+				holder = { save_scope_as = previous_holder }
+				county = { save_scope_as = target_county }
+			}
+		}
+		create_title_and_vassal_change = {
+			type = returned
+			save_scope_as = change
+			add_claim_on_loss = yes
+		}
+		scope:target_county = {
+			change_title_holder = {
+				holder = root
+				change = scope:change
+			}
+		}
+		resolve_title_and_vassal_change = scope:change
+		set_realm_capital = scope:target_county
+		scope:previous_holder = {
+			progress_towards_rival_effect = {
+				REASON = rival_seized_mandala_complex
+				CHARACTER = root
+				OPINION = -50
+			}
+		}
+	}
+	
+	ai_potential = {
+		always = no
+	}
+
+	ai_will_do = {
+		base = 0
+	}
+}
+
+create_bunga_mas_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/hindu_ruler.dds"
+	}
+	cooldown = { days = standard_commission_artifact_cooldown_time }
+	sort_order = 151
+	
+	ai_check_interval = 0 #Not for AI
+
+	is_shown = {
+		#Tease Mandala rulers
+		trigger_if = {
+			limit = { is_tributary = no }
+			government_has_flag = government_is_mandala
+		}
+		#... unless you're actually the tributary of a Mandala
+		trigger_else = {
+			is_tributary = yes
+			suzerain = { government_has_flag = government_is_mandala }
+		}
+		highest_held_title_tier >= tier_county
+		exists = capital_province
+	}
+	
+	is_valid_showing_failures_only = {
+		employs_court_position = antiquarian_court_position
+		is_tributary = yes
+	}
+
+	cost = {
+		gold = {
+			value = create_bunga_mas_cost
+			multiply = primary_title.tier
+		}
+	}
+
+
+	effect = {
+		custom_tooltip = create_bunga_mas_decision_effect
+
+		if = {
+			limit = {
+				any_court_position_holder = {
+					type = antiquarian_court_position
+				}
+			}
+			random_court_position_holder = {
+				type = antiquarian_court_position
+				save_scope_as = antiquarian
+			}
+		}
+
+		if = {
+			limit = {
+				any_pool_character = {
+					province = root.capital_province
+					has_no_particular_noble_roots_trigger = yes
+					is_available_healthy_ai_adult = yes
+					NOR = {
+						exists = inspiration
+						has_trait = peasant_leader
+					}
+				}
+			}
+			random_pool_character = {
+				province = root.capital_province
+				limit = {
+					has_no_particular_noble_roots_trigger = yes
+					is_available_healthy_ai_adult = yes
+					NOR = {
+						exists = inspiration
+						has_trait = peasant_leader
+					}
+				}
+				save_scope_as = local_artisan
+				hidden_effect = {
+					add_character_modifier = local_artisan_modifier
+				}
+			}
+		}
+		else = {
+			# Artisan Generation
+			hidden_effect = {
+				create_character = {
+					template = local_artisan_template
+					location = root.capital_province
+					gender_female_chance = root_faith_dominant_gender_adjusted_female_chance
+					save_scope_as = local_artisan
+				}
+				scope:local_artisan = {
+					hidden_effect = {
+						add_character_modifier = local_artisan_modifier
+					}
+				}
+			}
+		}
+
+		hidden_effect = {
+			if = {
+				# Conditional exists to avoid false-positives during tooltip generation, but 'local_artisan' should always exist on execution!
+				limit = { exists = scope:local_artisan }
+				root = { add_courtier = scope:local_artisan	}
+				scope:local_artisan = {
+					add_character_flag = local_artisan
+				}
+			}
+		}
+
+		#Mandala Creation Aspect
+		if = {
+			limit = { 
+				government_has_flag = government_is_mandala
+				house = { has_house_aspiration_parameter = aspect_of_creation }
+				is_house_head = yes
+			}
+			increment_variable_effect = {
+				VAR = num_commissioned_artifacts
+				VAL = 1
+			}
+		}
+
+		trigger_event = {
+			id = tgp_east_asia_decision_events.0300
+			delayed = yes
+		}
+
+	}
+
+	ai_potential = {
+		always = no
+	}
+
+	ai_will_do = {
+		base = 0
+	}
+}

--- a/common/decisions/dlc_decisions/tgp/tgp_east_asia_decisions.txt
+++ b/common/decisions/dlc_decisions/tgp/tgp_east_asia_decisions.txt
@@ -282,6 +282,8 @@ assimilate_to_mandala_decision = {
 			text = not_changed_government_recently_tt
 			NOT = { has_variable = changed_government_recently }
 		}
+		#Unop Japanese governments (ritsuryo/soryo) must not assimilate to mandala, mirroring convert_to_mandala_government_decision
+		government_is_japanese_trigger = no
 	}
 
 	effect = {


### PR DESCRIPTION
Fixes #561

**fixer:** A Japanese admin (ritsuryo) realm tributarized by a mandala overlord could take `assimilate_to_mandala_decision`, converting to mandala; later faction pressure then degraded it to feudal/soryo, matching the reported AI-Japan degeneration.

The designers already protect Japanese governments from becoming mandala on the independent-ruler path: `convert_to_mandala_government_decision`'s `is_valid_showing_failures_only` contains `government_is_japanese_trigger = no`. The tributary path `assimilate_to_mandala_decision` was missing that same guard — the asymmetry is the bug.

Fix: mirror the guard onto `assimilate_to_mandala_decision` so ritsuryo/soryo tributaries can no longer assimilate to mandala. The other mandala entry points don't apply (`mandala_adopt_clan_government_decision` converts *from* mandala). Vanilla file added unmodified in a separate commit.