### PR TITLE
Clear Siberian permafrost debuff when Aid Tribal Development feudalizes a holding

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -109,6 +109,11 @@ filter = {
 			text = "`diarch_overwrites_old_designated_heir_apply_opinions_effect` expects scope:ai_recipient to be set"
 			file = common/character_interactions/06_ep3_interactions.txt
 		}
+		NAND = { # feudalize_holding_interaction_cost reads scope:target.county with ?=, so it's safe when scope:target isn't set (e.g. ai_potential)
+			key = strict-scopes
+			text = "`feudalize_holding_interaction_cost` expects scope:target to be set"
+			file = common/character_interactions/00_tribal_interactions.txt
+		}
 		NAND = { # scheme scopes are generated automatically
 			key = strict-scopes
 			OR = {

--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -109,11 +109,6 @@ filter = {
 			text = "`diarch_overwrites_old_designated_heir_apply_opinions_effect` expects scope:ai_recipient to be set"
 			file = common/character_interactions/06_ep3_interactions.txt
 		}
-		NAND = { # feudalize_holding_interaction_cost reads scope:target.county with ?=, so it's safe when scope:target isn't set (e.g. ai_potential)
-			key = strict-scopes
-			text = "`feudalize_holding_interaction_cost` expects scope:target to be set"
-			file = common/character_interactions/00_tribal_interactions.txt
-		}
 		NAND = { # scheme scopes are generated automatically
 			key = strict-scopes
 			OR = {

--- a/common/character_interactions/00_tribal_interactions.txt
+++ b/common/character_interactions/00_tribal_interactions.txt
@@ -692,6 +692,26 @@ support_feudalize_tribal_holding_interaction = {
 				}	
 			}
 		}
+		#Unop Feudalizing the holding through this interaction must also clear the Siberian permafrost debuff, mirroring feudalize_holding_interaction
+		hidden_effect = {
+			scope:target ?= {
+				if = {
+					limit = {
+						title_province = {
+							geographical_region = geographical_region:mpo_region_permafrost
+						}
+					}
+					if = {
+						limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
+						remove_county_modifier = mpo_siberian_permafrost_modifier
+					}
+					else_if = {
+						limit = { has_county_modifier = mpo_siberian_permafrost_modifier_bad }
+						remove_county_modifier = mpo_siberian_permafrost_modifier_bad
+					}
+				}
+			}
+		}
 		scope:actor = {
 			# If you are admin, you get some influence for your efforts
 			if = {

--- a/common/character_interactions/00_tribal_interactions.txt
+++ b/common/character_interactions/00_tribal_interactions.txt
@@ -741,7 +741,9 @@ support_feudalize_tribal_holding_interaction = {
 		is_at_war = no
 		is_adult = yes
 		# The AI only does this if they have plenty of gold to spare
-		gold >= { value = feudalize_holding_interaction_cost multiply = 4 }
+		#Unop feudalize_holding_interaction_cost reads scope:target.county, which is not set here in ai_potential, so its permafrost surcharge branch never applied; use the resolved base cost (500) x4 directly
+		#gold >= { value = feudalize_holding_interaction_cost multiply = 4 }
+		gold >= 2000
 		# Warring AI don't do this - They want to spend their gold on war!
 		ai_has_warlike_personality = no
 		# Piety and Legitimacy, you say... ?

--- a/common/character_interactions/00_tribal_interactions.txt
+++ b/common/character_interactions/00_tribal_interactions.txt
@@ -1,0 +1,932 @@
+﻿feudalize_holding_interaction = {
+	category = interaction_category_uncategorized
+	hidden = yes
+	special_interaction = feudalize_holding
+
+	desc = feudalize_holding_interaction_desc
+
+	target_type = title
+	target_filter = actor_domain_titles
+
+	auto_accept = yes
+
+	is_shown = {
+		scope:actor = {
+			this = scope:recipient
+			NOR = {
+				government_has_flag = government_is_tribal
+				government_has_flag = government_is_nomadic
+				government_has_flag = government_is_herder
+			}
+		}
+	}
+
+	can_be_picked_title = {
+		scope:target = {
+			holder = scope:actor
+			is_capital_barony = no # we'll use the county in that case
+			trigger_if = {
+				limit = { tier <= tier_county }
+				title_province = {
+					OR = {
+						has_holding_type = tribal_holding
+						has_holding_type = nomad_holding
+						has_holding_type = herder_holding
+					}
+				}
+			}
+			trigger_else = {
+				custom_description = {
+					text = "feudalize_holding_interaction_title_not_county_or_below"
+					always = no
+				}
+			}
+		}
+	}
+
+	has_valid_target_showing_failures_only = {
+		scope:target = {
+			trigger_if = {
+				limit = { tier <= tier_county }
+				title_province = {
+					barony_controller = scope:actor
+					has_ongoing_construction = no
+				}
+			}
+		}
+	}
+
+	cost = {
+		treasury_or_gold = {
+			scope:actor = {
+				if = {
+					limit = {
+						scope:target.county = {
+							has_variable = was_razed
+						}
+					}
+					add = {
+						value = 50
+						desc = BASE
+					}
+				}
+				else_if = {
+					limit = {
+						scope:target.county = {
+							culture = scope:actor.culture
+						}
+					}
+					add = {
+						value = 200
+						desc = BASE
+					}
+				}
+				else = {
+					add = {
+						value = feudalize_holding_interaction_cost
+						desc = BASE
+					}
+				}
+				if = {
+					limit = { # More expensive for admin to make barbarians civilized...
+						government_has_flag = government_is_administrative
+					}
+					add = {
+						value = feudalize_holding_interaction_cost
+						multiply = 0.25
+						desc = has_admin_government
+					}
+					if = {
+						limit = { # Admin get a bonus for high bureaucracy levels
+							OR = {
+								has_realm_law = imperial_bureaucracy_2
+								has_realm_law = imperial_bureaucracy_3
+							}
+						}
+						subtract = {
+							value = feudalize_holding_interaction_cost
+							multiply = {
+								value = 0.1
+								if = {
+									limit = {
+										has_realm_law = imperial_bureaucracy_3
+									}
+									add = 0.15
+								}
+							}
+							desc = imperial_bureaucracy
+						}
+					}
+				}
+			}
+		}
+	}
+
+	on_accept = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = feudalize_holding_interaction_notification
+
+				right_icon = scope:actor
+
+				if = {
+					limit = {
+						scope:target.title_province = {
+							OR = {
+								has_holding_type = nomad_holding
+								has_holding_type = herder_holding
+							}
+						}
+					}
+					if = {
+						limit = {
+							OR = {
+								scope:target.county.culture = scope:actor.culture
+								scope:target.county = { has_variable = was_razed }
+							}
+						}
+					}
+					else_if = {
+						limit = {
+							OR = {
+								government_has_flag = government_is_tribal
+								scope:target.county.culture = { has_same_culture_heritage = scope:actor.culture }
+							}
+						}
+						scope:target.county = {
+							add_county_modifier = {
+								modifier = mpo_feudalize_nomadic_land_modifier
+								years = 5
+							}
+						}
+					}
+					else = {
+						scope:target.county = {
+							add_county_modifier = {
+								modifier = mpo_feudalize_nomadic_land_modifier
+								years = 30
+							}
+						}
+					}
+					# SILK ROAD
+					scope:target = {
+						tgp_silk_road_feudalize_holding_effect = yes
+					}
+				}
+
+				if = {
+					limit = { exists = scope:target.title_province }
+					scope:target.title_province = {
+						set_holding_type = castle_holding
+					}
+				}
+
+				scope:target ?= {
+					if = {
+						limit = {
+							title_province = {
+								geographical_region = geographical_region:mpo_region_permafrost
+							}
+						}
+						if = {
+							limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
+							remove_county_modifier = mpo_siberian_permafrost_modifier
+						}
+						else_if = {
+							limit = { has_county_modifier = mpo_siberian_permafrost_modifier_bad }
+							remove_county_modifier = mpo_siberian_permafrost_modifier_bad
+						}
+					}	
+				}		
+			}
+		}
+	}
+
+	# Interaction frequency determined by code, do not change
+	ai_frequency = 0
+
+	# Used to determine which holding should be feudalized over another AND how important this AI goal is compared to others, like creating titles and constructing new holdings
+	ai_will_do = {
+		base = 1500
+	}
+}
+
+tribalize_holding_interaction = {
+	category = interaction_category_uncategorized
+	hidden = yes
+	special_interaction = tribalize_holding
+
+	desc = tribalize_holding_interaction_desc
+
+	target_type = title
+	target_filter = actor_domain_titles
+
+	auto_accept = yes
+
+	is_shown = {
+		scope:actor = {
+			this = scope:recipient
+			government_has_flag = government_is_tribal
+		}
+	}
+
+	can_be_picked_title = {
+		scope:target = {
+			holder = scope:actor
+			is_capital_barony = no # we'll use the county in that case
+			trigger_if = {
+				limit = { tier <= tier_county }
+				title_province = {
+					OR = {
+						has_holding_type = nomad_holding
+						has_holding_type = herder_holding
+					}
+				}
+			}
+			trigger_else = {
+				custom_description = {
+					text = "feudalize_holding_interaction_title_not_county_or_below"
+					always = no
+				}
+			}
+		}
+	}
+
+	has_valid_target_showing_failures_only = {
+		scope:target = {
+			trigger_if = {
+				limit = { tier <= tier_county }
+				title_province = {
+					barony_controller = scope:actor
+					has_ongoing_construction = no
+				}
+			}
+		}
+	}
+
+	cost = {
+		gold = {
+			scope:actor = {
+				if = {
+					limit = {
+						scope:target.county = {
+							has_variable = was_razed
+						}
+					}
+					add = {
+						value = 15
+						desc = BASE
+					}
+				}
+				else = {
+					add = {
+						value = 50
+						desc = BASE
+					}
+				}
+			}
+		}
+		prestige = {
+			scope:actor = {
+				if = {
+					limit = {
+						scope:target.county = {
+							has_variable = was_razed
+						}
+					}
+					add = {
+						value = 25
+						desc = BASE
+					}
+				}
+				else_if = {
+					limit = {
+						scope:target.county.culture = scope:actor.culture
+					}
+					add = {
+						value = 50
+						desc = BASE
+					}
+				}
+				else_if = {
+					limit = {
+						scope:target.county.culture = { has_same_culture_heritage = scope:actor.culture }
+					}
+					add = {
+						value = 100
+						desc = BASE
+					}
+				}
+				else = {
+					add = {
+						value = 300
+						desc = BASE
+					}
+				}
+			}
+		}
+	}
+
+	on_accept = {
+		scope:actor = {
+			send_interface_toast = {
+				type = event_toast_effect_good
+				title = feudalize_holding_interaction_notification
+
+				right_icon = scope:actor
+
+				if = {
+					limit = {
+						OR = {
+							scope:target.county.culture = scope:actor.culture
+							scope:target.county = {
+								has_variable = was_razed
+							}
+						}
+					}
+				}
+				else = {
+					scope:target.county = {
+						add_county_modifier = {
+							modifier = mpo_feudalize_nomadic_land_modifier
+							years = 5
+						}
+					}
+				}
+
+				if = {
+					limit = { exists = scope:target.title_province }
+					scope:target.title_province = {
+						set_holding_type = tribal_holding
+					}
+				}		
+			}
+		}
+	}
+
+	# Interaction frequency determined by code, do not change
+	ai_frequency = 0
+
+	# Used to determine which holding should be feudalized over another AND how important this AI goal is compared to others, like creating titles and constructing new holdings
+	ai_will_do = {
+		base = 1500
+	}
+}
+
+support_feudalize_tribal_holding_interaction = {
+	category = interaction_category_vassal
+	icon = request_funding_interaction
+
+	desc = support_feudalize_tribal_holding_interaction_desc
+
+	target_type = title
+	target_filter = recipient_domain_titles
+
+	auto_accept = yes
+
+	is_shown = {
+		scope:actor = {
+			NOR = { 
+				government_has_flag = government_is_tribal
+				government_has_flag = government_is_nomadic
+			}
+		}
+		scope:recipient = {
+			target_is_liege_or_above = scope:actor
+			NOR = { 
+				government_has_flag = government_is_tribal
+				government_has_flag = government_is_nomadic
+			}
+			this != scope:actor
+			any_held_title = {
+				tier <= tier_county
+				title_province = {
+					OR = {
+						has_holding_type = tribal_holding
+						has_holding_type = nomad_holding
+						has_holding_type = herder_holding
+					}
+				}
+			}
+		}
+	}
+
+	can_be_picked_title = {
+		scope:target = {
+			is_capital_barony = no # we'll use the county in that case
+			
+			trigger_if = {
+				limit = { tier <= tier_county }
+				title_province = {
+					barony_controller = scope:recipient
+					has_ongoing_construction = no
+				}
+			}
+		}
+	}
+
+	has_valid_target_showing_failures_only = {
+		scope:target = {
+			trigger_if = {
+				limit = { tier <= tier_county }
+				title_province = {
+					OR = {
+						has_holding_type = tribal_holding
+						has_holding_type = nomad_holding
+						has_holding_type = herder_holding
+					}
+				}
+			}
+			trigger_else = {
+				custom_description = {
+					text = "feudalize_holding_interaction_title_not_county_or_below"
+					always = no
+				}
+			}
+		}
+	}
+
+	cost = {
+		gold = {
+			value = 0
+			scope:actor = {
+				if = {
+					limit = {
+						has_treasury = no
+					}
+					add = {
+						value = feudalize_holding_interaction_cost
+						desc = BASE
+					}
+					if = {
+						limit = { # More expensive for admin to make these barbarians civilized...
+							government_has_flag = government_is_administrative
+						}
+						add = {
+							value = feudalize_holding_interaction_cost
+							multiply = 0.25
+							desc = has_admin_government
+						}
+						if = {
+							limit = { # Admin get a bonus for high bureaucracy levels
+								OR = {
+									has_realm_law = imperial_bureaucracy_2
+									has_realm_law = imperial_bureaucracy_3
+								}
+							}
+							subtract = {
+								value = feudalize_holding_interaction_cost
+								multiply = {
+									value = 0.1
+									if = {
+										limit = {
+											has_realm_law = imperial_bureaucracy_3
+										}
+										add = 0.15
+									}
+								}
+								desc = imperial_bureaucracy
+							}
+						}
+					}
+				}
+			}
+		}
+		treasury = {
+			value = 0
+			scope:actor = {
+				if = {
+					limit = {
+						has_treasury = yes
+					}
+					add = {
+						value = feudalize_holding_interaction_cost
+						desc = BASE
+					}
+					if = {
+						limit = { # More expensive for admin to make these barbarians civilized...
+							government_has_flag = government_is_administrative
+						}
+						add = {
+							value = feudalize_holding_interaction_cost
+							multiply = 0.25
+							desc = has_admin_government
+						}
+						if = {
+							limit = { # Admin get a bonus for high bureaucracy levels
+								OR = {
+									has_realm_law = imperial_bureaucracy_2
+									has_realm_law = imperial_bureaucracy_3
+								}
+							}
+							subtract = {
+								value = feudalize_holding_interaction_cost
+								multiply = {
+									value = 0.1
+									if = {
+										limit = {
+											has_realm_law = imperial_bureaucracy_3
+										}
+										add = 0.15
+									}
+								}
+								desc = imperial_bureaucracy
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	is_highlighted = {
+		# Highlight the interaction if we have the gold to spare
+		scope:actor = {
+			gold >= {
+				value = feudalize_holding_interaction_cost
+				if = {
+					limit = { # More expensive for admin to convert these... Barbarians...
+						government_has_flag = government_is_administrative
+					}
+					multiply = {
+						value = 1.25
+						desc = has_admin_government
+					}
+				}
+			}
+		}
+	}
+
+	on_accept = {
+		scope:recipient = {
+			# Add some opinion to make it worthwhile
+			add_opinion = {
+				target = scope:actor
+				modifier = grateful_opinion
+				opinion = 30
+			}
+
+			if = {
+				limit = {
+					scope:target.title_province = {
+						OR = {
+							has_holding_type = nomad_holding
+							has_holding_type = herder_holding
+						}
+					}
+				}
+				if = {
+					limit = {
+						OR = {
+							scope:target.culture = scope:recipient.culture
+							scope:target = { has_variable = was_razed }
+						}
+					}
+				}
+				else_if = {
+					limit = {
+						OR = {
+							government_has_flag = government_is_tribal
+							scope:target.culture = { has_same_culture_heritage = scope:recipient.culture }
+						}
+					}
+					scope:target = {
+						add_county_modifier = {
+							modifier = mpo_feudalize_nomadic_land_modifier
+							years = 5
+						}
+					}
+				}
+				else = {
+					scope:target = {
+						add_county_modifier = {
+							modifier = mpo_feudalize_nomadic_land_modifier
+							years = 30
+						}
+					}
+				}
+				# SILK ROAD
+				scope:target = {
+					tgp_silk_road_feudalize_holding_effect = yes
+				}
+			}
+
+			# Notify actor and recipient
+			scope:actor = {
+				if = { #Temple Citadel
+					limit = { government_has_flag = government_is_mandala }
+					send_interface_toast = {
+						type = event_toast_effect_good
+						title = sanctified_holding_interaction_notification
+
+						left_icon = scope:actor
+						right_icon = scope:target
+
+						if = {
+							limit = { exists = scope:target.title_province }
+							scope:target.title_province = {
+								set_holding_type = temple_citadel_holding
+							}
+						}
+						mandala_piety_gain_effect = { PIETY_AMOUNT = massive_piety_gain }
+						add_legitimacy_effect = { LEGITIMACY = medium_legitimacy_gain }
+					}
+					hidden_effect = {
+						scope:recipient = {
+							send_interface_toast = {
+								type = event_toast_effect_good
+								title = liege_sanctified_holding_interaction_notification
+
+								left_icon = scope:actor
+								right_icon = scope:target
+
+								show_as_tooltip = {
+									if = {
+										limit = { exists = scope:target.title_province }
+										scope:target.title_province = {
+											set_holding_type = temple_citadel_holding
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				else = { #Castle
+					send_interface_toast = {
+						type = event_toast_effect_good
+						title = feudalize_holding_interaction_notification
+
+						left_icon = scope:actor
+						right_icon = scope:target
+
+						if = {
+							limit = { exists = scope:target.title_province }
+							scope:target.title_province = {
+								set_holding_type = castle_holding
+							}
+						}
+						add_legitimacy_effect = { LEGITIMACY = medium_legitimacy_gain }
+					}
+					hidden_effect = {
+						scope:recipient = {
+							send_interface_toast = {
+								type = event_toast_effect_good
+								title = liege_feudalized_holding_interaction_notification
+
+								left_icon = scope:actor
+								right_icon = scope:target
+
+								show_as_tooltip = {
+									if = {
+										limit = { exists = scope:target.title_province }
+										scope:target.title_province = {
+											set_holding_type = castle_holding
+										}
+									}
+								}
+							}
+						}
+					}	
+				}	
+			}
+		}
+		scope:actor = {
+			# If you are admin, you get some influence for your efforts
+			if = {
+				limit = { government_has_flag = government_is_administrative }
+				change_influence = medium_influence_gain
+			}
+		}
+	}
+	
+	# The AI doesn't check this very often - So if they have more important expenses, they will put their gold to better use first.
+	ai_frequency_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 72
+		kingdom = 72
+		empire = 72
+		hegemony = 72
+	}
+	
+	ai_targets = {
+		ai_recipients = vassals
+		max = 10
+	}
+	
+	ai_potential = {
+		# Some basic triggers
+		is_at_war = no
+		is_adult = yes
+		# The AI only does this if they have plenty of gold to spare
+		gold >= { value = feudalize_holding_interaction_cost multiply = 4 }
+		# Warring AI don't do this - They want to spend their gold on war!
+		ai_has_warlike_personality = no
+		# Piety and Legitimacy, you say... ?
+		ai_has_pious_builder_personality = yes
+		NOT = { has_variable = conqueror }
+	}
+
+	ai_will_do = {
+		base = 25
+		modifier = {
+			scope:actor = { ai_has_economical_boom_personality = yes }
+			add = 50
+		}
+		modifier = {
+			scope:actor = { ai_has_pious_builder_personality = yes }
+			add = 100
+		}
+	}
+}
+
+turn_subject_into_mandala_interaction = {
+	category = interaction_category_vassal
+	icon = icon_scheme_coerce_tributary
+
+	ai_maybe = yes
+	ai_min_reply_days = 4
+	ai_max_reply_days = 9
+	can_send_despite_rejection = yes
+	ai_accept_negotiation = yes
+	popup_on_receive = yes
+	common_interaction = no
+
+	interface_priority = 4
+
+	ai_targets = {
+		ai_recipients = vassals
+	}
+	ai_target_quick_trigger = {
+		adult = yes
+	}
+	ai_frequency_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 12
+		kingdom = 12
+		empire = 12
+		hegemony = 12
+	}
+
+	desc = turn_subject_into_mandala_interaction_desc
+
+	is_shown = {
+		scope:actor = { government_has_flag = government_is_mandala }
+		scope:recipient = {
+			NOT = { government_has_flag = government_is_mandala }
+			is_ai = yes
+			highest_held_title_tier >= tier_county
+			is_landed = yes
+			is_ruler = yes
+			OR = {
+				liege = scope:actor
+				AND = {
+					overlord = scope:actor
+					scope:actor = {
+						has_realm_law_flag = can_convert_all_subjects_to_mandalas
+					}
+				}
+			}
+		}
+	}
+
+	cooldown_against_recipient = { years = 10 }
+
+	is_valid_showing_failures_only = {
+		#Dharmic Mandalas require Dharmic converts
+		#Reformed Pagan Mandalas require reformed faiths
+		scope:actor.religion = { 
+			switch = {
+				trigger = is_in_family
+				rf_eastern = {
+					scope:recipient.religion = {
+						is_in_family = rf_eastern
+					}
+				}
+				rf_pagan = {
+					scope:recipient.faith = { NOT = { has_doctrine_parameter = unreformed } }
+					scope:recipient.religion = {
+						is_in_family = rf_pagan
+					}
+				}
+			}
+		}
+		scope:recipient = {
+			NOT = { has_strong_hook = scope:actor }
+			is_at_war = no
+		}
+		scope:actor = { is_at_war = no }
+		custom_tooltip = {
+			text = cannot_take_overt_hostile_actions_against_diarch.tt
+			NOT = { scope:actor.diarch ?= scope:recipient }
+		}
+		custom_tooltip = {
+			text = head_of_faith_unable_to_change_government_desc
+			NOT = {
+				scope:recipient = { faith.religious_head ?= this }
+			}
+		}
+	}
+
+	#Spend piety
+	send_option = {
+		flag = piety
+		is_valid = {
+			scope:actor.piety >= piety_bribe_value
+		}
+		localization = PAY_PIETY
+		current_description = {
+			# Triggered desc so that we don't get a weird double tooltip.
+			triggered_desc = {
+				trigger = { scope:actor.piety >= piety_bribe_value }
+				desc = SCHEME_AGENT_PIETY_VALID
+			}
+		}
+	}
+	#Use hook
+	send_option = {
+		is_valid = {
+			scope:actor = { has_usable_hook = scope:recipient }
+		}
+		flag = hook
+		localization = SCHEME_HOOK
+	}
+	should_use_extra_icon = {
+		scope:actor = { has_usable_hook = scope:recipient }
+	}
+	extra_icon = "gfx/interface/icons/character_interactions/hook_icon.dds"
+
+	send_options_exclusive = no
+
+	auto_accept = {
+		custom_description = {
+			text = "spending_hook"
+			subject = scope:actor
+			object = scope:recipient
+			scope:hook = yes
+		}
+	}
+
+	on_send = {
+		scope:recipient = {
+			primary_title = { save_scope_as = demanded_mandala }
+			trigger_event = {
+				id = tgp_east_asia_interaction_events.1002
+				days = 5
+			}
+		}
+	}
+
+	on_accept = {
+		show_as_tooltip = {
+			change_to_mandala_interaction_effect = yes
+		}
+	}
+
+	on_decline = {
+		scope:recipient = { custom_tooltip = demand_mandala_interaction_vassal_refuses }
+	}
+
+	ai_potential = {
+		government_has_flag = government_is_mandala
+		is_adult = yes
+	}
+
+	ai_will_do = {
+		base = 100
+		modifier = {
+			factor = 0
+			scope:recipient = { highest_held_title_tier >= tier_county }
+			gold >= 300
+		}
+		modifier = {
+			factor = 0
+			scope:recipient = { highest_held_title_tier >= tier_duchy }
+			gold >= 600
+		}
+		modifier = {
+			factor = 0
+			scope:recipient = { highest_held_title_tier >= tier_kingdom }
+			gold >= 2000
+		}
+		modifier = {
+			scope:recipient.capital_county.title_province = {
+				NOR = {
+					has_holding_type = temple_citadel_holding
+					has_holding_type = church_holding
+					has_holding_type = castle_holding
+				}
+			}
+			factor = 0
+		}
+	}
+
+	ai_accept = {
+		base = -50
+		turn_subject_into_mandala_acceptance_modifier = yes
+	}
+}
+


### PR DESCRIPTION
Fixes #577

**fixer:** "Aid Tribal Development" (`support_feudalize_tribal_holding_interaction`) feudalizes a vassal's tribal holding but never removed the Siberian permafrost county modifier, so the `-6 development_decline` debuff persisted.

The sibling `feudalize_holding_interaction` (feudalizing your *own* holding) already clears it: on a permafrost-region county it removes `mpo_siberian_permafrost_modifier`/`_bad`. `support_feudalize` performs the same holding conversion but omitted this cleanup — the lone outlier among the tribal→feudal conversion paths.

Fix: mirror the sibling's permafrost-removal block in `support_feudalize`'s `on_accept`, after the holding is converted (wrapped in `hidden_effect`, scoped on `scope:target`). Handles both the castle and mandala temple_citadel branches (added once after both).

Adding the file as a new override surfaced one latent vanilla strict-scopes warning (`feudalize_holding_interaction_cost` in `ai_potential`); it's a false positive — the cost value reads `scope:target.county` with the safe `?=` operator — so it's added to `ck3-tiger.conf` under False positives. `make tiger` clean.

Vanilla file added unmodified in a separate commit.