### PR TITLE
Only offer concubine tribute when a valid candidate exists

### DIFF
--- a/common/scripted_triggers/tgp_tribute_mission_triggers.txt
+++ b/common/scripted_triggers/tgp_tribute_mission_triggers.txt
@@ -151,7 +151,7 @@ has_concubine_tribute_trigger = {
 	}
 	custom_tooltip = {
 		text = tribute_mission_concubine_interaction.no_valid_concubines
-		#Unop match the effect's stricter candidate filter (tribute_mission_decision_effect) so the option is only offered when a courtier/guest can actually be sent, instead of the laxer can_become_concubine_of_character_valid_trigger
+		#Unop match the effect's stricter candidate filter so the option is only shown when a courtier/guest can actually be sent
 		any_courtier_or_guest = {
 			can_be_offered_as_concubine_to_character_trigger = { GIVER = scope:concubine_tribute_giver CHARACTER = scope:overlord_check }
 			tribute_mission_is_available_concubine_trigger = yes

--- a/common/scripted_triggers/tgp_tribute_mission_triggers.txt
+++ b/common/scripted_triggers/tgp_tribute_mission_triggers.txt
@@ -144,14 +144,17 @@ has_artifact_tribute_trigger = {
 }
 
 has_concubine_tribute_trigger = {
-	overlord = { 
+	save_temporary_scope_as = concubine_tribute_giver #Unop remember the offering tributary so the candidate check below can pass it as GIVER
+	overlord = {
 		is_adult = yes
 		save_temporary_scope_as = overlord_check
 	}
 	custom_tooltip = {
 		text = tribute_mission_concubine_interaction.no_valid_concubines
+		#Unop match the effect's stricter candidate filter (tribute_mission_decision_effect) so the option is only offered when a courtier/guest can actually be sent, instead of the laxer can_become_concubine_of_character_valid_trigger
 		any_courtier_or_guest = {
-			can_become_concubine_of_character_valid_trigger = { CHARACTER = scope:overlord_check }
+			can_be_offered_as_concubine_to_character_trigger = { GIVER = scope:concubine_tribute_giver CHARACTER = scope:overlord_check }
+			tribute_mission_is_available_concubine_trigger = yes
 		}
 	}
 }


### PR DESCRIPTION
Fixes #592

**fixer:** The concubine option in all 6 tribute-mission decisions was gated by `has_concubine_tribute_trigger`, whose candidate check used the lax `can_become_concubine_of_character_valid_trigger`. But `tribute_mission_decision_effect` selects candidates with the stricter `can_be_offered_as_concubine_to_character_trigger` + `tribute_mission_is_available_concubine_trigger`. When the strict set is empty but the lax one isn't (e.g. the only eligible courtier is a ruler, not young, diseased, an heir, or fails the desirability check), the option is offered but the effect finds no candidate — the tribute silently no-ops and can spam `error.log`.

Fixed at the single shared trigger: `has_concubine_tribute_trigger` now runs the same filter the effect uses (passing the offering tributary as `GIVER` and the overlord as `CHARACTER`). Because all 6 decisions and `tribute_mission_decision_concubine_trigger` route through this one trigger, every entry point is covered at once — mirroring the eunuch path, whose guard already checks the same predicate its effect filters on. The existing `no_valid_concubines` custom_tooltip is preserved.

tiger clean. (Vanilla bug; the trigger/effect are byte-identical to vanilla.)