### PR TITLE
Make Silk Road Steady Trading grant development growth percentage, not flat add

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -216,6 +216,7 @@ filter = {
 				file = common/scripted_effects/00_decisions_effects.txt
 				file = events/court_maintenance_events.txt
 				file = events/dlc/ep1/ep1_fund_inspiration_events.txt
+				file = events/artifacts/artifact_events.txt
 			}
 		}
 		NAND = { # var:banner_dynasty/var:banner_house track scope:target which is documented polymorphic (title, house, or dynasty)

--- a/common/situation/situations/tgp_silk_road.txt
+++ b/common/situation/situations/tgp_silk_road.txt
@@ -1,0 +1,560 @@
+﻿
+silk_road_situation = {
+	illustration = "gfx/interface/illustrations/decisions/tgp_silk_road.dds"
+	situation_group_type = minor
+	gui_tooltip_group_focused = yes
+
+	#########################################################################
+	# Feature ownership is theft
+	# Design by the collective will of the design discipline
+	# Additional design by you, the people
+	#########################################################################
+
+	#window = the_silk_road
+	#gui_window_name = "window_the_silk_road"
+	#gui_participation_window_name = "window_situation_participation"
+	#map_mode = sub_regions
+
+	is_unique = yes
+	map_mode = silk_road
+	window = silk_road
+	gui_window_name = "window_silk_road"
+	##################################################
+	# Regions
+	##################################################
+	sub_regions = {
+		region_silk_road_proper_china = {
+			geographical_regions = { tgp_silk_road_china_region }
+			capital_province = 10148 # Chang'an (Zhouzhi)
+
+			map_color = { 0 168 107 }
+		}
+		region_silk_road_proper_tibet = {
+			geographical_regions = { tgp_silk_road_tibet_region }
+			capital_province = 9238 # Potala (Lhasa)
+
+			map_color = { 239 208 40 }
+		}
+		region_silk_road_proper_india = {
+			geographical_regions = { tgp_silk_road_india_region }
+			capital_province = 1362 # Lahur
+
+			map_color = { 237 103 89 }
+		}
+		region_silk_road_proper_central_asia = {
+			geographical_regions = { tgp_silk_road_central_asia_region }
+			capital_province = 9476 # Dunhuang
+			map_color = { 57 105 168 }
+		}
+		region_silk_road_proper_transcaspia = {
+			geographical_regions = { tgp_silk_road_transcaspia_region }
+			capital_province = 4452 # Khiva
+			map_color = { 95 161 51 }
+		}
+		region_silk_road_proper_occident = {
+			geographical_regions = { tgp_silk_road_occident_region }
+			capital_province = 672 # Dvin
+
+			map_color = { 164 72 138 }
+		}
+	}
+
+	##################################################
+	# On Actions
+	##################################################
+	on_start = {
+		set_variable = {
+			name = innovation_travel_countdown
+			value = define:NSilkRoad|INNOVATION_TRAVEL_DURATION
+		}
+		trigger_event = neutral_situation.0001 # War/peace pseudo catalyst setup
+		trigger_event = neutral_situation.0007 # Starting innovation spread setup
+	}
+
+	on_yearly = {
+		change_variable = {
+			name = innovation_travel_countdown
+			add = -1
+		}
+		if = {
+			limit = { var:innovation_travel_countdown ?= 0 }
+			tgp_silk_road_movement_stream_effect = {
+				SUB_REGION = situation_sub_region:region_silk_road_proper_occident
+				UPSTREAM_SUB_REGION = situation_sub_region:region_silk_road_proper_transcaspia
+			}
+			tgp_silk_road_movement_stream_effect = {
+				SUB_REGION = situation_sub_region:region_silk_road_proper_transcaspia
+				UPSTREAM_SUB_REGION = situation_sub_region:region_silk_road_proper_central_asia
+			}
+			tgp_silk_road_movement_stream_effect = {
+				SUB_REGION = situation_sub_region:region_silk_road_proper_india
+				UPSTREAM_SUB_REGION = situation_sub_region:region_silk_road_proper_tibet
+			}
+			tgp_silk_road_movement_stream_effect = {
+				SUB_REGION = situation_sub_region:region_silk_road_proper_central_asia
+				UPSTREAM_SUB_REGION = situation_sub_region:region_silk_road_proper_china
+			}
+			tgp_silk_road_movement_stream_effect = {
+				SUB_REGION = situation_sub_region:region_silk_road_proper_tibet
+				UPSTREAM_SUB_REGION = situation_sub_region:region_silk_road_proper_china
+			}
+			tgp_silk_road_movement_china_effect = yes
+			change_variable = {
+				name = innovation_travel_countdown
+				add = define:NSilkRoad|INNOVATION_TRAVEL_DURATION
+			}
+		}
+	}
+
+	##################################################
+	# Groups
+	##################################################
+	participant_groups = {
+		# read order is first valid
+		china_realm = { # Non-Nomadic Realms in China region
+			icon = "gfx/interface/icons/silk_road_group_types/icon_silk_road_lands_under_heaven.dds"
+			require_capital_in_sub_region = yes
+
+			is_character_valid = {
+				is_landed = yes
+				is_independent_ruler = yes
+				highest_held_title_tier >= tier_county
+				OR = {
+					capital_province = { geographical_region = tgp_silk_road_china_region }
+					any_held_title = {
+  						tier = tier_county
+  						title_province = { geographical_region = tgp_silk_road_china_region }
+					}
+				}
+				NOT = { has_government = nomad_government }
+			}
+			on_join = {
+			}
+			map_color = hsv{ 0.1 1 1 }
+		}
+		silk_road_domain = { # Non-Nomadic Domains along Silk Road route
+			icon = "gfx/interface/icons/silk_road_group_types/icon_silk_road_domain.dds"
+			require_capital_in_sub_region = yes
+
+			is_character_valid = {
+				is_landed = yes
+				highest_held_title_tier >= tier_county
+				OR = {
+					capital_province = { geographical_region = dlc_tgp_silk_road_route_region } # On the actual Roads
+					any_held_title = {
+						tier = tier_county
+						title_province = { geographical_region = dlc_tgp_silk_road_route_region } # On the actual Roads
+					}
+				}
+				NOT = { has_government = nomad_government }
+			}
+			on_join = {
+			}
+			map_color = hsv{ 0.22 0.5 1 }
+		}
+		silk_road_realm = { # Non-Nomadic Realms in Silk Road regions
+			icon = "gfx/interface/icons/silk_road_group_types/icon_silk_road_realm.dds"
+			require_capital_in_sub_region = yes
+
+			is_character_valid = {
+				is_landed = yes
+				highest_held_title_tier >= tier_county
+				any_sub_realm_county = {
+					title_province = { geographical_region = dlc_tgp_silk_road_route_region } # On the actual Roads
+				}
+				NOT = { has_government = nomad_government }
+			}
+			on_join = {
+			}
+			map_color = hsv{ 0.15 0.75 1 }
+		}
+		silk_road_periphery = { # Silk Road Periphery
+			icon = "gfx/interface/icons/silk_road_group_types/icon_silk_road_peripheral_ruler.dds"
+			require_capital_in_sub_region = yes
+
+			is_character_valid = {
+				is_landed = yes
+				highest_held_title_tier >= tier_county
+				NOT = { has_government = nomad_government }
+			}
+			on_join = {
+			}
+			map_color = hsv{ 0.66 0.33 0.50 }
+		}
+		silk_road_nomad = { # Any Nomads
+			icon = "gfx/interface/icons/silk_road_group_types/icon_silk_road_steppe_nomads.dds"
+			require_realm_in_sub_region = yes
+
+			is_character_valid = {
+				is_ruler = yes
+				highest_held_title_tier >= tier_county
+				has_government = nomad_government
+			}
+			on_join = {
+			}
+			map_color = hsv{ 0.55 0.22 1 }
+		}
+	}
+
+	##################################################
+	# Phases
+	##################################################
+	start_phase = phase_steady_trading
+	use_situation_phase_flat_icons = no
+
+	phases = {
+		phase_exceptional_bounty = {
+			icon = "gfx/interface/icons/situations/debug_situation/flood.dds"
+			max_duration = { years = 8 }
+
+			parameters = {
+				good_phase = yes
+			}
+
+			future_phases = {
+				phase_steady_trading = {
+					takeover_type = points
+					takeover_points = 500
+
+					catalysts = {
+						# War
+						catalyst_silk_road_region_war = silk_road_downstream_primary_value
+						catalyst_silk_road_adjacent_upstream_region_war = silk_road_downstream_secondary_value
+						catalyst_silk_road_distant_upstream_region_war = silk_road_downstream_tertiary_value
+						# Byzantium
+						catalyst_silk_road_byzantium_blew_up = silk_road_byzantium_destroyed_value
+						catalyst_silk_road_mpo_region_to_steppe = silk_road_expand_steppe_value
+						# Dynastic Cycle
+						catalyst_silk_road_china_consolidation = silk_road_steppe_china_consolidation_value
+						# Persia
+						catalyst_silk_road_iranian_intermezzo_in_unrest = silk_road_steppe_iranian_intermezzo_unrest_value
+						# Siege
+						catalyst_silk_road_mongol_devastation = silk_road_mongol_devastation_value
+						# Raid
+						catalyst_silk_road_raided = silk_road_raid_value
+					}
+				}
+			}
+
+			modifier_sets = {
+				silk_road_phase_effects = {
+					icon = "gfx/interface/icons/modifiers/goods_positive.dds"
+
+					all = {
+						character_modifier = {
+							cultural_head_fascination_mult = 0.05 #Exchange of ideas in entire subregion
+						}
+						county_modifier = { # Very small boost to entire subregion - Main county effects are in on_start
+							development_growth_factor = 0.02
+							epidemic_resistance = -10 # lots of movement is a great way to get lots of plague
+						}
+					}
+
+					china_realm = {
+						character_modifier = {
+							domain_tax_mult = 0.02
+						}
+					}
+
+					silk_road_domain = {
+						character_modifier = {
+							domain_tax_mult = 0.02
+						}
+						county_modifier = {
+							development_growth = 0.01
+						}
+					}
+
+					silk_road_realm = {
+						character_modifier = {
+							domain_tax_mult = 0.02
+						}
+					}
+
+					silk_road_periphery = {
+						character_modifier = {
+							domain_tax_mult = 0.01
+						}
+					}
+
+					silk_road_nomad = {
+						character_modifier = {
+							domicile_travel_speed = 0.1
+							herd_conversion = 0.007
+						}
+						county_modifier = { #Land use is higher, less grazing
+							county_fertility_growth_mult = -0.02
+						}
+					}
+				}
+			}
+
+			on_start = {
+				tgp_silk_road_phase_message_effect = yes
+				scope:situation_sub_region = {
+					every_situation_sub_region_county  = {
+						limit = {
+							title_province = {
+								geographical_region = dlc_tgp_silk_road_route_region
+							}
+						}
+						add_county_modifier = {
+							modifier = silk_road_exceptional_bounty_province_modifier
+						}
+					}
+				}
+			}
+			on_end = {
+				scope:situation_sub_region = {
+					every_situation_sub_region_county  = {
+						limit = {
+							title_province = {
+								geographical_region = dlc_tgp_silk_road_route_region
+							}
+						}
+						remove_county_modifier = silk_road_exceptional_bounty_province_modifier
+					}
+				}
+			}
+		}
+		phase_steady_trading = {
+			icon = "gfx/interface/icons/situations/debug_situation/plentiful_harvest.dds"
+
+			future_phases = {
+				phase_exceptional_bounty = {
+					takeover_type = points
+					takeover_points = 500
+					catalysts = {
+						### PROSPERITY
+						# Peace
+						catalyst_silk_road_region_peace = silk_road_downstream_primary_value
+						catalyst_silk_road_adjacent_upstream_region_peace = silk_road_downstream_secondary_value
+						catalyst_silk_road_distant_upstream_region_peace = silk_road_downstream_tertiary_value
+						# Persia
+						catalyst_silk_road_iranian_intermezzo_ending_reached = silk_road_steppe_iranian_intermezzo_ending_value
+						# Dynastic Cycle
+						catalyst_silk_road_china_stability = silk_road_steppe_china_stability_value
+						# Grand Canal
+						catalyst_silk_road_china_grand_canal_expanded = silk_road_steppe_canal_built_primary_value
+						catalyst_silk_road_china_grand_canal_expanded_secondary = silk_road_steppe_canal_built_secondary_value
+						catalyst_silk_road_china_grand_canal_expanded_tertiary = silk_road_steppe_canal_built_tertiary_value
+						# Resettlement
+						catalyst_silk_road_mpo_region_resettled = silk_road_steppe_resettlement_value
+						# Market
+						catalyst_silk_road_famous_market_built = silk_road_steppe_market_built_value
+					}
+				}
+				phase_hardship = {
+					takeover_type = points
+					takeover_points = -500
+					catalysts = {
+						### HARDSHIP
+						# War
+						catalyst_silk_road_region_war = silk_road_downstream_primary_negative_value
+						catalyst_silk_road_adjacent_upstream_region_war = silk_road_downstream_secondary_negative_value
+						catalyst_silk_road_distant_upstream_region_war = silk_road_downstream_tertiary_negative_value
+						# Byzantium
+						catalyst_silk_road_byzantium_blew_up = silk_road_byzantium_destroyed_negative_value
+						catalyst_silk_road_mpo_region_to_steppe = silk_road_expand_steppe_negative_value
+						# Dynastic Cycle
+						catalyst_silk_road_china_consolidation = silk_road_steppe_china_consolidation_negative_value
+						# Persia
+						catalyst_silk_road_iranian_intermezzo_in_unrest = silk_road_steppe_iranian_intermezzo_unrest_negative_value
+						# Siege
+						catalyst_silk_road_mongol_devastation = silk_road_mongol_devastation_negative_value
+						# Raid
+						catalyst_silk_road_raided = silk_road_raid_negative_value
+					}
+				}
+			}
+
+			modifier_sets = {
+				silk_road_phase_effects = {
+					icon = "gfx/interface/icons/modifiers/goods_mixed.dds"
+
+					all = {
+						character_modifier = {
+							cultural_head_fascination_mult = 0.02
+						}
+						county_modifier = { # Very small boost to entire subregion - Main county effects are in on_start
+							development_growth = 0.01
+							epidemic_resistance = -5 # lots of movement is a great way to get lots of plague
+						}
+					}
+
+					china_realm = {
+						character_modifier = {
+							domain_tax_mult = 0.01
+						}
+					}
+
+					silk_road_domain = {
+						character_modifier = {
+							domain_tax_mult = 0.01
+						}
+					}
+
+					silk_road_realm = {
+						# No effects! They just get to watch and stay informed.
+					}
+
+					silk_road_periphery = {
+						# No effects! They just get to watch and stay informed.
+					}
+
+					silk_road_nomad = {
+						character_modifier = {
+							herd_conversion = 0.005
+						}
+						county_modifier = {
+
+						}
+					}
+				}
+			}
+
+			on_start = {
+				tgp_silk_road_phase_message_effect = yes
+				scope:situation_sub_region = {
+					every_situation_sub_region_county  = {
+						limit = {
+							title_province = {
+								geographical_region = dlc_tgp_silk_road_route_region
+							}
+						}
+						add_county_modifier = {
+							modifier = silk_road_steady_trading_province_modifier
+						}
+					}
+				}
+			}
+			on_end = {
+				scope:situation_sub_region = {
+					every_situation_sub_region_county  = {
+						limit = {
+							title_province = {
+								geographical_region = dlc_tgp_silk_road_route_region
+							}
+						}
+						remove_county_modifier = silk_road_steady_trading_province_modifier
+					}
+				}
+			}
+		}
+		phase_hardship = {
+			icon = "gfx/interface/icons/situations/debug_situation/flood.dds"
+			max_duration = { years = 8 }
+
+			future_phases = {
+				phase_steady_trading = {
+					takeover_type = points
+					takeover_points = 500
+					catalysts = {
+						### PROSPERITY
+						# Peace
+						catalyst_silk_road_region_peace = silk_road_downstream_primary_value
+						catalyst_silk_road_adjacent_upstream_region_peace = silk_road_downstream_secondary_value
+						catalyst_silk_road_distant_upstream_region_peace = silk_road_downstream_tertiary_value
+						# Persia
+						catalyst_silk_road_iranian_intermezzo_ending_reached = silk_road_steppe_iranian_intermezzo_ending_value
+						# Dynastic Cycle
+						catalyst_silk_road_china_stability = silk_road_steppe_china_stability_value
+						# Grand Canal
+						catalyst_silk_road_china_grand_canal_expanded = silk_road_steppe_canal_built_primary_value
+						catalyst_silk_road_china_grand_canal_expanded_secondary = silk_road_steppe_canal_built_secondary_value
+						catalyst_silk_road_china_grand_canal_expanded_tertiary = silk_road_steppe_canal_built_tertiary_value
+						# Resettlement
+						catalyst_silk_road_mpo_region_resettled = silk_road_steppe_resettlement_value
+						# Market
+						catalyst_silk_road_famous_market_built = silk_road_steppe_market_built_value
+					}
+				}
+			}
+
+			modifier_sets = {
+				silk_road_phase_effects = {
+					icon = "gfx/interface/icons/modifiers/goods_negative.dds"
+
+					# trade collapsing means there's less propensity for plague, at least
+					all = {
+						county_modifier = { # Applied to all counties in all Silk Road regions
+							development_growth_factor = -0.02
+						}
+					}
+
+					china_realm = { # Emperor's influence suffers when the Silk Road dies, if there's still an emperor at this point
+						character_modifier = {
+							legitimacy_loss_mult = 0.1
+						}
+					}
+					
+					silk_road_domain = { # Trade that you used to depend on is now gone
+						character_modifier = {
+							domain_tax_mult = -0.02
+						}
+						county_modifier = {
+
+						}
+					}
+
+					silk_road_realm = {
+						character_modifier = {
+							domain_tax_mult = -0.01
+
+						}
+						county_modifier = {
+
+						}
+					}
+
+					silk_road_periphery = { # Knock-on effects of economic downturns still hurt the periphery
+						character_modifier = {
+							domain_tax_mult = -0.01
+
+						}
+						county_modifier = {
+
+						}
+					}
+
+					silk_road_nomad = { # Silk Road's decline hurts herds, but there are other avenues for economic growth in these challenging times
+						character_modifier = {
+							herd_gain_mult = -0.005
+						}
+						county_modifier = { #Less land-use, more grazing
+							county_fertility_growth_mult = 0.02
+						}
+					}
+				}
+			}
+
+			on_start = {
+				tgp_silk_road_phase_message_effect = yes
+				scope:situation_sub_region = {
+					every_situation_sub_region_county = {
+						limit = {
+							title_province = {
+								geographical_region = dlc_tgp_silk_road_route_region
+							}
+						}
+						add_county_modifier = {
+							modifier = silk_road_hardship_province_modifier
+						}
+					}
+				}
+			}
+			on_end = {
+				scope:situation_sub_region = {
+					every_situation_sub_region_county  = {
+						limit = {
+							title_province = {
+								geographical_region = dlc_tgp_silk_road_route_region
+							}
+						}
+						remove_county_modifier = silk_road_hardship_province_modifier
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/situation/situations/tgp_silk_road.txt
+++ b/common/situation/situations/tgp_silk_road.txt
@@ -377,7 +377,7 @@ silk_road_situation = {
 							cultural_head_fascination_mult = 0.02
 						}
 						county_modifier = { # Very small boost to entire subregion - Main county effects are in on_start
-							development_growth = 0.01
+							development_growth_factor = 0.01 #Unop Was a flat development_growth add; the subregion-wide boost should be a percentage growth factor, matching the sibling phase_exceptional_bounty
 							epidemic_resistance = -5 # lots of movement is a great way to get lots of plague
 						}
 					}


### PR DESCRIPTION
Fixes #586

**fixer:** The Silk Road Steady Trading phase's subregion-wide `all` county_modifier used `development_growth = 0.01` (a flat +0.01 Monthly Development add) instead of `development_growth_factor = 0.01` (a +1% growth factor). The missing `_factor` is a vanilla typo: the parallel prosperity phase `phase_exceptional_bounty` uses `development_growth_factor = 0.02` in the identical `all` block (same "Very small boost to entire subregion" comment). Fixed to `development_growth_factor = 0.01`, matching the wiki's "1% Development Growth for Everyone".

Scoped strictly to the `all` block — the legitimate flat `development_growth = 0.01` in the `silk_road_domain` route blocks is untouched.

Adds a new Unop override of `common/situation/situations/tgp_silk_road.txt` (vanilla file added unmodified in its own commit first). Adding this override surfaced a latent, unrelated tiger scope false positive in `events/artifacts/artifact_events.txt` (a `var:banner_dynasty` comparison tiger can't type-infer; the value is a dynasty, so the comparison is correct); extended the existing `banner_dynasty` false-positive rule in `ck3-tiger.conf` to cover that file. `make tiger` is clean.