### PR TITLE
Add persistent cooldown to adventurer Training Grounds

### DIFF
--- a/events/dlc/ep3/ep3_laamp_decision_events.txt
+++ b/events/dlc/ep3/ep3_laamp_decision_events.txt
@@ -16391,8 +16391,14 @@ ep3_laamp_decision_event.1050 = {
 				}
 			}
 			#Been there, done that
+			#Unop Also block on the persistent cooldown variable, so leaving and re-entering the settlement (which drops the saved scope) does not reset the training cooldown
 			trigger_else_if = {
-				limit = { scope:laamp_decision_has_trained ?= flag:yes }
+				limit = {
+					OR = {
+						scope:laamp_decision_has_trained ?= flag:yes
+						has_variable = 1051_has_trained_recently
+					}
+				}
 				custom_tooltip = {
 					text = ep3_laamp_decision_event.1050.a.cooldown.tt
 					always = no
@@ -16739,6 +16745,11 @@ scripted_effect 1051_finished_training_effect = {
 	save_scope_value_as = {
 		name = laamp_decision_has_trained
 		value = flag:yes
+	}
+	#Unop Persistent cooldown so training can't be repeated by leaving and re-entering the settlement, mirroring the storyteller's 1031_has_storied_recently
+	set_variable = {
+		name = 1051_has_trained_recently
+		days = visit_settlement_minimum_cooldown_days
 	}
 	#Go back to castle grounds
 	hidden_effect = { 1051_return_to_castle_effect = yes }


### PR DESCRIPTION
Fixes #580

**fixer:** As an adventurer, the Training Grounds (castle) "train prowess" action only gated re-training on the transient `laamp_decision_has_trained` saved scope, which is dropped when the adventurer leaves the settlement — so leaving and re-entering the same holding reset the cooldown, letting you farm prowess/skill for gold.

Fix mirrors the storyteller's existing pattern (`1031_has_storied_recently`): `1051_finished_training_effect` (the shared chokepoint for both the paid-training and spar-with-partner grant paths) now also sets a persistent `1051_has_trained_recently` variable on the adventurer for `visit_settlement_minimum_cooldown_days` (90d), and the `1050.a` option's cooldown branch now also blocks while that variable is present. The Master-of-Arms recruit path (`flag:no`, no prowess granted) is unaffected.

Storyteller was reported too but is already variable-gated (`1031_has_storied_recently`) and not touched.