### PR TITLE
Fix flag-from-variable type error saving movement_petition_effect

### DIFF
--- a/common/scripted_effects/00_unop_effects.txt
+++ b/common/scripted_effects/00_unop_effects.txt
@@ -739,3 +739,30 @@ unop_distribute_determined_court_position_effect = {
 		}
 	}
 }
+
+# Saves scope:movement_petition_effect from var:movement_petition for petition types
+# that reach tgp_decision_events.0100 without it being set (e.g. via ai_movement_petition_change_laws_decision).
+# save_scope_value_as cannot take a flag read out of a variable, so the flag is re-derived as a literal per case.
+unop_save_movement_petition_effect = {
+	if = {
+		limit = { NOT = { exists = scope:movement_petition_effect } }
+		switch = {
+			trigger = var:movement_petition
+			flag:change_bureaucracy_laws_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_bureaucracy_laws_increase } }
+			flag:change_bureaucracy_laws_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_bureaucracy_laws_decrease } }
+			flag:change_army_laws_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_army_laws_increase } }
+			flag:change_army_laws_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_army_laws_decrease } }
+			flag:change_province_metropolitan = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_metropolitan } }
+			flag:change_province_industrial = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_industrial } }
+			flag:change_province_military = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_military } }
+			flag:change_province_protectorate = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_protectorate } }
+			flag:hold_examinations = { save_scope_value_as = { name = movement_petition_effect value = flag:hold_examinations } }
+			flag:change_retirement_law_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_retirement_law_increase } }
+			flag:change_retirement_law_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_retirement_law_decrease } }
+			flag:change_candidate_score_law = { save_scope_value_as = { name = movement_petition_effect value = flag:change_candidate_score_law } }
+			flag:increase_budget_salary = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_salary } }
+			flag:increase_budget_ministry = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_ministry } }
+			flag:increase_budget_military = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_military } }
+		}
+	}
+}

--- a/events/decisions_events/tgp_decision_events.txt
+++ b/events/decisions_events/tgp_decision_events.txt
@@ -491,7 +491,25 @@ tgp_decision_events.0100 = {
     after = {
         if = { #Unop save missing scope:movement_petition_effect for petition types that bypass movement_petition_change_laws_decision
             limit = { NOT = { exists = scope:movement_petition_effect } }
-            save_scope_value_as = { name = movement_petition_effect value = var:movement_petition }
+            #Unop the flag has to be re-derived as a literal per case: save_scope_value_as cannot take a flag read out of a variable
+            switch = {
+                trigger = var:movement_petition
+                flag:change_bureaucracy_laws_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_bureaucracy_laws_increase } }
+                flag:change_bureaucracy_laws_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_bureaucracy_laws_decrease } }
+                flag:change_army_laws_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_army_laws_increase } }
+                flag:change_army_laws_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_army_laws_decrease } }
+                flag:change_province_metropolitan = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_metropolitan } }
+                flag:change_province_industrial = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_industrial } }
+                flag:change_province_military = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_military } }
+                flag:change_province_protectorate = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_protectorate } }
+                flag:hold_examinations = { save_scope_value_as = { name = movement_petition_effect value = flag:hold_examinations } }
+                flag:change_retirement_law_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_retirement_law_increase } }
+                flag:change_retirement_law_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_retirement_law_decrease } }
+                flag:change_candidate_score_law = { save_scope_value_as = { name = movement_petition_effect value = flag:change_candidate_score_law } }
+                flag:increase_budget_salary = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_salary } }
+                flag:increase_budget_ministry = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_ministry } }
+                flag:increase_budget_military = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_military } }
+            }
         }
         display_movement_petition_recipient_acceptance_effect = yes
         scope:petition_recipient = {

--- a/events/decisions_events/tgp_decision_events.txt
+++ b/events/decisions_events/tgp_decision_events.txt
@@ -489,28 +489,7 @@ tgp_decision_events.0100 = {
         }
     }
     after = {
-        if = { #Unop save missing scope:movement_petition_effect for petition types that bypass movement_petition_change_laws_decision
-            limit = { NOT = { exists = scope:movement_petition_effect } }
-            #Unop the flag has to be re-derived as a literal per case: save_scope_value_as cannot take a flag read out of a variable
-            switch = {
-                trigger = var:movement_petition
-                flag:change_bureaucracy_laws_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_bureaucracy_laws_increase } }
-                flag:change_bureaucracy_laws_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_bureaucracy_laws_decrease } }
-                flag:change_army_laws_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_army_laws_increase } }
-                flag:change_army_laws_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_army_laws_decrease } }
-                flag:change_province_metropolitan = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_metropolitan } }
-                flag:change_province_industrial = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_industrial } }
-                flag:change_province_military = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_military } }
-                flag:change_province_protectorate = { save_scope_value_as = { name = movement_petition_effect value = flag:change_province_protectorate } }
-                flag:hold_examinations = { save_scope_value_as = { name = movement_petition_effect value = flag:hold_examinations } }
-                flag:change_retirement_law_increase = { save_scope_value_as = { name = movement_petition_effect value = flag:change_retirement_law_increase } }
-                flag:change_retirement_law_decrease = { save_scope_value_as = { name = movement_petition_effect value = flag:change_retirement_law_decrease } }
-                flag:change_candidate_score_law = { save_scope_value_as = { name = movement_petition_effect value = flag:change_candidate_score_law } }
-                flag:increase_budget_salary = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_salary } }
-                flag:increase_budget_ministry = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_ministry } }
-                flag:increase_budget_military = { save_scope_value_as = { name = movement_petition_effect value = flag:increase_budget_military } }
-            }
-        }
+        unop_save_movement_petition_effect = yes #Unop save missing scope:movement_petition_effect for petition types that bypass movement_petition_change_laws_decision
         display_movement_petition_recipient_acceptance_effect = yes
         scope:petition_recipient = {
             trigger_event = tgp_decision_events.0101


### PR DESCRIPTION
Fixes #591

**fixer:** The `tgp_decision_events.0100.after` block filled the missing `scope:movement_petition_effect` with `save_scope_value_as = { value = var:movement_petition }`. The `value` slot is parsed as a scriptvalue, and a flag read out of a variable can't be evaluated there — throwing the logged `jomini_scriptvalue.cpp:1485 ... Got value of type 'flag'` error and leaving the scope unset.

A flag *literal* is accepted by `save_scope_value_as` (vanilla's own `movement_petition_change_laws_decision` does exactly that), but a flag pulled from a variable is not. The scope is re-derived via a `switch` over `var:movement_petition` that saves the matching flag as a literal per case, covering all 15 petition flags the downstream `switch` (`grant_movement_petition_tooltip_effect`) handles. All 15 are required: `ai_movement_petition_change_laws_decision` bypasses `movement_petition_change_laws_decision` entirely and reaches event 0100 with any petition flag but no saved scope. The `NOT = { exists = scope:movement_petition_effect }` guard is kept, so the vanilla decision path (which already sets the scope from a literal) is untouched.

The switch is extracted into `unop_save_movement_petition_effect` (`common/scripted_effects/00_unop_effects.txt`), leaving the `.after` block a single call.

tiger clean.