### PR TITLE
Step China army command law down instead of resetting on Tension

### DIFF
--- a/common/situation/situations/tgp_dynastic_cycle.txt
+++ b/common/situation/situations/tgp_dynastic_cycle.txt
@@ -694,6 +694,20 @@ dynastic_cycle = {
 						}
 						add_realm_law = celestial_bureaucracy_2
 					}
+					#Unop Step the army command law down one level instead of letting it revert to the group default (Autonomous), mirroring the bureaucracy step-down above
+					if = {
+						limit = {
+							has_realm_law = celestial_army_liege_law_3
+						}
+						add_realm_law = celestial_army_liege_law_2
+						#Unop Step the vassals' mirrored army law down too, so they don't cascade-revert to the group default (Autonomous) once the liege drops below level 3
+						every_vassal_or_below = {
+							limit = {
+								has_realm_law = celestial_army_vassal_law_3
+							}
+							add_realm_law_skip_effects = celestial_army_vassal_law_2
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes #581

**fixer:** As China, `celestial_army_liege_law_3` (Grand Expansionist Command) has a `can_keep` that requires the dynastic-cycle situation to be in the Stability/Expansion phase. When the era changes to Tension, that `can_keep` invalidates and the engine reverts the law to the group **default** (`celestial_army_liege_law_0`, Autonomous) — a drop to the floor instead of a graceful step down to Imperial Command (level 2).

Vanilla already solves the identical problem for `celestial_bureaucracy` by stepping it down one level (`celestial_bureaucracy_3` → `_2`) in the Stability/Expansion phase `on_end`. This fix mirrors that step-down for the army law: in the same `on_end` (both dynastic-cycle phase-group variants), if the China holder has `celestial_army_liege_law_3`, set `celestial_army_liege_law_2` before the engine's default-revert can fire.

Scope note: like the vanilla bureaucracy step-down, this steps the top-liege's law. The vassal-side cascade (`celestial_army_vassal_law_3`) and the exact engine timing (script step-down vs. the "revert within a month" auto-revert) should be confirmed in-game.