### PR TITLE
Fix marshal overtime boost/decrease scales reading wrong scope and variable

### DIFF
--- a/common/script_values/99_marshal_values.txt
+++ b/common/script_values/99_marshal_values.txt
@@ -1,0 +1,663 @@
+﻿
+######################
+# Organize Levies
+######################
+
+### Improving Levies
+# Base value
+marshal_organize_levies_base = {
+	add = 1
+}
+
+marshal_organize_levies_skill_base = {
+	add = martial
+	multiply = 2
+}
+
+# Erudition bonus
+marshal_organize_levies_erudition_bonus = {
+	if = {
+		limit = { councillor_liege_has_erudition_legacy_5_perk = yes }
+		add = {
+			value = marshal_organize_levies_base
+			add = marshal_organize_levies_skill_base
+			multiply = {
+				add = erudition_legacy_5_percentage
+				divide = 100
+			}
+		}
+	}
+}
+
+# Tradition: Family business
+marshal_organize_levies_family_business_bonus = {
+	if = {
+		limit = { councillor_liege_has_family_business_bonus = yes }
+		add = {
+			value = marshal_organize_levies_base
+			add = marshal_organize_levies_skill_base
+			multiply = {
+				add = family_business_councillors_percentage
+				divide = 100
+			}
+		}
+	}
+}
+
+marshal_organize_levies_consulted_house_bonus = {
+	if = {
+		limit = { councillor_liege_has_consulted_house_bonus = yes }
+		add = {
+			value = marshal_organize_levies_base
+			add = marshal_organize_levies_skill_base
+			multiply = {
+				add = consulted_house_councillors_percentage
+				divide = 100
+			}
+		}
+	}
+}
+
+marshal_organize_levies_pandidakterion_bonus = {
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				has_title = title:c_byzantion
+				title:c_byzantion = { has_county_modifier = pandidakterion_university_modifier }
+			}
+		}
+		add = {
+			value = marshal_organize_levies_base
+			add = marshal_organize_levies_skill_base
+			multiply = {
+				add = 10
+				divide = 100
+			}
+		}
+	}
+}
+
+# Final value
+marshal_organize_levies_modifier_total = {
+	add = marshal_organize_levies_base
+	add = marshal_organize_levies_skill_base
+	add = marshal_organize_levies_erudition_bonus
+	add = marshal_organize_levies_family_business_bonus
+	add = marshal_organize_levies_consulted_house_bonus
+	add = marshal_organize_levies_pandidakterion_bonus
+}
+
+### Army maintenance
+# Base value
+marshal_organize_levies_maintenance_base = {
+	add = 1
+}
+
+marshal_organize_levies_maintenance_skill_base = {
+	add = martial
+}
+
+# Erudition bonus
+marshal_organize_levies_maintenance_erudition_bonus = {
+	if = {
+		limit = { councillor_liege_has_erudition_legacy_5_perk = yes }
+		add = {
+			value = marshal_organize_levies_maintenance_base
+			add = marshal_organize_levies_maintenance_skill_base
+			multiply = {
+				add = erudition_legacy_5_percentage
+				divide = 100
+			}
+		}
+	}
+}
+
+# Tradition: Family business
+marshal_organize_levies_maintenance_family_business_bonus = {
+	if = {
+		limit = { councillor_liege_has_family_business_bonus = yes }
+		add = {
+			value = marshal_organize_levies_maintenance_base
+			add = marshal_organize_levies_maintenance_skill_base
+			multiply = {
+				add = family_business_councillors_percentage
+				divide = 100
+			}
+		}
+	}
+}
+
+# FP3 Consulted House
+marshal_organize_levies_maintenance_consulted_house_bonus = {
+	if = {
+		limit = { councillor_liege_has_consulted_house_bonus = yes }
+		add = {
+			value = marshal_organize_levies_maintenance_base
+			add = marshal_organize_levies_maintenance_skill_base
+			multiply = {
+				add = consulted_house_councillors_percentage
+				divide = 100
+			}
+		}
+	}
+}
+
+task_organize_levies_maintenance_pandidakterion_bonus = {
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				has_title = title:c_byzantion
+				title:c_byzantion = { has_county_modifier = pandidakterion_university_modifier }
+			}
+		}
+		add = {
+			value = marshal_organize_levies_base
+			add = marshal_organize_levies_skill_base
+			multiply = {
+				add = 10
+				divide = 100
+			}
+		}
+	}
+}
+
+# Final value
+marshal_organize_levies_maintenance_total = {
+	add = marshal_organize_levies_maintenance_base
+	add = marshal_organize_levies_maintenance_skill_base
+	add = marshal_organize_levies_maintenance_erudition_bonus
+	add = marshal_organize_levies_maintenance_family_business_bonus
+	add = marshal_organize_levies_maintenance_consulted_house_bonus
+	add = task_organize_levies_maintenance_pandidakterion_bonus
+}
+
+########################
+# Train Commanders
+########################
+
+### Overtime Boost MaA
+# Base modifier
+marshal_maa_overtime_boost_base = {
+	add = martial
+}
+
+# Max value
+marshal_maa_overtime_boost_max = {
+	add = martial
+}
+
+# Monthly Increase
+marshal_maa_overtime_boost_monthly_increase = {
+	add = 1
+}
+
+# Current
+marshal_maa_overtime_boost_scale = {
+	add = 0
+	if = {
+		limit = {
+			has_variable = marshal_maa_overtime_boost
+		}
+		add = var:marshal_maa_overtime_boost
+	}
+}
+
+## Boost Knights
+marshal_knights_overtime_boost_scale = {
+	add = 0
+	if = {
+		limit = {
+			has_variable = marshal_maa_overtime_boost
+		}
+		add = var:marshal_maa_overtime_boost
+	}
+}
+
+
+
+### Improve commanders
+# Base value
+marshal_train_commanders_monthly_chance_value_base = {
+	add = martial
+	divide = 2
+}
+# Erudition value
+marshal_train_commanders_monthly_chance_erudition_bonus = {
+	add = marshal_train_commanders_monthly_chance_value_base
+	multiply = erudition_legacy_5_percentage
+	divide = 100
+}
+
+# Family Business
+marshal_train_commanders_monthly_chance_family_business_bonus = {
+	add = marshal_train_commanders_monthly_chance_value_base
+	multiply = family_business_councillors_percentage
+	divide = 100
+}
+
+# FP3 Consulted House
+marshal_train_commanders_monthly_chance_consulted_house_bonus = {
+	add = marshal_train_commanders_monthly_chance_value_base
+	multiply = consulted_house_councillors_percentage
+	divide = 100
+}
+
+# Master of Horse
+marshal_train_commanders_monthly_chance_master_of_horse_bonus = {
+	add = marshal_train_commanders_monthly_chance_value_base
+	multiply = 10
+	divide = 100
+}
+
+# Total value
+marshal_train_commanders_monthly_chance_value = {
+	value = marshal_train_commanders_monthly_chance_value_base
+	if = {
+		limit = {
+			councillor_liege_has_erudition_legacy_5_perk = yes
+		}
+		add = marshal_train_commanders_monthly_chance_erudition_bonus
+	}
+	if = {
+		limit = {
+			councillor_liege_has_family_business_bonus = yes
+		}
+		add = marshal_train_commanders_monthly_chance_family_business_bonus
+	}
+	if = {
+		limit = {
+			councillor_liege_has_consulted_house_bonus = yes
+		}
+		add = marshal_train_commanders_monthly_chance_consulted_house_bonus
+	}
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				OR = {
+					has_character_modifier = employer_booner_master_of_horse_2_modifier
+					has_character_modifier = employer_booner_master_of_horse_3_modifier
+				}
+			}
+		}
+		add = marshal_train_commanders_monthly_chance_master_of_horse_bonus
+	}
+}
+
+task_supress_crime_progress = {
+	add = martial
+	divide = 10
+}
+
+
+################################
+# Increase Control
+################################
+marshal_increase_control_full_progress = {
+	if = {
+		limit = { exists = scope:county }
+		add = scope:county.monthly_county_control_change
+	}
+}
+
+marshal_increase_control_current_progress = {
+	value = 0
+	if = {
+		limit = { exists = scope:county }
+		add = scope:county.county_control
+	}
+}
+
+marshal_increase_control_base = 0.2
+
+marshal_increase_county_control_monthly_change = {
+	add = martial
+	divide = 30
+}
+
+marshal_increase_control_base_total = {
+	add = marshal_increase_control_base
+	add = marshal_increase_county_control_monthly_change
+}
+
+marshal_increase_control_monthly_increase_friend_bonus = {
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				has_relation_friend = scope:councillor
+				NOT = { has_relation_best_friend = scope:councillor }
+			}
+		}
+		add = {
+			value = marshal_increase_control_base_total
+			multiply = {
+				value = council_friend_impact_percentage
+				divide = 100
+			}
+		}
+	}
+}
+marshal_increase_control_monthly_increase_best_friend_bonus = {
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				has_relation_best_friend = scope:councillor
+			}
+		}
+		add = {
+			value = marshal_increase_control_base_total
+			multiply = {
+				value = council_best_friend_impact_percentage
+				divide = 100
+			}
+		}
+	}
+}
+marshal_increase_control_monthly_increase_rival_bonus = {
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				has_relation_rival = scope:councillor
+				NOT = { has_relation_nemesis = scope:councillor }
+			}
+		}
+		add = {
+			value = marshal_increase_control_base_total
+			multiply = {
+				value = council_rival_impact_percentage
+				divide = 100
+			}
+		}
+	}
+}
+marshal_increase_control_monthly_increase_nemesis_bonus = {
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				has_relation_nemesis = scope:councillor
+			}
+		}
+		add = {
+			value = marshal_increase_control_base_total
+			multiply = {
+				value = council_nemesis_impact_percentage
+				divide = 100
+			}
+		}
+	}
+}
+
+marshal_increase_county_control_perk_bonus_monthly_change = {
+	value = 0
+	if = {
+		limit = {
+			liege ?= { has_perk = strict_organization_perk }
+		}
+		add = marshal_increase_control_base_total
+		multiply = {
+			add = strict_organization_percentage
+			divide = 100
+		}
+	}
+}
+
+marshal_increase_county_control_erudition_bonus_monthly_change = {
+	value = 0
+	add = marshal_increase_control_base_total
+	multiply = {
+		add = erudition_legacy_5_percentage
+		divide = 100
+	}
+}
+
+marshal_increase_county_control_family_business_bonus_monthly_change = {
+	value = 0
+	add = marshal_increase_control_base_total
+	multiply = {
+		add = family_business_councillors_percentage
+		divide = 100
+	}
+}
+
+marshal_increase_county_control_consulted_house_bonus_monthly_change = {
+	value = 0
+	add = marshal_increase_control_base_total
+	multiply = {
+		add = consulted_house_councillors_percentage
+		divide = 100
+	}
+}
+
+marshal_increase_county_control_experience_bonus_monthly_change = {
+	value = 0	
+	add = marshal_increase_control_base_total
+	multiply = {
+		add = 10
+		divide = 100
+	}
+}
+
+marshal_increase_control_total = {
+	value = marshal_increase_control_base
+	add = marshal_increase_county_control_monthly_change
+	add = marshal_increase_control_monthly_increase_friend_bonus
+	add = marshal_increase_control_monthly_increase_best_friend_bonus
+	add = marshal_increase_control_monthly_increase_rival_bonus
+	add = marshal_increase_control_monthly_increase_nemesis_bonus
+	add = marshal_increase_county_control_perk_bonus_monthly_change
+	if = {
+		limit = {
+			councillor_liege_has_erudition_legacy_5_perk = yes
+		}
+		add = marshal_increase_county_control_erudition_bonus_monthly_change
+	}
+	if = {
+		limit = {
+			councillor_liege_has_family_business_bonus = yes
+		}
+		add = marshal_increase_county_control_family_business_bonus_monthly_change
+	}
+	if = {
+		limit = {
+			has_character_modifier = event_bonus_to_county_control
+		}
+		add = marshal_increase_county_control_experience_bonus_monthly_change
+	}
+}
+
+marshal_councillor_county_corruption_value = {
+	add = martial
+	divide = 5
+}
+
+marshal_county_county_corruption_value = {
+	if = {
+		limit = { exists = scope:county }
+		add = scope:county.county_control
+		divide = 5
+	}
+}
+
+marshal_remove_county_corruption_chance = {
+	add = martial
+	if = {
+		limit = { exists = scope:county }
+		add = {
+			value = scope:county.county_control
+		}
+	}
+	divide = 5
+}
+
+marshal_learn_on_the_job_scale = {
+	value = 0
+	if = {
+		limit = {
+			liege = { has_perk = learn_on_the_job_perk }
+		}
+		add = martial
+		multiply = {
+			add = learn_on_the_job_percentage
+			divide = 100
+		}
+		floor = yes
+		min = 1
+	}
+}
+
+kurultai_marshal_learn_on_the_job_scale = {
+	value = 0
+	if = {
+		limit = {
+			liege = { has_perk = learn_on_the_job_perk }
+			highest_skill = martial
+		}
+		add = martial
+		multiply = {
+			add = learn_on_the_job_percentage
+			divide = 100
+		}
+		floor = yes
+		min = 1
+	}
+}
+
+marshal_scheme_overtime_boost_scale = {
+	add = 0
+	if = {
+		limit = {
+			has_variable = marshal_overtime_decrease
+		}
+		subtract = var:marshal_overtime_decrease
+	}
+}
+
+# Monthly Increase
+marshal_overtime_boost_monthly_increase = {
+	add = martial
+	multiply = 0.1
+	floor = yes
+	min = 0.1
+}
+
+marshal_overtime_decrease_monthly_increase = {
+	subtract = martial
+	multiply = 0.05
+}
+
+# Max value
+marshal_overtime_boost_base = {
+	add = martial
+	multiply = 2
+}
+
+marshal_manage_guards_max_erudition_bonus = {
+	if = {
+		limit = { councillor_liege_has_erudition_legacy_5_perk = yes }
+		add = marshal_overtime_boost_base
+		multiply = {
+			add = erudition_legacy_5_percentage
+			divide = 100
+		}
+	}
+}
+
+marshal_manage_guards_max_family_business_bonus = {
+	if = {
+		limit = { councillor_liege_has_family_business_bonus = yes }
+		add = marshal_overtime_boost_base
+		multiply = {
+			add = family_business_councillors_percentage
+			divide = 100
+		}
+	}
+}
+
+marshal_manage_guards_max_consulted_house_bonus = {
+	if = {
+		limit = { councillor_liege_has_consulted_house_bonus = yes }
+		add = marshal_overtime_boost_base
+		multiply = {
+			add = consulted_house_councillors_percentage
+			divide = 100
+		}
+	}
+}
+
+marshal_overtime_boost_max = {
+	add = marshal_overtime_boost_base
+	add = marshal_manage_guards_max_erudition_bonus
+	add = marshal_manage_guards_max_family_business_bonus
+	add = marshal_manage_guards_max_consulted_house_bonus
+}
+
+marshal_overtime_boost_scale = {
+	value = 0
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				is_ai = yes
+				top_liege = this
+			}
+		}
+		add = marshal_overtime_boost_max
+	}
+	else_if = {
+		limit = {
+			scope:councillor_liege = { has_variable = marshal_overtime_boost }
+		}
+		add = liege.var:marshal_overtime_boost
+	}
+}
+
+marshal_overtime_decrease_base = {
+	subtract = martial
+	multiply = 2
+	floor = yes
+	min = -40
+}
+
+marshal_overtime_decrease_max = {
+	add = marshal_overtime_decrease_base
+	subtract = marshal_manage_guards_max_erudition_bonus
+	subtract = marshal_manage_guards_max_family_business_bonus
+	subtract = marshal_manage_guards_max_consulted_house_bonus
+}
+
+marshal_overtime_decrease_scale = {
+	value = 0
+	if = {
+		limit = {
+			scope:councillor_liege = {
+				is_ai = yes
+				top_liege = this
+			}
+		}
+		add = marshal_overtime_decrease_max
+	}
+	else_if = {
+		limit = {
+			scope:councillor_liege = { has_variable = marshal_overtime_boost }
+		}
+		add = liege.var:marshal_overtime_decrease
+	}
+	multiply = -1
+}
+
+### Reliable House modifier
+marshal_reliable_house_scale = {
+	value = 0
+	if = {
+		limit = {
+			exists = liege.dynasty
+			liege.dynasty = { has_dynasty_perk = fp2_coterie_legacy_2 }
+			house = liege.house
+		}
+		add = martial
+		multiply = {
+			add = council_reliable_house_percentage
+			divide = 100
+		}
+		floor = yes
+		min = 1
+	}
+}

--- a/common/script_values/99_marshal_values.txt
+++ b/common/script_values/99_marshal_values.txt
@@ -605,7 +605,7 @@ marshal_overtime_boost_scale = {
 		limit = {
 			scope:councillor_liege = { has_variable = marshal_overtime_boost }
 		}
-		add = liege.var:marshal_overtime_boost
+		add = scope:councillor_liege.var:marshal_overtime_boost #Unop the variable is stored on the council owner (scope:councillor_liege), not on the owner's own liege
 	}
 }
 
@@ -636,9 +636,9 @@ marshal_overtime_decrease_scale = {
 	}
 	else_if = {
 		limit = {
-			scope:councillor_liege = { has_variable = marshal_overtime_boost }
+			scope:councillor_liege = { has_variable = marshal_overtime_decrease } #Unop guard on the variable actually read below (was marshal_overtime_boost, a copy-paste error)
 		}
-		add = liege.var:marshal_overtime_decrease
+		add = scope:councillor_liege.var:marshal_overtime_decrease #Unop the variable is stored on the council owner (scope:councillor_liege), not on the owner's own liege
 	}
 	multiply = -1
 }


### PR DESCRIPTION
Fixes #593

**fixer:** Both `marshal_overtime_boost_scale` and `marshal_overtime_decrease_scale` are consumed in `council_owner_modifier` blocks of `task_manage_guards`, where root = the council owner. The overtime variables are stored on the council owner (= `scope:councillor_liege`), but the scales read them via `liege` — the owner's *own* liege, a different character with no such variable — so the ramp was read as 0.

Two fixes:
- **Wrong scope (both scales):** `add = liege.var:marshal_overtime_boost` / `...decrease` → `add = scope:councillor_liege.var:...`, matching the `else_if` guards that already test `scope:councillor_liege`.
- **Wrong variable (decrease scale):** its `else_if` guarded on `has_variable = marshal_overtime_boost` but adds `marshal_overtime_decrease` — a copy-paste error. Guard now tests `marshal_overtime_decrease`.

Adds `99_marshal_values.txt` as a new vanilla override (unmodified in the first commit, fix in the second). tiger clean. Vanilla bug.