### PR TITLE
Fix accolade successor loop from low-prowess existing knights

### DIFF
--- a/common/scripted_effects/00_accolades_scripted_effects.txt
+++ b/common/scripted_effects/00_accolades_scripted_effects.txt
@@ -1,0 +1,10511 @@
+﻿##################################################
+# Accolade Effects
+
+accolades_development_growth_for_least_developed_county_effect = {
+	# First, should this apply at all?
+	if = {
+		limit = {
+			# Do you have a knight with this accolade at all?
+			any_active_accolade = {
+				OR = {
+					has_accolade_parameter = accolade_development_growth_on_tournament_completion_low
+					has_accolade_parameter = accolade_development_growth_on_tournament_completion_high
+				}
+			}
+			# Plus, pre-filter out landless rulers.
+			is_landed_or_landless_administrative = yes
+		}
+		# Now, find our least developed county.
+		ordered_held_title = {
+			title_tier = county
+			order_by = {
+				value = development_level
+				multiply = -1
+			}
+			save_scope_as = least_developed_county
+		}
+		# Next, we'll need to apply a bonus to it.
+		## Low boost.
+		if = {
+			limit = {
+				any_active_accolade = {
+					accolade_parameter = accolade_development_growth_on_tournament_completion_low
+				}
+			}
+			scope:least_developed_county = { change_development_progress_with_overflow = accolade_development_growth_on_tournament_completion_value }
+		}
+		## High boost.
+		if = {
+			limit = {
+				any_active_accolade = {
+					accolade_parameter = accolade_development_growth_on_tournament_completion_high
+				}
+			}
+			scope:least_developed_county = { change_development_level = accolade_development_level_on_tournament_completion_value }
+		}
+	}
+}
+
+accolades_contender_tournament_xp_gain_effect = {
+	custom_tooltip = accolade_tournament_xp_gain_contender_only.tt
+	hidden_effect = {
+		if = {
+			limit = {
+				NOT = { has_trait = tourney_participant }
+			}
+			add_trait = tourney_participant
+		}
+	}
+	# Low level bonus
+	if = {
+		limit = {
+			accolade = {
+				has_accolade_parameter = accolade_tournament_xp_gain_contender_only_low
+			}
+		}
+		
+		hidden_effect = {
+			random_list = {
+				10 = {
+					show_chance = no
+					add_trait_xp = {
+						trait = tourney_participant
+						track = foot
+						value = accolade_contender_trait_xp_low_value
+					}
+				}
+				10 = {
+					show_chance = no
+					add_trait_xp = {
+						trait = tourney_participant
+						track = horse
+						value = accolade_contender_trait_xp_low_value
+					}
+				}
+				10 = {
+					show_chance = no
+					add_trait_xp = {
+						trait = tourney_participant
+						track = bow
+						value = accolade_contender_trait_xp_low_value
+					}
+				}
+				10 = {
+					show_chance = no
+					add_trait_xp = {
+						trait = tourney_participant
+						track = wit
+						value = accolade_contender_trait_xp_low_value
+					}
+				}
+			}
+		}
+	}
+	# Mid level bonus
+	else_if = {
+		limit = {
+			accolade = {
+				has_accolade_parameter = accolade_tournament_xp_gain_contender_only
+			}
+		}
+		hidden_effect = {
+			random_list = {
+				10 = {
+					add_trait_xp = {
+						trait = tourney_participant
+						track = foot
+						value = accolade_contender_trait_xp_medium_value
+					}
+				}
+				10 = {
+					add_trait_xp = {
+						trait = tourney_participant
+						track = horse
+						value = accolade_contender_trait_xp_medium_value
+					}
+				}
+				10 = {
+					add_trait_xp = {
+						trait = tourney_participant
+						track = bow
+						value = accolade_contender_trait_xp_medium_value
+					}
+				}
+				10 = {
+					add_trait_xp = {
+						trait = tourney_participant
+						track = wit
+						value = accolade_contender_trait_xp_medium_value
+					}
+				}
+			}
+		}
+	}
+	# High level bonus
+	else_if = {
+		limit = {
+			accolade = {
+				has_accolade_parameter = accolade_tournament_xp_gain_contender_only_high
+			}
+		}
+		hidden_effect = {
+			random_list = {
+				10 = {
+					add_trait_xp = {
+						trait = tourney_participant
+						track = foot
+						value = accolade_contender_trait_xp_high_value
+					}
+				}
+				10 = {
+					add_trait_xp = {
+						trait = tourney_participant
+						track = horse
+						value = accolade_contender_trait_xp_high_value
+					}
+				}
+				10 = {
+					add_trait_xp = {
+						trait = tourney_participant
+						track = bow
+						value = accolade_contender_trait_xp_high_value
+					}
+				}
+				10 = {
+					add_trait_xp = {
+						trait = tourney_participant
+						track = wit
+						value = accolade_contender_trait_xp_high_value
+					}
+				}
+			}
+		}
+	}
+}
+
+accolades_all_knights_liege_tournament_xp_gain_effect = {
+	custom_tooltip = accolade_tournament_xp_gain_all_knights.tt
+	hidden_effect = {
+		if = {
+			limit = {
+				NOT = { has_trait = tourney_participant }
+			}
+			add_trait = tourney_participant
+		}
+	}
+	# low bonus
+	if = {
+		limit = {
+			liege = {
+				any_active_accolade = {
+					accolade_parameter = accolade_tournament_xp_gain_all_knights
+				}
+			}
+		}
+		hidden_effect = {
+			random_list = {
+				10 = {
+					modifier = { 
+						add = 20
+						has_trait_xp = {
+							trait = tourney_participant
+							track = foot
+							value = 30
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						track = foot
+						value = accolade_all_knights_trait_xp_low_value
+					}
+				}
+				10 = {
+					modifier = { 
+						add = 20
+						has_trait_xp = {
+							trait = tourney_participant
+							track = horse
+							value = 30
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						track = horse
+						value = accolade_all_knights_trait_xp_low_value
+					}
+				}
+				10 = {
+					modifier = { 
+						add = 20
+						has_trait_xp = {
+							trait = tourney_participant
+							track = bow
+							value = 30
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						track = bow
+						value = accolade_all_knights_trait_xp_low_value
+					}
+				}
+				10 = {
+					modifier = { 
+						add = 20
+						has_trait_xp = {
+							trait = tourney_participant
+							track = wit
+							value = 30
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						track = wit
+						value = accolade_all_knights_trait_xp_low_value
+					}
+				}
+			}
+		}
+	}
+	# high bonus
+	else_if = {
+		limit = {
+			liege = {
+				any_active_accolade = {
+					accolade_parameter = accolade_tournament_xp_gain_all_knights_high
+				}
+			}
+		}
+		hidden_effect = {
+			random_list = {
+				10 = {
+					modifier = { 
+						add = 20
+						has_trait_xp = {
+							trait = tourney_participant
+							track = foot
+							value = 30
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						track = foot
+						value = accolade_all_knights_trait_xp_high_value
+					}
+				}
+				10 = {
+					modifier = { 
+						add = 20
+						has_trait_xp = {
+							trait = tourney_participant
+							track = horse
+							value = 30
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						track = horse
+						value = accolade_all_knights_trait_xp_high_value
+					}
+				}
+				10 = {
+					modifier = { 
+						add = 20
+						has_trait_xp = {
+							trait = tourney_participant
+							track = bow
+							value = 30
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						track = bow
+						value = accolade_all_knights_trait_xp_high_value
+					}
+				}
+				10 = {
+					modifier = { 
+						add = 20
+						has_trait_xp = {
+							trait = tourney_participant
+							track = wit
+							value = 30
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						track = wit
+						value = accolade_all_knights_trait_xp_high_value
+					}
+				}
+			}
+		}
+	}
+}
+
+#GLORY GAIN FOR TOURS
+# used in disburse_tour_activity_rewards on scope:host
+accolades_activity_complete_tour_glory_effect = {
+	if = {
+		limit = {
+			scope:activity = {
+				any_attending_character = {
+					is_acclaimed = yes
+				}
+			}
+		}
+		save_scope_as = accolade_owner
+		scope:activity = {
+			add_activity_log_entry = {
+				key = liege_accolades_glory_reward_tour
+				tags = { completed }
+				score = 10
+				show_in_conclusion = no
+				character = scope:accolade_owner
+				scope:host = {
+					every_acclaimed_knight = {
+						limit = {
+							involved_activity = scope:activity
+						}
+						accolade = {
+							add_glory = {
+								value = minimal_glory_gain
+								if = {
+									limit = {
+										acclaimed_knight = {
+											is_knight_of = scope:host
+										}
+									}
+									add = major_glory_gain
+								}
+								if = {
+									limit = {
+										scope:activity = {
+											variable_list_size = {
+												name = tour_vassals_to_visit
+												value >= activity_tour_high_stop_value
+											}
+										}
+									}
+									add = major_glory_gain
+								}
+								else_if = {
+									limit = {
+										scope:activity = {
+											variable_list_size = {
+												name = tour_vassals_to_visit
+												value >= activity_tour_low_stop_value
+											}
+										}
+									}
+									add = medium_glory_value
+								}
+								if = {
+									limit = {
+										has_accolade_type = reeve_attribute
+									}
+									add = sub_minimal_glory_gain
+								}
+							}
+						}
+					}
+				}
+			}
+			every_attending_character = {
+				limit = {
+					is_acclaimed = yes
+					this != scope:host
+					NOT = {
+						is_knight_of = scope:host
+					}
+				}
+				save_scope_as = acclaimed_knight
+				scope:activity = {
+					add_activity_log_entry = {
+						key = knight_accolade_glory_reward
+						tags = { completed }
+						score = 10
+						show_in_conclusion = no
+						character = scope:acclaimed_knight
+						scope:acclaimed_knight = {
+							accolade = {
+								add_glory = {
+									value = minimal_glory_gain
+									if = {
+										limit = {
+											accolade_owner.involved_activity ?= scope:activity
+										}
+										add = medium_glory_gain
+									}
+									if = {
+										limit = {
+											scope:activity = {
+												variable_list_size = {
+													name = tour_vassals_to_visit
+													value >= activity_tour_high_stop_value
+												}
+											}
+										}
+										add = major_glory_gain
+									}
+									else_if = {
+										limit = {
+											scope:activity = {
+												variable_list_size = {
+													name = tour_vassals_to_visit
+													value >= activity_tour_low_stop_value
+												}
+											}
+										}
+										add = medium_glory_value
+									}
+									if = {
+										limit = {
+											has_accolade_type = reeve_attribute
+										}
+										add = sub_minimal_glory_gain
+									}
+								}
+							}
+						}
+					}
+				}
+				clear_saved_scope = acclaimed_knight
+			}
+		}
+	}
+}
+
+#GLORY GAIN FOR HUNTS
+# used in disburse_hunt_activity_rewards on scope:host
+accolades_activity_complete_hunt_glory_effect = {
+	# Glory management.
+	## We want to toss out a little glory when knights go hunting
+	if = {
+		limit = {
+			scope:activity = {
+				any_attending_character = {
+					is_acclaimed = yes
+				}
+			}
+		}
+		save_scope_as = accolade_owner
+		scope:activity = {
+			add_activity_log_entry = {
+				key = liege_accolades_glory_reward
+				tags = { completed }
+				score = 10
+				show_in_conclusion = yes
+				character = scope:accolade_owner
+				scope:host = {
+					every_acclaimed_knight = {
+						limit = {
+							involved_activity = scope:activity
+						}
+						accolade = {
+							add_glory = {
+								value = 20
+								multiply = hunt_prestige_animal_level_value
+								if = {
+									limit = { scope:activity.var:hunt_success = flag:no }
+									divide = 5
+								}
+								add = major_glory_gain #for being the host's acclaimed knight
+								if = {
+									limit = {
+										scope:animal_slayer ?= acclaimed_knight
+									}
+									add = massive_glory_value
+								}
+								if = {
+									limit = {
+										has_accolade_type = huntsmaster_attribute
+									}
+									add = sub_minimal_glory_gain
+								}
+							}
+						}
+					}
+				}
+			}
+			every_attending_character = {
+				limit = {
+					is_acclaimed = yes
+					this != scope:host
+					NOT = {
+						is_knight_of = scope:host
+					}
+				}
+				save_scope_as = acclaimed_knight
+				scope:activity = {
+					add_activity_log_entry = {
+						key = knight_accolade_glory_reward
+						tags = { completed }
+						score = 10
+						show_in_conclusion = no
+						character = scope:acclaimed_knight
+						scope:acclaimed_knight = {
+							accolade = {
+								add_glory = {
+									value = 20
+									multiply = hunt_prestige_animal_level_value
+									if = {
+										limit = { scope:activity.var:hunt_success = flag:no }
+										divide = 5
+									}
+									if = {
+										limit = {
+											accolade_owner.involved_activity ?= scope:activity
+										}
+										add = minor_glory_gain
+									}
+									if = {
+										limit = {
+											scope:animal_slayer ?= acclaimed_knight
+										}
+										add = massive_glory_value
+									}
+									if = {
+										limit = {
+											has_accolade_type = huntsmaster_attribute
+										}
+										add = sub_minimal_glory_gain
+									}
+								}
+							}
+						}
+					}
+				}
+				clear_saved_scope = acclaimed_knight
+			}
+		}
+	}
+}
+
+#GLORY GAIN FOR WEDDINGS
+accolades_activity_complete_wedding_glory_effect = {
+	# Much glory if you did a magnificent wedding
+	if = {
+		limit = {
+			scope:activity = {
+				any_attending_character = {
+					is_acclaimed = yes
+				}
+			}
+		}
+		save_scope_as = accolade_owner
+		scope:activity = {
+			add_activity_log_entry = {
+				key = liege_accolades_glory_reward
+				tags = { completed }
+				score = 10
+				# this line below adds the entry to the Effects section of the conclusion UI
+				show_in_conclusion = yes
+				character = scope:accolade_owner
+				scope:host = {
+					every_acclaimed_knight = {
+						limit = {
+							involved_activity = scope:activity
+						}
+						accolade = {
+							add_glory = {
+								value = major_glory_gain
+								if = {
+									limit = {
+										acclaimed_knight = {
+											OR = {
+												this = scope:spouse_1
+												this = scope:spouse_2
+											}
+										}
+									}
+									add = massive_glory_value
+								}
+								if = {
+									limit = {
+										scope:activity = {
+											# perfect options
+											has_activity_option = {
+												category = wedding_option_entertainment
+												option = wedding_entertainment_good
+											}
+											has_activity_option = {
+												category = wedding_option_food
+												option = wedding_food_good
+											}
+											has_activity_option = {
+												category = wedding_option_decoration
+												option = wedding_decoration_good
+											}
+										}
+									}
+									add = major_glory_gain
+								}
+								else_if = {
+									limit = {
+										scope:activity = {
+											OR = {
+												AND = {
+													# at least two tier threes
+													has_activity_option = {
+														category = wedding_option_entertainment
+														option = wedding_entertainment_good
+													}
+													has_activity_option = {
+														category = wedding_option_food
+														option = wedding_food_good
+													}
+												}
+												AND = {
+													has_activity_option = {
+														category = wedding_option_entertainment
+														option = wedding_entertainment_good
+													}
+													has_activity_option = {
+														category = wedding_option_decoration
+														option = wedding_decoration_good
+													}
+												}
+												AND = {
+													has_activity_option = {
+														category = wedding_option_decoration
+														option = wedding_decoration_good
+													}
+													has_activity_option = {
+														category = wedding_option_food
+														option = wedding_food_good
+													}
+												}
+												# a tier 3 and two tier 2s
+												AND = {
+													has_activity_option = {
+														category = wedding_option_entertainment
+														option = wedding_entertainment_good
+													}
+													has_activity_option = {
+														category = wedding_option_food
+														option = wedding_food_normal
+													}
+													has_activity_option = {
+														category = wedding_option_decoration
+														option = wedding_decoration_normal
+													}
+												}
+												AND = {
+													has_activity_option = {
+														category = wedding_option_food
+														option = wedding_food_good
+													}
+													has_activity_option = {
+														category = wedding_option_entertainment
+														option = wedding_entertainment_normal
+													}
+													has_activity_option = {
+														category = wedding_option_decoration
+														option = wedding_decoration_normal
+													}
+												}
+												AND = {
+													has_activity_option = {
+														category = wedding_option_decoration
+														option = wedding_decoration_good
+													}
+													has_activity_option = {
+														category = wedding_option_entertainment
+														option = wedding_entertainment_normal
+													}
+													has_activity_option = {
+														category = wedding_option_food
+														option = wedding_food_normal
+													}
+												}
+											}
+										}
+									}
+									add = medium_glory_value
+								}
+								else_if = {
+									limit = {
+										scope:activity = {
+											# 1 tier 3 option
+											OR = {
+												has_activity_option = {
+													category = wedding_option_entertainment
+													option = wedding_entertainment_good
+												}
+												has_activity_option = {
+													category = wedding_option_food
+													option = wedding_food_good
+												}
+												has_activity_option = {
+													category = wedding_option_decoration
+													option = wedding_decoration_good
+												}
+												# 2 tier 2 options
+												AND = {
+													has_activity_option = {
+														category = wedding_option_entertainment
+														option = wedding_entertainment_normal
+													}
+													has_activity_option = {
+														category = wedding_option_food
+														option = wedding_food_normal
+													}
+												}
+												AND = {
+													has_activity_option = {
+														category = wedding_option_entertainment
+														option = wedding_entertainment_normal
+													}
+													has_activity_option = {
+														category = wedding_option_decoration
+														option = wedding_decoration_normal
+													}
+												}
+												AND = {
+													has_activity_option = {
+														category = wedding_option_decoration
+														option = wedding_decoration_normal
+													}
+													has_activity_option = {
+														category = wedding_option_food
+														option = wedding_food_normal
+													}
+												}
+											}
+										}
+									}
+									add = minimal_glory_value
+								}
+								if = {
+									limit = {
+										has_accolade_type = politicker_attribute
+									}
+									add = sub_minimal_glory_gain
+								}
+							}
+						}
+					}
+				}
+			}
+			every_attending_character = {
+				limit = {
+					is_acclaimed = yes
+					this != scope:host
+					NOT = {
+						is_knight_of = scope:host
+					}
+				}
+				save_scope_as = acclaimed_knight
+				scope:activity = {
+					add_activity_log_entry = {
+						key = knight_accolade_glory_reward
+						tags = { completed }
+						score = 10
+						show_in_conclusion = no
+						character = scope:acclaimed_knight
+						scope:acclaimed_knight = {
+							accolade = {
+								add_glory = {
+									value = minimal_glory_gain
+									if = {
+										limit = {
+											accolade_owner.involved_activity ?= scope:activity
+										}
+										add = major_glory_gain
+									}
+									if = {
+										limit = {
+											accolade_owner = {
+												OR = {
+													this = scope:host
+													this = scope:spouse_1
+													this = scope:spouse_2
+												}
+											}
+										}
+										add = massive_glory_value
+									}
+									if = {
+										limit = {
+											acclaimed_knight = {
+												OR = {
+													this = scope:host
+													this = scope:spouse_1
+													this = scope:spouse_2
+												}
+											}
+										}
+										add = massive_glory_value
+									}
+									if = {
+										limit = {
+											scope:activity = {
+												# perfect options
+												has_activity_option = {
+													category = wedding_option_entertainment
+													option = wedding_entertainment_good
+												}
+												has_activity_option = {
+													category = wedding_option_food
+													option = wedding_food_good
+												}
+												has_activity_option = {
+													category = wedding_option_decoration
+													option = wedding_decoration_good
+												}
+											}
+										}
+										add = major_glory_gain
+									}
+									else_if = {
+										limit = {
+											scope:activity = {
+												OR = {
+													AND = {
+														# at least two tier threes
+														has_activity_option = {
+															category = wedding_option_entertainment
+															option = wedding_entertainment_good
+														}
+														has_activity_option = {
+															category = wedding_option_food
+															option = wedding_food_good
+														}
+													}
+													AND = {
+														has_activity_option = {
+															category = wedding_option_entertainment
+															option = wedding_entertainment_good
+														}
+														has_activity_option = {
+															category = wedding_option_decoration
+															option = wedding_decoration_good
+														}
+													}
+													AND = {
+														has_activity_option = {
+															category = wedding_option_decoration
+															option = wedding_decoration_good
+														}
+														has_activity_option = {
+															category = wedding_option_food
+															option = wedding_food_good
+														}
+													}
+													# a tier 3 and two tier 2s
+													AND = {
+														has_activity_option = {
+															category = wedding_option_entertainment
+															option = wedding_entertainment_good
+														}
+														has_activity_option = {
+															category = wedding_option_food
+															option = wedding_food_normal
+														}
+														has_activity_option = {
+															category = wedding_option_decoration
+															option = wedding_decoration_normal
+														}
+													}
+													AND = {
+														has_activity_option = {
+															category = wedding_option_food
+															option = wedding_food_good
+														}
+														has_activity_option = {
+															category = wedding_option_entertainment
+															option = wedding_entertainment_normal
+														}
+														has_activity_option = {
+															category = wedding_option_decoration
+															option = wedding_decoration_normal
+														}
+													}
+													AND = {
+														has_activity_option = {
+															category = wedding_option_decoration
+															option = wedding_decoration_good
+														}
+														has_activity_option = {
+															category = wedding_option_entertainment
+															option = wedding_entertainment_normal
+														}
+														has_activity_option = {
+															category = wedding_option_food
+															option = wedding_food_normal
+														}
+													}
+												}
+											}
+										}
+										add = medium_glory_value
+									}
+									else_if = {
+										limit = {
+											scope:activity = {
+												# 1 tier 3 option
+												OR = {
+													has_activity_option = {
+														category = wedding_option_entertainment
+														option = wedding_entertainment_good
+													}
+													has_activity_option = {
+														category = wedding_option_food
+														option = wedding_food_good
+													}
+													has_activity_option = {
+														category = wedding_option_decoration
+														option = wedding_decoration_good
+													}
+													# 2 tier 2 options
+													AND = {
+														has_activity_option = {
+															category = wedding_option_entertainment
+															option = wedding_entertainment_normal
+														}
+														has_activity_option = {
+															category = wedding_option_food
+															option = wedding_food_normal
+														}
+													}
+													AND = {
+														has_activity_option = {
+															category = wedding_option_entertainment
+															option = wedding_entertainment_normal
+														}
+														has_activity_option = {
+															category = wedding_option_decoration
+															option = wedding_decoration_normal
+														}
+													}
+													AND = {
+														has_activity_option = {
+															category = wedding_option_decoration
+															option = wedding_decoration_normal
+														}
+														has_activity_option = {
+															category = wedding_option_food
+															option = wedding_food_normal
+														}
+													}
+												}
+											}
+										}
+										add = minimal_glory_value
+									}
+									if = {
+										limit = {
+											has_accolade_type = politicker_attribute
+										}
+										add = sub_minimal_glory_gain
+									}
+								}
+							}
+						}
+					}
+				}
+				clear_saved_scope = acclaimed_knight
+			}
+		}
+	}
+}
+
+#GLORY GAIN FOR FEASTS
+accolades_activity_complete_feast_glory_effect = {
+	if = {
+		limit = {
+			scope:activity = {
+				any_attending_character = {
+					is_acclaimed = yes
+				}
+			}
+		}
+		save_scope_as = accolade_owner
+		if = {
+			limit = {
+				scope:activity.special_guest:honorary_guest_regular ?= {
+					is_acclaimed = yes
+				}
+			}
+			scope:activity.special_guest:honorary_guest_regular ?= {
+				save_scope_as = honorary_guest_knight
+			}
+		}
+		# Decent glory if the acclaimed knight attends a grand-ass feast without liege
+		scope:activity = {
+			add_activity_log_entry = {
+				key = liege_accolades_glory_reward
+				tags = { completed }
+				score = 10
+				# this line below adds the entry to the Effects section of the conclusion UI
+				show_in_conclusion = yes
+				character = scope:accolade_owner
+				scope:host = {
+					every_acclaimed_knight = {
+						limit = {
+							involved_activity = scope:activity
+						}
+						accolade = {
+							add_glory = {
+								value = major_glory_gain
+								if = {
+									limit = {
+										scope:honorary_guest_knight ?= acclaimed_knight
+									}
+									add = major_glory_gain
+								}
+								if = {
+									limit = {
+										has_accolade_type = master_of_revels_attribute
+									}
+									add = sub_minimal_glory_gain
+								}
+								if = {
+									limit = {
+										scope:activity = {
+											has_activity_option = {
+												category = feast_option_food
+												option = feast_food_good
+											}
+											has_activity_option = {
+												category = feast_option_courses
+												option = feast_courses_good
+											}
+										}
+									}
+									add = minor_glory_value
+								}
+								else_if = {
+									limit = {
+										scope:activity = {
+											OR = {
+												has_activity_option = {
+													category = feast_option_food
+													option = feast_food_good
+												}
+												has_activity_option = {
+													category = feast_option_food
+													option = feast_food_normal
+												}
+											}
+											OR = {
+												has_activity_option = {
+													category = feast_option_courses
+													option = feast_courses_good
+												}
+												has_activity_option = {
+													category = feast_option_courses
+													option = feast_courses_normal
+												}
+											}
+										}
+									}
+									add = minimal_glory_gain
+								}
+							}
+						}
+					}
+				}
+			}
+			every_attending_character = {
+				limit = {
+					is_acclaimed = yes
+					this != scope:host
+					NOT = {
+						is_knight_of = scope:host
+					}
+				}
+				save_scope_as = acclaimed_knight
+				scope:activity = {
+					add_activity_log_entry = {
+						key = knight_accolade_glory_reward
+						tags = { completed }
+						score = 10
+						show_in_conclusion = no
+						character = scope:acclaimed_knight
+						scope:acclaimed_knight = {
+							accolade = {
+								add_glory = {
+									value = minor_glory_gain
+									if = {
+										limit = {
+											scope:honorary_guest_knight ?= acclaimed_knight
+										}
+										add = major_glory_gain
+									}
+									if = {
+										limit = {
+											accolade_owner.involved_activity ?= scope:activity
+										}
+										add = medium_glory_value
+									}
+									if = {
+										limit = {
+											has_accolade_type = master_of_revels_attribute
+										}
+										add = sub_minimal_glory_gain
+									}
+									if = {
+										limit = {
+											scope:activity = {
+												has_activity_option = {
+													category = feast_option_food
+													option = feast_food_good
+												}
+												has_activity_option = {
+													category = feast_option_courses
+													option = feast_courses_good
+												}
+											}
+										}
+										add = minor_glory_value
+									}
+									else_if = {
+										limit = {
+											scope:activity = {
+												OR = {
+													has_activity_option = {
+														category = feast_option_food
+														option = feast_food_good
+													}
+													has_activity_option = {
+														category = feast_option_food
+														option = feast_food_normal
+													}
+												}
+												OR = {
+													has_activity_option = {
+														category = feast_option_courses
+														option = feast_courses_good
+													}
+													has_activity_option = {
+														category = feast_option_courses
+														option = feast_courses_normal
+													}
+												}
+											}
+										}
+										add = minimal_glory_gain
+									}
+								}
+							}
+						}
+					}
+				}
+				clear_saved_scope = acclaimed_knight
+			}
+		}
+	}
+}
+
+#GLORY GAIN FOR CORONATION
+accolades_activity_complete_coronation_glory_effect = {
+	if = {
+		limit = {
+			scope:activity = {
+				any_attending_character = {
+					is_acclaimed = yes
+				}
+			}
+		}
+		save_scope_as = accolade_owner
+		# Decent glory if the acclaimed knight attends a grand-ass feast without liege
+		scope:activity = {
+			add_activity_log_entry = {
+				key = liege_accolades_glory_reward
+				tags = { completed }
+				score = 10
+				# this line below adds the entry to the Effects section of the conclusion UI
+				show_in_conclusion = yes
+				character = scope:accolade_owner
+				scope:host = {
+					every_acclaimed_knight = {
+						limit = {
+							involved_activity = scope:activity
+						}
+						accolade = {
+							add_glory = {
+								value = medium_glory_gain
+								add = {
+									value = scope:activity.var:activity_special_type_progression
+									multiply = 1.5
+								}
+								if = {
+									limit = {
+										has_accolade_type = politicker_attribute
+									}
+									add = sub_minimal_glory_gain
+								}
+							}
+						}
+					}
+				}
+			}
+			every_attending_character = {
+				limit = {
+					is_acclaimed = yes
+					this != scope:host
+					NOT = {
+						is_knight_of = scope:host
+					}
+				}
+				save_scope_as = acclaimed_knight
+				scope:activity = {
+					add_activity_log_entry = {
+						key = knight_accolade_glory_reward
+						tags = { completed }
+						score = 10
+						show_in_conclusion = no
+						character = scope:acclaimed_knight
+						scope:acclaimed_knight = {
+							accolade = {
+								add_glory = {
+									value = medium_glory_gain
+									add = {
+										value = scope:activity.var:activity_special_type_progression
+										multiply = 1.5
+									}
+									if = {
+										limit = {
+											has_accolade_type = politicker_attribute
+										}
+										add = sub_minimal_glory_gain
+									}
+								}
+							}
+						}
+					}
+				}
+				clear_saved_scope = acclaimed_knight
+			}
+		}
+	}
+}
+
+#Glory Gain from winning wars against THE BIG BAD
+# little wars when the attacker wins
+accolade_attacker_war_end_glory_gain_low_effect = {
+	if = {
+		limit = {
+			has_dlc_feature = accolades
+		}
+		if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value <= -3
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = medium_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value = -2
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = minor_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value = -1
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = minimal_glory_gain
+			}
+		}
+	}
+}
+
+# little wars when the defender wins
+accolade_defender_war_end_glory_gain_low_effect = {
+	if = {
+		limit = {
+			has_dlc_feature = accolades
+		}
+		if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value <= -3
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = medium_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value = -2
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = minor_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value = -1
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = minimal_glory_gain
+			}
+		}
+	}
+}
+
+# duchy-type wars when the attacker wins
+accolade_attacker_war_end_glory_gain_med_effect = {
+	if = {
+		limit = {
+			has_dlc_feature = accolades
+		}
+		if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value <= -3
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = major_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value = -2
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = medium_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value = -1
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = minor_glory_gain
+			}
+		}
+	}
+}	
+
+# duchy-type wars when the defender wins
+accolade_defender_war_end_glory_gain_med_effect = {
+	if = {
+		limit = {
+			has_dlc_feature = accolades
+		}
+		if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value <= -3
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = major_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value = -2
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = medium_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value = -1
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = minor_glory_gain
+			}
+		}
+	}
+}
+
+# KINGDOM-type wars when the attacker wins
+accolade_attacker_war_end_glory_gain_high_effect = {
+	if = {
+		limit = {
+			has_dlc_feature = accolades
+		}
+		if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value <= -3
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = massive_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value = -2
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = major_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value = -1
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = medium_glory_gain
+			}
+		}
+	}
+}
+
+# KINGDOM-type wars when the defender wins
+accolade_defender_war_end_glory_gain_high_effect = {
+	if = {
+		limit = {
+			has_dlc_feature = accolades
+		}
+		if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value <= -3
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = massive_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value = -2
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = major_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value = -1
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = medium_glory_gain
+			}
+		}
+	}
+}
+
+# EMPIRE-type wars when the attacker wins
+accolade_attacker_war_end_glory_gain_very_high_effect = {
+	if = {
+		limit = {
+			has_dlc_feature = accolades
+		}
+		if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value <= -3
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = monumental_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value = -2
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = massive_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:defender
+					value = -1
+				}
+			}
+			every_active_accolade = {
+				custom = custom.attacker_every_active_accolade
+				add_glory = major_glory_gain
+			}
+		}
+	}
+}
+
+# EMPIRE-type wars when the defender wins
+accolade_defender_war_end_glory_gain_very_high_effect = {
+	if = {
+		limit = {
+			has_dlc_feature = accolades
+		}
+		if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value <= -3
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = monumental_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value = -2
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = massive_glory_gain
+			}
+		}
+		else_if = {
+			limit = {
+				tier_difference = {
+					target = scope:attacker
+					value = -1
+				}
+			}
+			every_active_accolade = {
+				custom = custom.defender_every_active_accolade
+				add_glory = major_glory_gain
+			}
+		}
+	}
+}
+
+#Add glory with accolade checks MINIMAL GAIN
+accolade_minimal_glory_gain_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = minimal_glory_gain
+		}
+	}
+}
+#Add glory with accolade checks MINOR GAIN
+accolade_minor_glory_gain_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = minor_glory_gain
+		}
+	}
+}
+#Add glory with accolade checks MEDIUM GAIN
+accolade_medium_glory_gain_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = medium_glory_gain
+		}
+	}
+}
+#Add glory with accolade checks MAJOR GAIN
+accolade_major_glory_gain_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = major_glory_gain
+		}
+	}
+}
+#Add glory with accolade checks MASSIVE GAIN
+accolade_massive_glory_gain_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = massive_glory_gain
+		}
+	}
+}
+
+#Add glory with accolade checks MONUMENTAL GAIN
+accolade_monumental_glory_gain_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = monumental_glory_gain
+		}
+	}
+}
+
+#Add glory with accolade checks MINIMAL LOSS
+accolade_minimal_glory_loss_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = minimal_glory_loss
+		}
+	}
+}
+#Add glory with accolade checks MINOR LOSS
+accolade_minor_glory_loss_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = minor_glory_loss
+		}
+	}
+}
+#Add glory with accolade checks MEDIUM LOSS
+accolade_medium_glory_loss_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = medium_glory_loss
+		}
+	}
+}
+#Add glory with accolade checks MAJOR LOSS
+accolade_major_glory_loss_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = major_glory_loss
+		}
+	}
+}
+#Add glory with accolade checks MASSIVE LOSS
+accolade_massive_glory_loss_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = massive_glory_loss
+		}
+	}
+}
+
+#Add glory with accolade checks MONUMENTAL LOSS
+accolade_monumental_glory_loss_with_checks_effect = {
+	if = {
+		limit = {
+			is_acclaimed = yes
+			is_alive = yes
+		}
+		accolade = {
+			add_glory = monumental_glory_loss
+		}
+	}
+}
+
+# FIND SUITABLE ACCOLADE SUCCESSOR INTERACTION
+#this saves a random culture that's known for its knights and is familiar enough to the accolade_tournament_xp_gain_all_knights
+save_general_accolade_successor_culture_effect = {
+	random_culture_global = {
+		limit = {
+			OR = {
+				has_cultural_pillar = ethos_stoic
+				has_cultural_pillar = ethos_bellicose
+				has_cultural_parameter = wanderers_gain_extra_combat_skills
+				has_cultural_parameter = high_prowess_ignores_knight_restrictions
+				has_cultural_parameter = prowess_from_martial_education
+				has_cultural_parameter = martial_education_more_valued
+				has_cultural_parameter = strong_traits_more_valued
+			}
+			trigger_if = {
+				limit = {
+					scope:owner = {
+						highest_held_title_tier >= tier_duchy
+					}
+					exists = scope:owner.capital_county
+				}
+				any_culture_county = {
+					OR = {
+						holder = {
+							this = scope:owner
+						}
+						holder.liege = {
+							this = scope:owner
+						}
+						holder.top_liege = {
+							this = scope:owner
+						}
+						empire = scope:owner.capital_county.empire
+					}
+				}
+			}
+			trigger_else = {
+				exists = scope:owner.capital_county
+				any_culture_county = {
+					OR = {
+						holder = {
+							this = scope:owner
+						}
+						holder.liege = {
+							this = scope:owner
+						}
+						holder.top_liege = {
+							this = scope:owner
+						}
+						kingdom = scope:owner.capital_county.kingdom
+					}
+				}
+			}
+			culture_number_of_counties > 0
+			cultural_acceptance = {
+				target = scope:owner.culture
+				value >= 15
+			}
+		}
+		save_scope_as = knight_culture
+	}
+}
+
+#this one's just for the varangians
+save_varangian_successor_culture_effect = {
+	if = {
+		limit = {
+			current_date < 1400
+			scope:owner = {
+				has_title = title:e_byzantium
+			}
+		}
+		random_culture_global = {
+			limit = {
+				OR = {
+					has_cultural_parameter = unlock_maa_huscarls
+					has_cultural_parameter = unlock_maa_varangian_veterans
+				}
+				culture_number_of_counties > 0
+				any_culture_duchy = {
+					NOT = {
+						this = title:d_iceland
+					}
+				}
+				NOT = {
+					this = culture:estonian
+				}
+				NAND = {
+					this = culture:anglo_saxon
+					current_date < 1067
+				}
+			}
+			save_scope_as = varangian_culture
+		}
+	}
+}
+
+#this one's just for the varangians
+save_turkic_successor_culture_effect = {
+	if = {
+		limit = {
+			scope:owner = {
+				faith.religion = religion:islam_religion
+				capital_county.title_province ?= {
+   					OR = {
+						geographical_region = world_middle_east
+						geographical_region = world_africa_north_east
+						geographical_region = world_asia_minor
+						geographical_region = world_europe_south_east
+						geographical_region = world_steppe
+					}
+				}
+				culture = {
+					NOT = {
+						culture_has_archer_cavalry_maa = yes
+					}
+				}
+				NOT = { has_trait = nomadic_philosophy }
+				highest_held_title_tier >= tier_kingdom
+			}
+		}
+		random_culture_global = {
+			limit = {
+				culture_has_archer_cavalry_maa = yes
+				has_cultural_pillar = heritage_turkic
+				culture_number_of_counties > 0
+				any_culture_county = {
+					holder = {
+						in_diplomatic_range = scope:owner
+					}
+				}
+			}
+			weight = {
+				modifier = {
+					add = 100
+					any_culture_county = {
+						empire = scope:owner.capital_county.empire
+					}
+				}
+				modifier = {
+					add = 50
+					any_culture_county = {
+						kingdom = scope:owner.capital_county.kingdom
+					}
+				}
+			}
+			save_scope_as = turkic_culture
+		}
+	}
+}
+
+#this saves appropriate cultures for specific accolade types, just need to check for the type along with its relevant cultural triggers
+save_type_specific_successor_culture_effect = {
+	random_culture_global = {
+		limit = {
+			OR = {
+				# Marauder
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:marauder_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_bellicose
+						has_cultural_tradition = tradition_ruling_caste
+						has_cultural_tradition = tradition_eye_for_an_eye
+					}
+				}
+				# Idealist
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:idealist_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_egalitarian
+						has_cultural_tradition = tradition_charitable
+						has_cultural_tradition = tradition_loyal_soldiers
+						has_cultural_tradition = tradition_chivalry
+					}
+				}
+				# Charmer
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:charmer_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_courtly
+						has_cultural_tradition = tradition_welcoming
+					}
+				}
+				# Thug
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:thug_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_bellicose
+						has_cultural_tradition = tradition_battlefield_looters
+						has_cultural_tradition = tradition_ruling_caste
+						has_cultural_tradition = tradition_quarrelsome
+					}
+				}
+				# Disciplinarian
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:disciplinarian_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_stoic
+						has_cultural_pillar = ethos_bureaucratic
+						has_cultural_tradition = tradition_hard_working
+						has_cultural_tradition = tradition_staunch_traditionalists
+						has_cultural_tradition = tradition_formation_fighting
+					}
+				}
+				# Valiant
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:valiant_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_bellicose
+						has_cultural_tradition = tradition_talent_acquisition
+						has_cultural_tradition = tradition_only_the_strong
+						has_cultural_tradition = tradition_stand_and_fight
+						has_cultural_tradition = tradition_warrior_culture
+						has_cultural_tradition = tradition_fp1_performative_honour
+						has_cultural_tradition = tradition_fp1_the_right_to_prove
+					}
+				}
+				# Stalwart
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:stalwart_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_stoic
+						has_cultural_pillar = ethos_communal
+						has_cultural_tradition = tradition_stalwart_defenders
+                        has_cultural_tradition = tradition_stand_and_fight
+                        has_cultural_tradition = tradition_druzhina
+                        has_cultural_tradition = tradition_hird
+                        has_cultural_tradition = tradition_fp1_coastal_warriors
+					}
+					NOT = {
+						has_cultural_tradition = tradition_hit_and_run
+					}
+				}
+				# Scoundrel
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:scoundrel_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_bellicose
+						has_cultural_tradition = tradition_hit_and_run
+                        has_cultural_tradition = tradition_quarrelsome
+                        has_cultural_tradition = tradition_swords_for_hire
+                        has_cultural_tradition = tradition_ep3_audacious_cadets
+                        has_cultural_tradition = tradition_fp1_coastal_warriors
+                        has_cultural_tradition = tradition_fp2_state_ransoming
+                        has_cultural_tradition = tradition_practiced_pirates
+					}
+					NOT = {
+						has_cultural_tradition = tradition_hit_and_run
+					}
+				}
+				# Politicker
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:politicker_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_courtly
+						has_cultural_pillar = ethos_egalitarian
+						has_cultural_parameter = facilitate_alliance_acceptance
+						has_cultural_parameter = can_make_republican_vassals
+						has_cultural_parameter = learns_more_languages
+						has_cultural_parameter = diplomacy_education_better_outcomes
+						has_cultural_parameter = eunuch_trait_bonuses
+					}
+					NOT = {
+						has_cultural_parameter = ai_doesnt_marry_outside_culture
+					}
+				}
+				# Tactician
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:tactician_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_bellicose
+						has_cultural_pillar = ethos_bureaucratic
+						has_cultural_tradition = tradition_adaptive_skirmishing
+						has_cultural_tradition = tradition_formation_fighting
+						has_cultural_parameter = better_knights_from_decision
+						has_cultural_tradition = tradition_hit_and_run
+					}
+				}
+				# Reeve
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:reeve_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_bureaucratic
+						has_cultural_pillar = ethos_egalitarian
+						has_cultural_parameter = martial_education_worse_outcomes
+						has_cultural_parameter = poorly_educated_leaders_distrusted
+						has_cultural_parameter = just_trait_more_common
+						has_cultural_tradition = tradition_hard_working
+					}
+				}
+				# Manipulator
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:manipulator_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_courtly
+						has_cultural_pillar = ethos_communal
+						has_cultural_parameter = eunuch_trait_bonuses
+						has_cultural_parameter = rivalries_more_common
+					}
+					NOR = {
+						has_cultural_tradition = tradition_stand_and_fight
+						has_cultural_parameter = honest_trait_more_common
+					}
+				}
+				# Mentor
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:mentor_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_communal
+						has_cultural_pillar = ethos_spiritual
+						has_cultural_parameter = guardians_can_transfer_commander_traits
+						has_cultural_parameter = generous_trait_more_common
+						has_cultural_parameter = patient_trait_more_common
+						has_cultural_parameter = innovation_from_learning_traits
+						has_cultural_parameter = better_ward_education
+					}
+					NOT = {
+						has_cultural_parameter = minimum_prowess_for_knights
+					}
+				}
+				# Contender
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:contender_attribute
+					}
+					OR = {
+						has_cultural_pillar = ethos_bellicose
+						has_cultural_pillar = ethos_stoic
+						has_cultural_parameter = high_prowess_ignores_knight_restrictions
+						has_cultural_parameter = prowess_from_martial_education
+						has_cultural_parameter = martial_education_more_valued
+						has_cultural_parameter = strong_traits_more_valued
+						has_cultural_parameter = better_knights_from_decision
+						has_cultural_parameter = minimum_prowess_for_knights
+						has_cultural_parameter = has_access_to_trials_by_combat
+					}
+				}
+				# Archer
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:archer_attribute
+					}
+					OR = {
+						has_cultural_pillar = heritage_brythonic
+						has_cultural_pillar = heritage_east_african
+						has_cultural_pillar = heritage_indo_aryan
+						has_cultural_pillar = heritage_dravidian
+						has_cultural_pillar = heritage_burman
+						has_cultural_pillar = heritage_yoruba
+						has_cultural_pillar = heritage_baltic
+						has_cultural_pillar = heritage_balto_finnic
+					}
+				}
+				# Skirmisher
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:skirmisher_attribute
+					}
+					OR = {
+						has_cultural_pillar = heritage_baltic
+						has_cultural_pillar = heritage_ugro_permian
+						has_cultural_pillar = heritage_balto_finnic
+						has_cultural_pillar = heritage_somalian
+						has_cultural_pillar = heritage_west_african
+						has_cultural_pillar = heritage_goidelic
+						has_cultural_pillar = heritage_brythonic
+					}
+				}
+				# Pike
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:pike_attribute
+					}
+					OR = {
+						has_cultural_pillar = heritage_central_germanic
+						has_cultural_pillar = heritage_latin
+					}
+				}
+				# Outrider
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:outrider_attribute
+					}
+					OR = {
+						has_cultural_tradition = tradition_ep3_indomitable_azatani
+						has_cultural_tradition = tradition_desert_ribat
+						has_cultural_tradition = tradition_chanson_de_geste
+						has_cultural_tradition = tradition_hussar
+					}
+					OR = {
+						has_cultural_pillar = heritage_iranian
+						has_cultural_pillar = heritage_turkic
+						has_cultural_pillar = heritage_mongolic
+						has_cultural_pillar = heritage_arabic
+						has_cultural_pillar = heritage_berber
+						has_cultural_pillar = heritage_iberian
+						has_cultural_pillar = heritage_indo_aryan
+						has_cultural_pillar = heritage_magyar
+					}
+				}
+				# Vanguard
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:vanguard_attribute
+					}
+					OR = {
+						has_innovation = innovation_quilted_armor
+						has_cultural_tradition = tradition_fp1_coastal_warriors
+						has_cultural_tradition = tradition_hird
+						has_cultural_tradition = tradition_futuwaa
+						has_cultural_tradition = tradition_druzhina
+						has_cultural_tradition = tradition_khadga_puja
+						has_cultural_tradition = tradition_garuda_warriors
+						has_cultural_tradition = tradition_himalayan_settlers
+						has_cultural_tradition = tradition_mubarizuns
+						has_cultural_tradition = tradition_burman_royal_army
+						has_cultural_tradition = tradition_mountaineer_ruralism
+						has_innovation = innovation_sarawit
+						has_innovation = innovation_legionnaires
+						has_cultural_parameter = unlock_zhanmadao
+						has_cultural_parameter = unlock_burenjia
+					}
+					OR = {
+						has_cultural_pillar = heritage_central_germanic
+						has_cultural_pillar = heritage_north_germanic
+						has_cultural_pillar = heritage_west_germanic
+						has_cultural_pillar = heritage_east_slavic
+						has_cultural_pillar = heritage_burman
+						has_cultural_pillar = heritage_qiangic
+						has_cultural_pillar = heritage_tibetan
+					}
+				}
+				# Lancer
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:lancer_attribute
+					}
+					OR = {
+						has_innovation = innovation_arched_saddle
+						has_cultural_tradition = tradition_caucasian_wolves
+						has_cultural_tradition = tradition_roman_legacy
+						has_innovation = innovation_valets
+						has_cultural_tradition = tradition_ep3_audacious_cadets
+						has_cultural_tradition = tradition_ep3_imperial_tagmata
+						has_cultural_parameter = unlock_maa_cataphract_archers
+						has_innovation = innovation_tiefutu
+						has_cultural_parameter = unlock_maa_black_armor_cavalry
+					}
+					OR = {
+						has_cultural_pillar = heritage_iranian
+						has_cultural_pillar = heritage_turkic
+						has_cultural_pillar = heritage_mongolic
+						has_cultural_pillar = heritage_central_germanic
+						has_cultural_pillar = heritage_frankish
+						has_cultural_pillar = heritage_indo_aryan
+						has_cultural_pillar = heritage_byzantine
+						has_cultural_pillar = heritage_caucasian
+					}
+				}
+				# Besieger
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:besieger_attribute
+					}
+					has_innovation = innovation_mangonel
+					OR = {
+						has_cultural_tradition = tradition_castle_keepers
+						has_cultural_tradition = tradition_hereditary_hierarchy
+						has_cultural_tradition = tradition_hard_working
+						has_cultural_tradition = tradition_swords_for_hire
+						has_cultural_tradition = tradition_ep3_audacious_cadets
+						has_cultural_tradition = tradition_malleable_invaders
+						has_cultural_tradition = tradition_metal_craftsmanship
+					}
+				}
+				# Crossbowman
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:crossbowmen_attribute
+					}
+					OR = {
+						has_innovation = innovation_advanced_bowmaking
+						has_innovation = innovation_repeating_crossbow
+					}
+					OR = {
+						has_cultural_pillar = heritage_chinese
+						has_cultural_pillar = heritage_latin
+						has_cultural_tradition = tradition_swords_for_hire
+					}
+				}
+				# Camel Rider
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:camelry_attribute
+					}
+					has_innovation = innovation_war_camels
+					OR = {
+						has_cultural_pillar = heritage_arabic
+						has_cultural_pillar = heritage_berber
+						has_cultural_tradition = tradition_desert_nomads
+						has_cultural_tradition = tradition_warriors_of_the_dry
+					}
+				}
+				# Elephant Rider
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:elephantry_attribute
+					}
+					has_innovation = innovation_elephantry
+					OR = {
+						has_cultural_pillar = heritage_dravidian
+						has_cultural_pillar = heritage_indo_aryan
+						has_cultural_pillar = heritage_burman
+					}
+				}
+				# Horse Archer
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:horse_archer_attribute
+					}
+					culture_has_archer_cavalry_maa = yes
+					OR = {
+						has_cultural_pillar = heritage_turkic
+						has_cultural_pillar = heritage_mongolic
+						has_cultural_pillar = heritage_burman
+					}
+				}
+				# Huntsmaster
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:huntsmaster_attribute
+					}
+					OR = {
+						has_cultural_tradition = tradition_bush_hunting
+						has_cultural_tradition = tradition_hunters
+						has_cultural_tradition = tradition_sacred_hunts
+						has_cultural_tradition = tradition_forest_fighters
+						has_cultural_tradition = tradition_jungle_warriors
+						has_cultural_tradition = tradition_land_of_the_bow
+						has_cultural_tradition = tradition_bush_hunting
+						has_cultural_tradition = tradition_hunters
+						has_cultural_tradition = tradition_sacred_hunts
+					}
+					NOT = {
+						has_cultural_tradition = tradition_vegetarianism
+					}
+				}
+				# Blademaster
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:blademaster_attribute
+					}
+					OR = {
+						has_cultural_tradition = tradition_druzhina
+						has_cultural_tradition = tradition_futuwaa
+						has_cultural_tradition = tradition_khadga_puja
+						has_cultural_tradition = tradition_talent_acquisition
+						has_cultural_tradition = tradition_swords_for_hire
+						has_cultural_tradition = tradition_warriors_by_merit
+						has_cultural_tradition = tradition_only_the_strong
+						has_cultural_tradition = tradition_martial_admiration
+						has_cultural_tradition = tradition_fp1_trials_by_combat
+						has_cultural_tradition = tradition_chanson_de_geste
+						has_cultural_tradition = tradition_fp1_performative_honour
+						has_cultural_tradition = tradition_chivalry
+						has_cultural_tradition = tradition_warrior_culture
+						has_cultural_tradition = tradition_fp1_the_right_to_prove
+						has_cultural_tradition = tradition_garuda_warriors
+					}
+				}
+				# Master of Revels
+				AND = {
+					scope:accolade_in_need = {
+						initial_type = accolade_type:master_of_revels_attribute
+					}
+					OR = {
+						has_cultural_tradition = tradition_esteemed_hospitality
+						has_cultural_tradition = tradition_wedding_ceremonies
+						has_cultural_tradition = tradition_welcoming
+						has_cultural_tradition = tradition_music_theory
+						has_cultural_tradition = tradition_festivities
+						has_cultural_tradition = tradition_culinary_art
+					}
+				}
+			}
+			trigger_if = {
+				limit = {
+					exists = scope:owner.capital_county
+					scope:owner = {
+						highest_held_title_tier >= tier_duchy
+					}
+				}
+				any_culture_county = {
+					OR = {
+						holder = {
+							this = scope:owner
+						}
+						holder.liege = {
+							this = scope:owner
+						}
+						holder.top_liege = {
+							this = scope:owner
+						}
+						empire = scope:owner.capital_county.empire
+					}
+				}
+			}
+			trigger_else = {
+				exists = scope:owner.capital_county
+				any_culture_county = {
+					OR = {
+						holder = {
+							this = scope:owner
+						}
+						holder.liege = {
+							this = scope:owner
+						}
+						holder.top_liege = {
+							this = scope:owner
+						}
+						kingdom = scope:owner.capital_county.kingdom
+					}
+				}
+			}
+			culture_number_of_counties > 0
+			cultural_acceptance = {
+				target = scope:owner.culture
+				value >= 15
+			}
+		}
+		save_scope_as = type_specific_culture
+	}
+}
+
+accolade_character_creation_effect = {
+	#don't want AI using our performance intensive checks
+	if = {
+		limit = {
+			OR = {
+				is_ai = no
+				any_held_title = { this = title:e_byzantium }
+			}
+		}
+		#save a general knight-y culture that can randomly be used
+		save_general_accolade_successor_culture_effect = yes
+		#varangians if relevant
+		save_varangian_successor_culture_effect = yes
+		#turkic warriors if relevant
+		save_turkic_successor_culture_effect = yes
+		#save one specific to the accolade type
+		save_type_specific_successor_culture_effect = yes
+	}
+	save_scope_as = value_target #needed for gender chance
+	#let's get creating - but needs to be the right type of knight
+	#Marauder
+	if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:marauder_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_marauder_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Idealist
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:idealist_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_idealist_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Charmer
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:charmer_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_charmer_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Thug
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:thug_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_thug_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Disciplinarian
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:disciplinarian_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_disciplinarian_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Fanatic
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:fanatic_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_fanatic_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Valiant
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:valiant_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_valiant_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Stalwart
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:stalwart_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_stalwart_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Scoundrel
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:scoundrel_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_scoundrel_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Politicker
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:politicker_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_politicker_character
+			save_scope_as = chosen_knight
+		}
+		if = {
+			limit = {
+				scope:chosen_knight = { diplomacy < 12 }
+			}
+			scope:chosen_knight = {
+				add_diplomacy_skill = {
+					value = 12
+					subtract = diplomacy
+				}
+			}
+		}
+	}
+	#Tactician
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:tactician_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_tactician_character
+			save_scope_as = chosen_knight
+		}
+		if = {
+			limit = {
+				scope:chosen_knight = { martial < 12 }
+			}
+			scope:chosen_knight = {
+				add_martial_skill = {
+					value = 12
+					subtract = martial
+				}
+			}
+		}
+	}
+	#Reeve
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:reeve_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_reeve_character
+			save_scope_as = chosen_knight
+		}
+		if = {
+			limit = {
+				scope:chosen_knight = { stewardship < 12 }
+			}
+			scope:chosen_knight = {
+				add_stewardship_skill = {
+					value = 12
+					subtract = stewardship
+				}
+			}
+		}
+	}
+	#Manipulator
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:manipulator_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_manipulator_character
+			save_scope_as = chosen_knight
+		}
+		if = {
+			limit = {
+				scope:chosen_knight = { intrigue < 12 }
+			}
+			scope:chosen_knight = {
+				add_intrigue_skill = {
+					value = 12
+					subtract = intrigue
+				}
+			}
+		}
+	}
+	#Mentor
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:mentor_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_mentor_character
+			save_scope_as = chosen_knight
+		}
+		if = {
+			limit = {
+				scope:chosen_knight = { learning < 12 }
+			}
+			scope:chosen_knight = {
+				add_learning_skill = {
+					value = 12
+					subtract = learning
+				}
+			}
+		}
+	}
+	#Contender
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:contender_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_contender_character
+			save_scope_as = chosen_knight
+		}
+		if = {
+			limit = {
+				scope:chosen_knight = { prowess < 15 }
+			}
+			scope:chosen_knight = {
+				add_prowess_skill = {
+					value = 15
+					subtract = prowess
+				}
+			}
+		}
+	}
+	#Archer
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:archer_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_archer_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Skirmisher
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:skirmisher_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_skirmisher_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Pike
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:pike_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_pike_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Outrider
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:outrider_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_outrider_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Vanguard
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:vanguard_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_vanguard_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Lancer
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:lancer_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_lancer_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Besieger
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:besieger_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_besieger_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Crossbowman
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:crossbowmen_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_crossbowmen_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Camel Rider
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:camelry_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_camelry_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Elephant Rider
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:elephantry_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_elephantry_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Horse Archer
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:horse_archer_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_horse_archer_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Huntsmaster
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:huntsmaster_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_huntsmaster_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Blademaster
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:blademaster_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_blademaster_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#Reveler
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:master_of_revels_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_master_of_revels_character
+			save_scope_as = chosen_knight
+		}
+	}
+	#House Knight... we'll do our best
+	else_if = {
+		limit = {
+			scope:accolade_in_need = {
+				initial_type = {
+					this = accolade_type:house_knight_attribute
+				}
+			}
+		}
+		create_character = {
+			location = capital_province
+			template = accolade_house_knight_character
+			save_scope_as = chosen_knight
+		}
+	}
+}
+
+accolades_tactician_unlock_from_chess_effect = {
+	if = {
+		limit = {
+			OR = { # either player is a knight of the other
+				scope:bg_loser = {
+					any_knight = {
+						this = scope:bg_victor
+						can_unlock_accolade_attribute_trigger = {
+							ATTRIBUTE = tactician
+						}
+					}
+				}
+				scope:bg_victor = {
+					any_knight = {
+						this = scope:bg_loser
+						can_unlock_accolade_attribute_trigger = {
+							ATTRIBUTE = tactician
+						}
+					}
+				}
+			}
+		}
+		if = {
+			limit = {
+				scope:bg_loser = {
+					any_knight = {
+						this = scope:bg_victor
+						can_unlock_accolade_attribute_trigger = {
+							ATTRIBUTE = tactician
+						}
+					}
+				}
+			}
+			scope:bg_loser = {
+				save_scope_as = accolade_liege
+			}
+			scope:bg_victor = {
+				save_scope_as = accolade_knight
+			}
+		}
+		else = {
+			scope:bg_victor = {
+				save_scope_as = accolade_liege
+			}
+			scope:bg_loser = {
+				save_scope_as = accolade_knight
+			}
+		}
+		random = {
+			chance = 2
+			modifier = {
+				factor = accolade_progress # scales with accolade progress
+			}
+			modifier = {
+				factor = 5
+				scope:accolade_knight = {
+					is_acclaimed = yes
+				}
+			}
+			scope:accolade_liege = {
+				send_interface_message = {
+					type = msg_accolade_eligibility
+					title = accolade_tactician_unlock.t
+					left_icon = scope:accolade_knight
+					right_icon = scope:accolade_liege
+					custom_tooltip = accolade_tactician_unlock.tt
+					scope:accolade_knight = {
+						set_variable = {
+							name = tactician_attribute_unlock
+							value = yes
+						}
+					}	
+				}
+			}
+		}
+	}
+}
+
+# unlock_accolade_type_scripted_effect = { ACCOLADE = charmer_attribute }
+unlock_accolade_type_scripted_effect = {
+    save_scope_as = accolade_knight
+    accolade_type:$ACCOLADE$ = { save_scope_as = unlock_accolade }
+    set_variable = {
+        name = $ACCOLADE$_unlock
+        value = yes
+    }
+    custom_tooltip = unlock_accolade_type_scripted_effect.tt
+}
+
+#Increases martial skill or tournament trait xp
+accolade_squires_boost_martial_tourney_effect = {
+	#Increase tourney participant and/or martial effect (scaled by squires)
+	#Divided by which accolade type needs what
+	#Archer
+	if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:archer_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					scope:owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = forest
+									terrain = taiga
+								}
+							}
+						}
+					}
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = forest_fighter
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			3 = {
+				if = {
+					limit = {
+						NOT = {
+							has_trait = tourney_participant
+						}
+					}
+					add_trait = tourney_participant
+				}
+				add_trait_xp = {
+					trait = tourney_participant
+					track = bow
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Skirmisher
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:skirmisher_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					scope:owner.capital_county = {
+						any_county_province = {
+							has_province_modifier = winter_harsh_modifier
+						}
+					}
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = winter_soldier
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			1 = {
+				trigger = {
+					scope:owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								terrain = jungle
+							}
+						}
+						martial >= medium_skill_rating
+					}
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = jungle_stalker
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			1 = {
+				if = {
+					limit = {
+						NOT = {
+							has_trait = tourney_participant
+						}
+					}
+					add_trait = tourney_participant
+				}
+				add_trait_xp = {
+					trait = tourney_participant
+					track = bow
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+			1 = {
+				if = {
+					limit = {
+						NOT = {
+							has_trait = tourney_participant
+						}
+					}
+					add_trait = tourney_participant
+				}
+				add_trait_xp = {
+					trait = tourney_participant
+					track = foot
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Pike Captain
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:pike_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					scope:owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = hills
+									terrain = mountains
+									terrain = wetlands
+								}
+							}
+						}
+					}
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = rough_terrain_expert
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			3 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = foot
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Outrider
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:outrider_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					scope:owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = plains
+									terrain = farmlands
+									terrain = steppe
+								}
+							}
+						}
+					}
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = open_terrain_expert
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			3 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = horse
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Vanguard
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:vanguard_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_feckless_minimum_value }
+					NOT = {
+						has_trait = athletic
+					}
+				}
+				add_trait = athletic
+			}
+			1 = {
+				trigger = {
+					scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+					NOT = {
+						has_trait = strong
+					}
+				}
+				add_trait = strong
+			}
+			5 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = foot
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Lancer
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:lancer_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					ai_boldness >= 0
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = aggressive_attacker
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			3 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = horse
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Crossbowmen
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:crossbowmen_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					ai_boldness <= 0
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = cautious_leader
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			3 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = bow
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Besieger
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:besieger_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = military_engineer
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			1 = {
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = logistician
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+		}
+	}
+	#Camelry
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:camelry_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					scope:owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = drylands
+									terrain = desert
+									terrain = desert_mountains
+								}
+							}
+						}
+					}
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = desert_warrior
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			3 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = horse
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Elephantry
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:elephantry_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					scope:owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								terrain = jungle
+							}
+						}
+					}
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = jungle_stalker
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			3 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = horse
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Horse Archer
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:horse_archer_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				trigger = {
+					martial >= medium_skill_rating
+				}
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+					}
+					add_trait = flexible_leader
+				}
+				add_martial_skill = squires_bonus_martial
+			}
+			3 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = horse
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+			3 = {
+				add_trait = tourney_participant
+				add_trait_xp = {
+					trait = tourney_participant
+					track = bow
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Politicker
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:politicker_attribute
+				}
+			}
+		}
+		add_trait = tourney_participant
+		add_trait_xp = {
+			trait = tourney_participant
+			track = wit
+			value = squires_bonus_trait_xp_high
+		}
+	}
+	#Tactician
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:tactician_attribute
+				}
+			}
+		}
+		add_martial_skill = squires_bonus_martial
+	}
+	#Mentor
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:mentor_attribute
+				}
+			}
+		}
+		add_trait = tourney_participant
+		add_trait_xp = {
+			trait = tourney_participant
+			track = wit
+			value = squires_bonus_trait_xp_high
+		}
+	}
+	#Contender
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:contender_attribute
+				}
+			}
+		}
+		add_trait = tourney_participant
+		random_list = {
+			1 = {
+				add_trait_xp = {
+					trait = tourney_participant
+					track = foot
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+			1 = {
+				add_trait_xp = {
+					trait = tourney_participant
+					track = horse
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+			1 = {
+				add_trait_xp = {
+					trait = tourney_participant
+					track = bow
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+			1 = {
+				add_trait_xp = {
+					trait = tourney_participant
+					track = wit
+					value = squires_bonus_trait_xp_very_high
+				}
+			}
+		}
+	}
+	#Master of Revels
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = {
+				initial_type = {
+					this = accolade_type:master_of_revels_attribute
+				}
+			}
+		}
+		add_trait = tourney_participant
+		add_trait_xp = {
+			trait = tourney_participant
+			track = wit
+			value = squires_bonus_trait_xp_high
+		}
+	}
+	#Generic
+	else = {
+		random_list = {
+			1 = {
+				modifier = {
+					add = {
+						value = martial
+						subtract = 6
+						min = 0
+					}
+				}
+				add_martial_skill = squires_bonus_martial
+				if = {
+					limit = {
+						scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+					}
+					give_random_commander_trait_effect = yes
+				}
+			}
+			10 = {
+				if = {
+					limit = {
+						NOT = {
+							has_trait = tourney_participant
+						}
+					}
+					add_trait = tourney_participant
+				}
+				#Add appropriate-feeling amounts of trait XP based on squires quality
+				if = {
+					limit = {
+						culture = {
+							OR = {
+								culture_specializes_in_light_cavalry_maa = yes
+								culture_specializes_in_heavy_cavalry_maa = yes
+								culture_specializes_in_archer_cavalry_maa = yes
+							}
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						value = squires_bonus_trait_xp_high
+						track = horse
+					}
+				}
+				else = {
+					add_trait_xp = {
+						trait = tourney_participant
+						value = squires_bonus_trait_xp
+						track = horse
+					}
+				}
+				if = {
+					limit = {
+						culture = {
+							OR = {
+								culture_specializes_in_skirmisher_maa = yes
+								culture_specializes_in_heavy_infantry_maa = yes
+								culture_specializes_in_pikemen_maa = yes
+							}
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						value = squires_bonus_trait_xp_high
+						track = foot
+					}
+				}
+				else = {
+					add_trait_xp = {
+						trait = tourney_participant
+						value = squires_bonus_trait_xp
+						track = foot
+					}
+				}
+				if = {
+					limit = {
+						culture = {
+							OR = {
+								culture_specializes_in_archer_maa = yes
+								culture_specializes_in_archer_cavalry_maa = yes
+							}
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						value = squires_bonus_trait_xp_high
+						track = bow
+					}
+				}
+				else = {
+					add_trait_xp = {
+						trait = tourney_participant
+						value = squires_bonus_trait_xp
+						track = bow
+					}
+				}
+				if = {
+					limit = {
+						culture = {
+							OR = {
+								has_cultural_parameter = poet_trait_romance_bonuses
+								has_cultural_parameter = tells_stories
+								has_cultural_parameter = poet_trait_gives_bonuses
+								has_cultural_parameter = characters_are_better_court_poets
+								has_cultural_parameter = poet_trait_more_common
+								has_cultural_parameter = better_court_poets
+								has_cultural_parameter = may_challenge_to_board_games
+								has_cultural_parameter = may_wager_land_on_board_games
+								has_cultural_parameter = can_author_books
+							}
+						}
+					}
+					add_trait_xp = {
+						trait = tourney_participant
+						value = squires_bonus_trait_xp_high
+						track = wit
+					}
+				}
+				else = {
+					add_trait_xp = {
+						trait = tourney_participant
+						value = squires_bonus_trait_xp
+						track = wit
+					}
+				}
+			}
+		}
+	}
+}
+
+#Increases prowess xp
+accolade_squires_boost_prowess_effect = {
+	#ADD PROWESS BASED ON SQUIRES
+	#Pathetic quality squires
+	if = {
+		limit = {
+			#Squires value, which should be using old knight stats instead of current one's
+			scope:succeeding_accolade = { accolade_squires_quality_value < accolade_squires_feckless_minimum_value }
+			#Don't ruin scope:owner's children or heir
+			NOR = {
+				is_primary_heir_of = scope:owner
+				is_child_of = scope:owner
+			}
+		}
+		add_prowess_skill = -1
+	}
+	#Feckless quality squires
+	# Default, +/- 0
+	
+	#Inexperienced or better squires
+	if = {
+		limit = {
+			#Squires value, which should be using old knight stats instead of current one's
+			scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+		}
+		add_prowess_skill = 1
+	}
+	#Capable or better squires
+	if = {
+		limit = {
+			#Squires value, which should be using old knight stats instead of current one's
+			scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+		}
+		random_list = {
+			1 = { add_prowess_skill = 2 }
+			2 = { add_prowess_skill = 3 }
+		}
+	}
+	#Accomplished Squires
+	if = {
+		limit = {
+			#Squires value, which should be using old knight stats instead of current one's
+			scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+		}
+		if = {
+			limit = {
+				NOT = {
+					has_trait = tourney_participant
+				}
+			}
+			add_trait = tourney_participant
+		}
+		random_list = {
+			1 = { add_prowess_skill = 4 }
+			2 = { add_prowess_skill = 5 }
+			1 = { add_prowess_skill = 6 }
+		}
+	}
+	#If prowess is too low, get up to minimum
+	if = {
+		limit = {
+			prowess < 8
+		}
+		save_scope_value_as = {
+			name = prowess
+			value = prowess
+		}
+		
+		if = {
+			limit = {
+				prowess > 0
+			}
+			add_prowess_skill = {
+				value = scope:prowess
+				multiply = -1
+			}
+		}
+		add_prowess_skill = 8
+	}
+}
+assign_diplomacy_education_from_squires_quality_effect = {
+	remove_trait = education_martial_1
+	if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:politicker_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_diplomacy_5
+			}
+			4 = {
+				add_trait = education_diplomacy_4
+			}
+			1 = {
+				add_trait = education_diplomacy_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:politicker_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_diplomacy_4
+			}
+			1 = {
+				add_trait = education_diplomacy_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_feckless_minimum_value
+					initial_type = accolade_type:politicker_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_diplomacy_3
+			}
+			1 = {
+				add_trait = education_diplomacy_2
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_feckless_minimum_value }
+		}
+		random_list = {
+			1 = {
+				add_trait = education_diplomacy_3
+			}
+			1 = {
+				add_trait = education_diplomacy_2
+			}
+			1 = {
+				add_trait = education_diplomacy_1
+			}
+		}
+	}
+	else = {
+		random_list = {
+			1 = {
+				add_trait = education_diplomacy_2
+			}
+			1 = {
+				add_trait = education_diplomacy_1
+			}
+		}
+	}
+}
+assign_martial_education_from_squires_quality_effect = {
+	remove_trait = education_martial_1
+	random_trait = {
+		limit = {
+			has_trait_category = education
+		}
+		save_scope_as = education_trait
+	}
+	if = {
+		limit = {
+			exists = scope:education_trait
+		}
+		remove_trait = scope:education_trait
+	}
+	if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:tactician_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_martial_5
+			}
+			4 = {
+				add_trait = education_martial_4
+			}
+			1 = {
+				add_trait = education_martial_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:tactician_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_martial_4
+			}
+			1 = {
+				add_trait = education_martial_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_feckless_minimum_value
+					initial_type = accolade_type:tactician_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_martial_3
+			}
+			1 = {
+				add_trait = education_martial_2
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_feckless_minimum_value }
+		}
+		random_list = {
+			1 = {
+				add_trait = education_martial_3
+			}
+			1 = {
+				add_trait = education_martial_2
+			}
+			1 = {
+				add_trait = education_martial_1
+			}
+		}
+	}
+	else = {
+		random_list = {
+			1 = {
+				add_trait = education_martial_2
+			}
+			1 = {
+				add_trait = education_martial_1
+			}
+		}
+	}
+}
+assign_stewardship_education_from_squires_quality_effect = {
+	remove_trait = education_martial_1
+	random_trait = {
+		limit = {
+			has_trait_category = education
+		}
+		save_scope_as = education_trait
+	}
+	if = {
+		limit = {
+			exists = scope:education_trait
+		}
+		remove_trait = scope:education_trait
+	}
+	if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:reeve_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_stewardship_5
+			}
+			4 = {
+				add_trait = education_stewardship_4
+			}
+			1 = {
+				add_trait = education_stewardship_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:reeve_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_stewardship_4
+			}
+			1 = {
+				add_trait = education_stewardship_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_feckless_minimum_value
+					initial_type = accolade_type:reeve_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_stewardship_3
+			}
+			1 = {
+				add_trait = education_stewardship_2
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_feckless_minimum_value }
+		}
+		random_list = {
+			1 = {
+				add_trait = education_stewardship_3
+			}
+			1 = {
+				add_trait = education_stewardship_2
+			}
+			1 = {
+				add_trait = education_stewardship_1
+			}
+		}
+	}
+	else = {
+		random_list = {
+			1 = {
+				add_trait = education_stewardship_2
+			}
+			1 = {
+				add_trait = education_stewardship_1
+			}
+		}
+	}
+}
+assign_intrigue_education_from_squires_quality_effect = {
+	remove_trait = education_martial_1
+	random_trait = {
+		limit = {
+			has_trait_category = education
+		}
+		save_scope_as = education_trait
+	}
+	if = {
+		limit = {
+			exists = scope:education_trait
+		}
+		remove_trait = scope:education_trait
+	}
+	if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:manipulator_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_intrigue_5
+			}
+			4 = {
+				add_trait = education_intrigue_4
+			}
+			1 = {
+				add_trait = education_intrigue_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:manipulator_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_intrigue_4
+			}
+			1 = {
+				add_trait = education_intrigue_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_feckless_minimum_value
+					initial_type = accolade_type:manipulator_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_intrigue_3
+			}
+			1 = {
+				add_trait = education_intrigue_2
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_feckless_minimum_value }
+		}
+		random_list = {
+			1 = {
+				add_trait = education_intrigue_3
+			}
+			1 = {
+				add_trait = education_intrigue_2
+			}
+			1 = {
+				add_trait = education_intrigue_1
+			}
+		}
+	}
+	else = {
+		random_list = {
+			1 = {
+				add_trait = education_intrigue_2
+			}
+			1 = {
+				add_trait = education_intrigue_1
+			}
+		}
+	}
+}
+assign_learning_education_from_squires_quality_effect = {
+	remove_trait = education_martial_1
+	random_trait_in_category = {
+		category = education
+		limit = {
+			scope:owner = {
+				has_trait = prev
+			}
+		}
+		save_scope_as = education_trait
+	}
+	if = {
+		limit = {
+			exists = scope:education_trait
+		}
+		remove_trait = scope:education_trait
+	}
+	if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:mentor_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_learning_5
+			}
+			4 = {
+				add_trait = education_learning_4
+			}
+			2 = {
+				add_trait = education_learning_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					initial_type = accolade_type:mentor_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_learning_4
+			}
+			1 = {
+				add_trait = education_learning_3
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			OR = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+				scope:succeeding_accolade = {
+					accolade_squires_quality_value >= accolade_squires_feckless_minimum_value
+					initial_type = accolade_type:mentor_attribute
+				}
+			}
+		}
+		random_list = {
+			1 = {
+				add_trait = education_learning_3
+			}
+			1 = {
+				add_trait = education_learning_2
+			}
+		}
+	}
+	else_if = {
+		limit = {
+			scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_feckless_minimum_value }
+		}
+		random_list = {
+			1 = {
+				add_trait = education_learning_3
+			}
+			1 = {
+				add_trait = education_learning_2
+			}
+			1 = {
+				add_trait = education_learning_1
+			}
+		}
+	}
+	else = {
+		random_list = {
+			1 = {
+				add_trait = education_learning_2
+			}
+			1 = {
+				add_trait = education_learning_1
+			}
+		}
+	}
+}
+
+#train chars in acclaimed knight's court
+#Inside Accolade scope
+accolade_squire_training_effect = {
+	save_scope_as = accolade
+	accolade_owner = {
+		save_scope_as = owner
+	}
+
+	pick_accolade_type_effect = yes
+	
+	#PICK A SQUIRE TO TRAIN
+	#First, pick from the knight's wards
+	acclaimed_knight = {
+		save_scope_as = acclaimed_knight
+		ordered_relation = {
+			order_by = prowess
+			type = ward
+			limit = {
+				this = scope:owner
+				valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+			}
+			alternative_limit = {
+				is_close_family_of = scope:owner
+				valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+			}
+			alternative_limit = {
+				exists = scope:owner.dynasty
+				dynasty = scope:owner.dynasty
+				valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+			}
+			alternative_limit = {
+				valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+			}
+			save_scope_as = squire
+		}
+	}
+	#Then, pick from the knight's children
+	if = {
+		limit = {
+			NOT = {
+				exists = scope:squire
+			}
+		}
+		acclaimed_knight = {
+			ordered_child = {
+				order_by = prowess
+				limit = {
+					this = scope:owner
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					is_close_family_of = scope:owner
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					exists = scope:owner.dynasty
+					dynasty = scope:owner.dynasty
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					scope:accolade = {
+						has_variable_list = accolade_squire_chars
+					}
+					save_temporary_scope_as = squire_temp
+					scope:accolade = {
+						any_in_list = {
+							variable = accolade_squire_chars
+							this = scope:squire_temp
+						}
+					}
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				save_scope_as = squire
+			}
+		}
+	}
+	#Then, pick from the knight's siblings
+	if = {
+		limit = {
+			NOT = {
+				exists = scope:squire
+			}
+		}
+		acclaimed_knight = {
+			ordered_sibling = {
+				order_by = prowess
+				limit = {
+					this = scope:owner
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					is_close_family_of = scope:owner
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					exists = scope:owner.dynasty
+					dynasty = scope:owner.dynasty
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					scope:accolade = {
+						has_variable_list = accolade_squire_chars
+					}
+					save_temporary_scope_as = squire_temp
+					scope:accolade = {
+						any_in_list = {
+							variable = accolade_squire_chars
+							this = scope:squire_temp
+						}
+					}
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				save_scope_as = squire
+			}
+		}
+	}
+	#Then, pick from other knights
+	if = {
+		limit = {
+			NOT = {
+				exists = scope:squire
+			}
+		}
+		scope:owner = {
+			ordered_knight = {
+				order_by = prowess
+				limit = {
+					this = scope:owner
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					is_close_family_of = scope:owner
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					exists = scope:owner.dynasty
+					dynasty = scope:owner.dynasty
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					scope:accolade = {
+						has_variable_list = accolade_squire_chars
+					}
+					save_temporary_scope_as = squire_temp
+					scope:accolade = {
+						any_in_list = {
+							variable = accolade_squire_chars
+							this = scope:squire_temp
+						}
+					}
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				save_scope_as = squire
+			}
+		}
+	}
+	#Then pick from random martial education courtiers
+	if = {
+		limit = {
+			NOT = {
+				exists = scope:squire
+			}
+		}
+		scope:owner = {
+			ordered_courtier_or_guest = {
+				order_by = prowess
+				limit = {
+					is_close_family_of = scope:owner
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+					#No pool guests
+					OR = {
+						is_courtier = yes
+						is_foreign_court_guest = yes
+					}
+					OR = {
+						is_knight = yes
+						has_trait = education_martial
+						has_focus = education_martial
+						has_lifestyle = martial_lifestyle
+					}
+				}
+				alternative_limit = {
+					exists = scope:owner.dynasty
+					dynasty = scope:owner.dynasty
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+					#No pool guests
+					OR = {
+						is_courtier = yes
+						is_foreign_court_guest = yes
+					}
+					OR = {
+						is_knight = yes
+						has_trait = education_martial
+						has_focus = education_martial
+						has_lifestyle = martial_lifestyle
+					}
+				}
+				alternative_limit = {
+					#No pool guests
+					OR = {
+						is_courtier = yes
+						is_foreign_court_guest = yes
+					}
+					OR = {
+						is_knight = yes
+						has_trait = education_martial
+						has_focus = education_martial
+						has_lifestyle = martial_lifestyle
+					}
+					scope:accolade = {
+						has_variable_list = accolade_squire_chars
+					}
+					save_temporary_scope_as = squire_temp
+					scope:accolade = {
+						any_in_list = {
+							variable = accolade_squire_chars
+							this = scope:squire_temp
+						}
+					}
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+				}
+				alternative_limit = {
+					valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+					#No pool guests
+					OR = {
+						is_courtier = yes
+						is_foreign_court_guest = yes
+					}
+					OR = {
+						is_knight = yes
+						has_trait = education_martial
+						has_focus = education_martial
+						has_lifestyle = martial_lifestyle
+					}
+				}
+				save_scope_as = squire
+			}
+		}
+	}
+	#Then pick from random courtiers
+	if = {
+		limit = {
+			NOT = {
+				exists = scope:squire
+			}
+		}
+		#Shouldn't be messing with non-martial chars every year
+		random = {
+			chance = 50
+			scope:owner = {
+				ordered_courtier_or_guest = {
+					order_by = prowess
+					limit = {
+						is_close_family_of = scope:owner
+						valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+						#No pool guests
+						OR = {
+							is_courtier = yes
+							is_foreign_court_guest = yes
+						}
+					}
+					alternative_limit = {
+						exists = scope:owner.dynasty
+						dynasty = scope:owner.dynasty
+						valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+						#No pool guests
+						OR = {
+							is_courtier = yes
+							is_foreign_court_guest = yes
+						}
+					}
+					alternative_limit = {
+						#No pool guests
+						OR = {
+							is_courtier = yes
+							is_foreign_court_guest = yes
+						}
+						scope:accolade = {
+							has_variable_list = accolade_squire_chars
+						}
+						save_temporary_scope_as = squire_temp
+						scope:accolade = {
+							any_in_list = {
+								variable = accolade_squire_chars
+								this = scope:squire_temp
+							}
+						}
+						valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+					}
+					alternative_limit = {
+						valid_squire_for_accolade_trigger = { KNIGHT = scope:acclaimed_knight }
+						#No pool guests
+						OR = {
+							is_courtier = yes
+							is_foreign_court_guest = yes
+						}
+					}
+					save_scope_as = squire
+				}
+			}
+		}
+	}
+
+	#IF we found a squire... do the thing
+	if = {
+		limit = {
+			exists = scope:squire
+		}
+		#Tracking variables
+		if = {
+			limit = {
+				scope:accolade = {
+					accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+				}
+			}
+			scope:squire = {
+				set_variable = {
+					name = acclaimed_sq_maxed
+					value = scope:accolade
+				}
+				#Clean up now-unnecessary variables
+				if = {
+					limit = {
+						has_variable = acclaimed_sq_inexperienced
+					}
+					remove_variable = acclaimed_sq_inexperienced
+				}
+				if = {
+					limit = {
+						has_variable = acclaimed_sq_capable
+					}
+					remove_variable = acclaimed_sq_capable
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				scope:accolade = {
+					accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+				}
+			}
+			scope:squire = {
+				set_variable = {
+					name = acclaimed_sq_capable
+					value = scope:accolade
+				}
+				#Clean up now-unnecessary variables
+				if = {
+					limit = {
+						has_variable = acclaimed_sq_inexperienced
+					}
+					remove_variable = acclaimed_sq_inexperienced
+				}
+			}
+		}
+		else = {
+			scope:squire = {
+				set_variable = {
+					name = acclaimed_sq_inexperienced
+					value = scope:accolade
+				}
+			}
+		}
+		add_to_variable_list = {
+			name = accolade_squire_chars
+			target = scope:squire
+		}
+		#Have to set up randomized effects outside of message
+		#FRICKIN ANNOYING AMIRITE?
+		scope:squire = {
+			#PERSONALITY TRAITS
+			#Not DEFINITELY gaining personality trait, more likely based on squires quality
+			random = {
+				chance = {
+					value = 70
+					if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+							}
+						}
+						add = 15
+					}
+					if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+							}
+						}
+						add = 15
+					}
+				}
+				#HOUSE_KNIGHT - ADD LOYAL
+				if = {
+					limit = {
+						is_ai = yes
+						scope:accolade = {
+							scope:type = accolade_type:house_knight_attribute
+						}
+						NOR = {
+							has_trait = loyal
+							has_trait = disloyal
+							has_focus = education_intrigue
+							has_lifestyle = intrigue_lifestyle
+							has_trait = education_intrigue
+						}
+					}
+					#Just add it if they have fitting personality, only chance to add if they don't
+					if = {
+						limit = {
+							#Some fitting personality element
+							OR = {
+								ai_honor >= low_positive_ai_value
+								ai_compassion >= low_positive_ai_value
+							}
+						}
+						trait:loyal = { save_scope_as = personality_trait_add }
+					}
+					else = {
+						random = {
+							chance = {
+								value = 50
+								#Very contrary personality element
+								if = {
+									limit = {
+										OR = {
+											ai_honor < low_negative_ai_value
+											ai_compassion < low_negative_ai_value
+										}
+									}
+									add = -20
+								}
+								#No fitting personality element
+								if = {
+									limit = {
+										NOR = {
+											ai_honor >= 0
+											ai_compassion >= 0
+										}
+									}
+									add = -20
+								}
+							}
+							trait:loyal = { save_scope_as = personality_trait_add }
+						}
+					}
+				}
+				accolade_personality_trait_picking_effect = yes
+			}
+			#GENERIC HASTILUDER XP (is randomized and then applied later)
+			if = {
+				limit = {
+					scope:accolade = {
+						accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+					}
+				}
+				random_list = {
+					1 = {
+						add_character_flag = {
+							flag = squire_foot
+							days = 30
+						}
+					}
+					1 = {
+						add_character_flag = {
+							flag = squire_horse
+							days = 30
+						}
+					}
+					1 = {
+						trigger = {
+							OR = {
+								scope:accolade.accolade_owner = {
+									government_has_flag = government_is_nomadic
+								}
+								culture = {
+									OR = {
+										culture_specializes_in_skirmisher_maa = yes
+										culture_specializes_in_archer_maa = yes
+										culture_specializes_in_archer_cavalry_maa = yes
+									}
+								}
+							}
+						}
+						add_character_flag = {
+							flag = squire_bow
+							days = 30
+						}
+					}
+					1 = {
+						trigger = {
+							culture = {
+								OR = {
+									has_cultural_parameter = poet_trait_romance_bonuses
+									has_cultural_parameter = tells_stories
+									has_cultural_parameter = poet_trait_gives_bonuses
+									has_cultural_parameter = characters_are_better_court_poets
+									has_cultural_parameter = poet_trait_more_common
+									has_cultural_parameter = better_court_poets
+									has_cultural_parameter = may_challenge_to_board_games
+									has_cultural_parameter = may_wager_land_on_board_games
+									has_cultural_parameter = can_author_books
+								}
+							}
+						}
+						add_character_flag = {
+							flag = squire_wit
+							days = 30
+						}
+					}
+				}
+			}
+			#COMMANDER/LIFESTYLE TRAITS - randomized and applied later
+			#ARCHER
+			if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:archer_attribute
+					}
+				}
+				if = {
+					limit = {
+						scope:accolade.accolade_owner = {
+							any_held_title = {
+								title_tier = county
+								is_landless_type_title = no
+								any_county_province = {
+									OR = {
+										terrain = forest
+										terrain = taiga
+									}
+								}
+							}
+						}
+					}
+					random = {
+						chance = {
+							value = 25
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add = 25
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add = 25
+							}
+						}
+						trait:forest_fighter = { save_scope_as = squire_commlife_trait }
+					}
+				}
+			}
+			#SKIRMISHER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:skirmisher_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								terrain = jungle
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 25
+						}
+					}
+					trait:jungle_stalker = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:skirmisher_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								location_has_harsh_winter_trigger = yes
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 15
+						}
+					}
+					trait:winter_soldier = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#PIKEMAN
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:pike_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = hills
+									terrain = mountains
+									terrain = wetlands
+								}
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 25
+						}
+					}
+					trait:rough_terrain_expert = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#OUTRIDER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:outrider_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = plains
+									terrain = farmlands
+									terrain = steppe
+								}
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 25
+						}
+					}
+					trait:open_terrain_expert = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#VANGUARD
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:vanguard_attribute
+					}
+				}
+				random_list = {
+					2 = {
+						trigger = {
+							NOT = {
+								has_trait = athletic
+							}
+						}
+						random = {
+							chance = {
+								value = 15
+								if = {
+									limit = {
+										scope:accolade = {
+											accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+										}
+									}
+									add = 15
+								}
+								if = {
+									limit = {
+										scope:accolade = {
+											accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+										}
+									}
+									add = 15
+								}
+							}
+							trait:athletic = { save_scope_as = squire_commlife_trait }
+						}
+					}
+					1 = {
+						trigger = {
+							NOT = {
+								has_trait = strong
+							}
+						}
+						random = {
+							chance = {
+								value = 15
+								if = {
+									limit = {
+										scope:accolade = {
+											accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+										}
+									}
+									add = 15
+								}
+								if = {
+									limit = {
+										scope:accolade = {
+											accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+										}
+									}
+									add = 15
+								}
+							}
+							trait:strong = { save_scope_as = squire_commlife_trait }
+						}
+					}
+				}
+			}
+			#LANCER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:lancer_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 15
+						}
+					}
+					trait:aggressive_attacker = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#CROSSBOWMEN
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:crossbowmen_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 15
+						}
+					}
+					trait:cautious_leader = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#BESIEGER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:besieger_attribute
+					}
+				}
+				random_list = {
+					3 = {
+						trigger = {
+							NOT = {
+								has_trait = military_engineer
+							}
+						}
+						trait:military_engineer = { save_scope_as = squire_commlife_trait }
+					}
+					2 = {
+						trigger = {
+							NOT = {
+								has_trait = logistician
+							}
+						}
+						trait:logistician = { save_scope_as = squire_commlife_trait }
+					}
+					1 = {}
+				}
+			}
+			#CAMELRY
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:camelry_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = drylands
+									terrain = desert
+									terrain = desert_mountains
+								}
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 25
+						}
+					}
+					trait:desert_warrior = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#ELEPHANTS
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:elephantry_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								terrain = jungle
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 25
+						}
+					}
+					trait:jungle_stalker = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#HORSE ARCHER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:horse_archer_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 20
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 20
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 20
+						}
+					}
+					trait:flexible_leader = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#THUG
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:thug_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 15
+						}
+					}
+					trait:reaver = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#DISCIPLINARIAN
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:disciplinarian_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 15
+						}
+					}
+					trait:organizer = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#FANATIC
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:fanatic_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 15
+						}
+					}
+					trait:holy_warrior = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#STALWART
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:stalwart_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 15
+						}
+					}
+					trait:unyielding_defender = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#VALIANT
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:valiant_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add = 15
+						}
+					}
+					trait:aggressive_attacker = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#HUNTSMASTER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:huntsmaster_attribute
+					}
+				}
+				trait:lifestyle_hunter = { save_scope_as = squire_commlife_trait }
+			}
+			#BLADEMASTER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:blademaster_attribute
+					}
+				}
+				trait:lifestyle_blademaster = { save_scope_as = squire_commlife_trait }
+			}
+			#MASTER OF REVELS
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:master_of_revels_attribute
+					}
+				}
+				trait:lifestyle_reveler = { save_scope_as = squire_commlife_trait }
+			}
+		}
+		#Send notification to player, wherein:
+		#Apply scaled bonus based on accolade squire quality
+		scope:owner = {
+			send_interface_message = {
+				type = msg_accolade_squires
+				title = accolade_squire_training.t
+				left_icon = scope:squire
+				right_icon = scope:acclaimed_knight
+
+				desc = accolade_squire_training.desc
+				#Looks weird if knight doesn't have this trait, but is giving it
+				hidden_effect = {
+					scope:acclaimed_knight = {
+						add_trait = tourney_participant
+					}
+				}
+				
+				scope:squire = {
+					#PERSONALITY TRAITS
+					if = {
+						limit = {
+							exists = scope:personality_trait_add
+							NOT = {
+								has_trait = scope:personality_trait_add
+							}
+						}
+						add_trait = scope:personality_trait_add
+					}
+					if = {
+						limit = {
+							number_of_personality_traits > 3
+							exists = scope:personality_trait_remove
+						}
+						remove_trait = scope:personality_trait_remove
+					}
+	
+					#Skill-type Accolades
+					#DIPLOMACY
+					if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								scope:type = accolade_type:politicker_attribute
+							}
+						}
+						add_diplomacy_skill = 2
+					}
+					#MARTIAL
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								scope:type = accolade_type:tactician_attribute
+							}
+						}
+						add_martial_skill = 2
+					}
+					#STEWARDSHIP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								scope:type = accolade_type:reeve_attribute
+							}
+						}
+						add_stewardship_skill = 2
+					}
+					#INTRIGUE
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								scope:type = accolade_type:manipulator_attribute
+							}
+						}
+						add_intrigue_skill = 2
+					}
+					#LEARNING
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								OR = {
+									scope:type = accolade_type:mentor_attribute
+									scope:type = accolade_type:gunpowder_attribute
+								}
+							}
+						}
+						add_learning_skill = 2
+					}
+					#DIPLOMACY
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								scope:type = accolade_type:politicker_attribute
+							}
+						}
+						add_diplomacy_skill = 1
+					}
+					#MARTIAL
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								scope:type = accolade_type:tactician_attribute
+							}
+						}
+						add_martial_skill = 1
+					}
+					#STEWARDSHIP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								scope:type = accolade_type:reeve_attribute
+							}
+						}
+						add_stewardship_skill = 1
+					}
+					#INTRIGUE
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								scope:type = accolade_type:manipulator_attribute
+							}
+						}
+						add_intrigue_skill = 1
+					}
+					#LEARNING
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								OR = {
+									scope:type = accolade_type:mentor_attribute
+									scope:type = accolade_type:gunpowder_attribute
+								}
+							}
+						}
+						add_learning_skill = 1
+					}
+					#Contender is with prowess gains below
+
+					#Commander/lifestyle XP
+
+					#COMMANDER/LIFESTYLE TRAITS AND XP
+					#ARCHER
+					if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:archer_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											OR = {
+												terrain = forest
+												terrain = taiga
+											}
+										}
+									}
+								}
+								has_trait = forest_fighter
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = forest_fighter
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = forest_fighter
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = forest_fighter
+									value = 5
+								}
+							}
+						}
+					}
+					#SKIRMISHER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:skirmisher_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											terrain = jungle
+										}
+									}
+								}
+								has_trait = jungle_stalker
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = jungle_stalker
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = jungle_stalker
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = jungle_stalker
+									value = 5
+								}
+							}
+						}
+						else_if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											location_has_harsh_winter_trigger = yes
+										}
+									}
+								}
+								has_trait = winter_soldier
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = winter_soldier
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = winter_soldier
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = winter_soldier
+									value = 5
+								}
+							}
+						}
+					}
+					#PIKEMAN
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:pike_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											OR = {
+												terrain = hills
+												terrain = mountains
+												terrain = wetlands
+											}
+										}
+									}
+								}
+								has_trait = rough_terrain_expert
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = rough_terrain_expert
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = rough_terrain_expert
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = rough_terrain_expert
+									value = 5
+								}
+							}
+						}
+					}
+					#OUTRIDER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:outrider_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											OR = {
+												terrain = plains
+												terrain = farmlands
+												terrain = steppe
+											}
+										}
+									}
+								}
+								has_trait = open_terrain_expert
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = open_terrain_expert
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = open_terrain_expert
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = open_terrain_expert
+									value = 5
+								}
+							}
+						}
+					}
+					#LANCER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:lancer_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = aggressive_attacker
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = aggressive_attacker
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = aggressive_attacker
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = aggressive_attacker
+									value = 5
+								}
+							}
+						}
+					}
+					#CROSSBOWMEN
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:crossbowmen_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = cautious_leader
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = cautious_leader
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = cautious_leader
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = cautious_leader
+									value = 5
+								}
+							}
+						}
+					}
+					#BESIEGER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:besieger_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = military_engineer
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = military_engineer
+									value = 20
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = military_engineer
+									value = 15
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = military_engineer
+									value = 10
+								}
+							}
+						}
+						else_if = {
+							limit = {
+								has_trait = logistician
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = logistician
+									value = 20
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = logistician
+									value = 15
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = logistician
+									value = 10
+								}
+							}
+						}
+					}
+					#CAMELRY
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:camelry_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											OR = {
+												terrain = drylands
+												terrain = desert
+												terrain = desert_mountains
+											}
+										}
+									}
+								}
+								has_trait = desert_warrior
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = desert_warrior
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = desert_warrior
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = desert_warrior
+									value = 5
+								}
+							}
+						}
+					}
+					#ELEPHANTS
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:elephantry_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											terrain = jungle
+										}
+									}
+								}
+								has_trait = jungle_stalker
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = jungle_stalker
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = jungle_stalker
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = jungle_stalker
+									value = 5
+								}
+							}
+						}
+					}
+					#HORSE ARCHER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:horse_archer_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = flexible_leader
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = flexible_leader
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = flexible_leader
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = flexible_leader
+									value = 5
+								}
+							}
+						}
+					}
+					#THUG
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:thug_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = reaver
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = reaver
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = reaver
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = reaver
+									value = 5
+								}
+							}
+						}
+					}
+					#DISCIPLINARIAN
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:disciplinarian_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = organizer
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = organizer
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = organizer
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = organizer
+									value = 5
+								}
+							}
+						}
+					}
+					#FANATIC
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:fanatic_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = holy_warrior
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = holy_warrior
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = holy_warrior
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = holy_warrior
+									value = 5
+								}
+							}
+						}
+					}
+					#STALWART
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:stalwart_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = unyielding_defender
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = unyielding_defender
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = unyielding_defender
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = unyielding_defender
+									value = 5
+								}
+							}
+						}
+					}
+					#VALIANT
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:valiant_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = aggressive_attacker
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = aggressive_attacker
+									value = 15
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = aggressive_attacker
+									value = 10
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = aggressive_attacker
+									value = 5
+								}
+							}
+						}
+					}
+					#HUNTSMASTER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:huntsmaster_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = lifestyle_hunter
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = lifestyle_hunter
+									track = hunter
+									value = 10
+								}
+								add_trait_xp = {
+									trait = lifestyle_hunter
+									track = falconer
+									value = 10
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = lifestyle_hunter
+									track = hunter
+									value = 8
+								}
+								add_trait_xp = {
+									trait = lifestyle_hunter
+									track = falconer
+									value = 8
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = lifestyle_hunter
+									track = hunter
+									value = 5
+								}
+								add_trait_xp = {
+									trait = lifestyle_hunter
+									track = falconer
+									value = 5
+								}
+							}
+						}
+					}
+					#BLADEMASTER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:blademaster_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = lifestyle_blademaster
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = lifestyle_blademaster
+									value = 20
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = lifestyle_blademaster
+									value = 15
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = lifestyle_blademaster
+									value = 10
+								}
+							}
+						}
+					}
+					#MASTER OF REVELS
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:master_of_revels_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = lifestyle_reveler
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = lifestyle_reveler
+									value = 20
+								}
+							}
+							else_if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add_trait_xp = {
+									trait = lifestyle_reveler
+									value = 15
+								}
+							}
+							else = {
+								add_trait_xp = {
+									trait = lifestyle_reveler
+									value = 10
+								}
+							}
+						}
+					}
+
+					#Commander/lifestyle traits
+					if = {
+						limit = {
+							exists = scope:squire_commlife_trait
+							NOT = {
+								has_trait = scope:squire_commlife_trait
+							}
+							#Don't put martial trait on those abysmal at and uninterested in martial
+							trigger_if = {
+								limit = {
+									scope:squire_commlife_trait = { has_trait_category = commander }
+								}
+								OR = {
+									martial > low_skill_rating
+									has_focus = education_martial
+									has_lifestyle = martial_lifestyle
+									has_trait = education_martial
+								}
+							}
+						}
+						add_trait = scope:squire_commlife_trait
+					}
+
+					#Prowess - for everyone, extra for Contender
+					if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+							}
+						}
+						#Contender gets more prowess
+						if = {
+							limit = {
+								scope:accolade = {
+									scope:type = accolade_type:contender_attribute
+								}
+							}
+							add_prowess_skill = 3
+						}
+						else = {
+							add_prowess_skill = 2
+						}
+					}
+					else = {
+						if = {
+							limit = {
+								scope:accolade = {
+									scope:type = accolade_type:contender_attribute
+								}
+							}
+							add_prowess_skill = 2
+						}
+						else = {
+							add_prowess_skill = 1
+						}
+					}
+
+					#HASTILUDER
+					#Always give, but hide if giving other things
+					if = {
+						limit = {
+							scope:accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+						}
+						hidden_effect = { add_trait = tourney_participant }
+					}
+					else = {
+						add_trait = tourney_participant
+					}
+					#HASTILUDER XP
+					#BOW XP
+					if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									scope:type = accolade_type:archer_attribute
+									scope:type = accolade_type:crossbowmen_attribute
+								}
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 20
+							}
+						}
+						else_if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 15
+							}
+						}
+						else = {
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 10
+							}
+						}
+					}
+					#FOOT XP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									scope:type = accolade_type:pike_attribute
+									scope:type = accolade_type:vanguard_attribute
+								}
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 20
+							}
+						}
+						else_if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 15
+							}
+						}
+						else = {
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 10
+							}
+						}
+					}
+					#HORSE XP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									scope:type = accolade_type:outrider_attribute
+									scope:type = accolade_type:lancer_attribute
+									scope:type = accolade_type:elephantry_attribute
+									scope:type = accolade_type:camelry_attribute
+								}
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 20
+							}
+						}
+						else_if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 15
+							}
+						}
+						else = {
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 10
+							}
+						}
+					}
+					#HORSE AND BOW XP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:horse_archer_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 10
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 8
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 8
+							}
+						}
+						else = {
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 5
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 5
+							}
+						}
+					}
+					#FOOT AND BOW XP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:skirmisher_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 10
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								scope:accolade = {
+									accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+								}
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 8
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 8
+							}
+						}
+						else = {
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 5
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 5
+							}
+						}
+					}
+					#CONTENDER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+								scope:type = accolade_type:contender_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_character_flag = squire_foot
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 20
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_horse
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 20
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_bow
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 20
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_wit
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = wit
+								value = 20
+							}
+						}
+					}
+					#then generic fallback hastiluder
+					else_if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									scope:type = accolade_type:contender_attribute
+								}
+							}
+						}
+						if = {
+							limit = {
+								has_character_flag = squire_foot
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_horse
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_bow
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_wit
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = wit
+								value = 10
+							}
+						}
+					}
+					#Lower quality generic fallback
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+							}
+						}
+						if = {
+							limit = {
+								has_character_flag = squire_foot
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 5
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_horse
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 5
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_bow
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 5
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_wit
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = wit
+								value = 5
+							}
+						}
+					}
+					#No XP for inexperienced squires, just the hastiluder trait
+				}
+			}
+		}
+	}
+}
+
+#This is so hacky... but script functionality is missing.
+#Gotta do what ya gotta do
+pick_accolade_type_effect = {
+	random_list = {
+		1 = {
+			trigger = {
+				has_accolade_type = marauder_attribute
+			}
+			accolade_type:marauder_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = idealist_attribute
+			}
+			accolade_type:idealist_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = charmer_attribute
+			}
+			accolade_type:charmer_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = thug_attribute
+			}
+			accolade_type:thug_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = disciplinarian_attribute
+			}
+			accolade_type:disciplinarian_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = fanatic_attribute
+			}
+			accolade_type:fanatic_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = valiant_attribute
+			}
+			accolade_type:valiant_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = stalwart_attribute
+			}
+			accolade_type:stalwart_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = scoundrel_attribute
+			}
+			accolade_type:scoundrel_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = politicker_attribute
+			}
+			accolade_type:politicker_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = tactician_attribute
+			}
+			accolade_type:tactician_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = reeve_attribute
+			}
+			accolade_type:reeve_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = manipulator_attribute
+			}
+			accolade_type:manipulator_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = mentor_attribute
+			}
+			accolade_type:mentor_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = contender_attribute
+			}
+			accolade_type:contender_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = archer_attribute
+			}
+			accolade_type:archer_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = skirmisher_attribute
+			}
+			accolade_type:skirmisher_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = pike_attribute
+			}
+			accolade_type:pike_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = outrider_attribute
+			}
+			accolade_type:outrider_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = vanguard_attribute
+			}
+			accolade_type:vanguard_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = lancer_attribute
+			}
+			accolade_type:lancer_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = crossbowmen_attribute
+			}
+			accolade_type:crossbowmen_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = besieger_attribute
+			}
+			accolade_type:besieger_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = camelry_attribute
+			}
+			accolade_type:camelry_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = elephantry_attribute
+			}
+			accolade_type:elephantry_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = horse_archer_attribute
+			}
+			accolade_type:horse_archer_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = gunpowder_attribute
+			}
+			accolade_type:gunpowder_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = huntsmaster_attribute
+			}
+			accolade_type:huntsmaster_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = blademaster_attribute
+			}
+			accolade_type:blademaster_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = master_of_revels_attribute
+			}
+			accolade_type:master_of_revels_attribute = {
+				save_scope_as = type
+			}
+		}
+		1 = {
+			trigger = {
+				has_accolade_type = house_knight_attribute
+			}
+			accolade_type:house_knight_attribute = {
+				save_scope_as = type
+			}
+		}
+	}
+}
+
+#train chars in acclaimed knight's court
+#Inside Accolade scope
+accolade_knight_training_effect = {
+	save_scope_as = accolade
+	acclaimed_knight = { save_scope_as = acclaimed_knight }
+	accolade_owner = {
+		save_scope_as = owner
+	}
+
+	#Set tracking variable so knight isn't trained a crazy amount
+	acclaimed_knight = {
+		if = {
+			limit = {
+				NOT = {
+					has_variable = acc_knight_trained
+				}
+			}
+			
+			set_variable = {
+				name = acc_knight_trained
+				value = 1
+			}
+		}
+		else = {
+			change_variable = {
+				name = acc_knight_trained
+				add = 1
+			}
+		}
+	}
+	pick_accolade_type_effect = yes
+
+
+	#Train the knight
+	if = {
+		limit = {
+			exists = scope:acclaimed_knight
+		}
+		#Have to set up randomized effects outside of message
+		#FRICKIN ANNOYING AMIRITE?
+		scope:acclaimed_knight = {
+			#PERSONALITY TRAITS
+			#Not DEFINITELY gaining personality trait, more likely based on squires quality
+			random = {
+				chance = {
+					value = 30
+					if = {
+						limit = {
+							scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+						}
+						add = 10
+					}
+					if = {
+						limit = {
+							scope:accolade = { var:lifetime_glory >= massive_glory_value }
+						}
+						add = 10
+					}
+				}
+				#HOUSE_KNIGHT - ADD LOYAL
+				if = {
+					limit = {
+						scope:accolade = {
+							scope:type = accolade_type:house_knight_attribute
+						}
+						NOR = {
+							has_trait = loyal
+							has_trait = disloyal
+							has_focus = education_intrigue
+							has_lifestyle = intrigue_lifestyle
+							has_trait = education_intrigue
+						}
+					}
+					trait:loyal = { save_scope_as = personality_trait_add }
+				}
+				accolade_personality_trait_picking_effect = yes
+			}
+			#GENERIC HASTILUDER XP (is randomized and then applied later)
+			random_list = {
+				1 = {
+					add_character_flag = {
+						flag = squire_foot
+						days = 30
+					}
+				}
+				1 = {
+					add_character_flag = {
+						flag = squire_horse
+						days = 30
+					}
+				}
+				1 = {
+					trigger = {
+						OR = {
+							scope:accolade.accolade_owner = {
+								government_has_flag = government_is_nomadic
+							}
+							culture = {
+								OR = {
+									culture_specializes_in_skirmisher_maa = yes
+									culture_specializes_in_archer_maa = yes
+									culture_specializes_in_archer_cavalry_maa = yes
+								}
+							}
+						}
+					}
+					add_character_flag = {
+						flag = squire_bow
+						days = 30
+					}
+				}
+				1 = {
+					trigger = {
+						culture = {
+							OR = {
+								has_cultural_parameter = poet_trait_romance_bonuses
+								has_cultural_parameter = tells_stories
+								has_cultural_parameter = poet_trait_gives_bonuses
+								has_cultural_parameter = characters_are_better_court_poets
+								has_cultural_parameter = poet_trait_more_common
+								has_cultural_parameter = better_court_poets
+								has_cultural_parameter = may_challenge_to_board_games
+								has_cultural_parameter = may_wager_land_on_board_games
+								has_cultural_parameter = can_author_books
+							}
+						}
+					}
+					add_character_flag = {
+						flag = squire_wit
+						days = 30
+					}
+				}
+			}
+			#COMMANDER/LIFESTYLE TRAITS - randomized and applied later
+			#ARCHER
+			if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:archer_attribute
+					}
+				}
+				if = {
+					limit = {
+						scope:accolade.accolade_owner = {
+							any_held_title = {
+								title_tier = county
+								is_landless_type_title = no
+								any_county_province = {
+									OR = {
+										terrain = forest
+										terrain = taiga
+									}
+								}
+							}
+						}
+					}
+					random = {
+						chance = {
+							value = 25
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+									}
+								}
+								add = 25
+							}
+							if = {
+								limit = {
+									scope:accolade = {
+										accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+									}
+								}
+								add = 25
+							}
+						}
+						trait:forest_fighter = { save_scope_as = squire_commlife_trait }
+					}
+				}
+			}
+			#SKIRMISHER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:skirmisher_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								terrain = jungle
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 25
+						}
+					}
+					trait:jungle_stalker = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:skirmisher_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								location_has_harsh_winter_trigger = yes
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 15
+						}
+					}
+					trait:winter_soldier = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#PIKEMAN
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:pike_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = hills
+									terrain = mountains
+									terrain = wetlands
+								}
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 25
+						}
+					}
+					trait:rough_terrain_expert = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#OUTRIDER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:outrider_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = plains
+									terrain = farmlands
+									terrain = steppe
+								}
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 25
+						}
+					}
+					trait:open_terrain_expert = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#VANGUARD
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:vanguard_attribute
+					}
+				}
+				random_list = {
+					2 = {
+						trigger = {
+							NOT = {
+								has_trait = athletic
+							}
+						}
+						random = {
+							chance = {
+								value = 15
+								if = {
+									limit = {
+										scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+									}
+									add = 15
+								}
+								if = {
+									limit = {
+										scope:accolade = { var:lifetime_glory >= massive_glory_value }
+									}
+									add = 15
+								}
+							}
+							trait:athletic = { save_scope_as = squire_commlife_trait }
+						}
+					}
+					1 = {
+						trigger = {
+							NOT = {
+								has_trait = strong
+							}
+						}
+						random = {
+							chance = {
+								value = 15
+								if = {
+									limit = {
+										scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+									}
+									add = 15
+								}
+								if = {
+									limit = {
+										scope:accolade = { var:lifetime_glory >= massive_glory_value }
+									}
+									add = 15
+								}
+							}
+							trait:strong = { save_scope_as = squire_commlife_trait }
+						}
+					}
+				}
+			}
+			#LANCER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:lancer_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 15
+						}
+					}
+					trait:aggressive_attacker = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#CROSSBOWMEN
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:crossbowmen_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 15
+						}
+					}
+					trait:cautious_leader = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#BESIEGER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:besieger_attribute
+					}
+				}
+				random_list = {
+					3 = {
+						trigger = {
+							NOT = {
+								has_trait = military_engineer
+							}
+						}
+						trait:military_engineer = { save_scope_as = squire_commlife_trait }
+					}
+					2 = {
+						trigger = {
+							NOT = {
+								has_trait = logistician
+							}
+						}
+						trait:logistician = { save_scope_as = squire_commlife_trait }
+					}
+					1 = {}
+				}
+			}
+			#CAMELRY
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:camelry_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								OR = {
+									terrain = drylands
+									terrain = desert
+									terrain = desert_mountains
+								}
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 25
+						}
+					}
+					trait:desert_warrior = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#ELEPHANTS
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:elephantry_attribute
+					}
+					scope:accolade.accolade_owner = {
+						any_held_title = {
+							title_tier = county
+							is_landless_type_title = no
+							any_county_province = {
+								terrain = jungle
+							}
+						}
+					}
+				}
+				random = {
+					chance = {
+						value = 25
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 25
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 25
+						}
+					}
+					trait:jungle_stalker = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#HORSE ARCHER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:horse_archer_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 20
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 20
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 20
+						}
+					}
+					trait:flexible_leader = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#THUG
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:thug_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 15
+						}
+					}
+					trait:reaver = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#DISCIPLINARIAN
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:disciplinarian_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 15
+						}
+					}
+					trait:organizer = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#FANATIC
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:fanatic_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 15
+						}
+					}
+					trait:holy_warrior = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#STALWART
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:stalwart_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 15
+						}
+					}
+					trait:unyielding_defender = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#VALIANT
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:valiant_attribute
+					}
+				}
+				random = {
+					chance = {
+						value = 15
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= monumental_glory_value }
+							}
+							add = 15
+						}
+						if = {
+							limit = {
+								scope:accolade = { var:lifetime_glory >= massive_glory_value }
+							}
+							add = 15
+						}
+					}
+					trait:aggressive_attacker = { save_scope_as = squire_commlife_trait }
+				}
+			}
+			#HUNTSMASTER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:huntsmaster_attribute
+					}
+				}
+				trait:lifestyle_hunter = { save_scope_as = squire_commlife_trait }
+			}
+			#BLADEMASTER
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:blademaster_attribute
+					}
+				}
+				trait:lifestyle_blademaster = { save_scope_as = squire_commlife_trait }
+			}
+			#MASTER OF REVELS
+			else_if = {
+				limit = {
+					scope:accolade = {
+						scope:type = accolade_type:master_of_revels_attribute
+					}
+				}
+				trait:lifestyle_reveler = { save_scope_as = squire_commlife_trait }
+			}
+		}
+		#Send notification to player, wherein:
+		#Apply scaled bonus based on accolade squire quality
+		scope:owner = {
+			send_interface_message = {
+				type = msg_accolade_knight_training
+				title = accolade_knight_training.t
+				left_icon = scope:acclaimed_knight
+				desc = accolade_knight_training.desc
+				scope:acclaimed_knight = {
+					hidden_effect = { add_trait = tourney_participant }
+					#PERSONALITY TRAITS
+					if = {
+						limit = {
+							exists = scope:personality_trait_add
+							NOT = {
+								has_trait = scope:personality_trait_add
+							}
+						}
+						add_trait = scope:personality_trait_add
+					}
+					if = {
+						limit = {
+							exists = scope:personality_trait_remove
+							number_of_personality_traits > 3
+						}
+						remove_trait = scope:personality_trait_remove
+					}
+	
+					#Skill-type Accolades
+					#DIPLOMACY
+					if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:politicker_attribute
+							}
+							diplomacy < medium_skill_rating
+						}
+						add_diplomacy_skill = 2
+					}
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:politicker_attribute
+							}
+							diplomacy < monumentally_high_skill_rating
+						}
+						add_diplomacy_skill = 1
+					}
+					#MARTIAL
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:tactician_attribute
+							}
+							martial < medium_skill_rating
+						}
+						add_martial_skill = 2
+					}
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:tactician_attribute
+							}
+							martial < monumentally_high_skill_rating
+						}
+						add_martial_skill = 1
+					}
+					#STEWARDSHIP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:reeve_attribute
+							}
+							stewardship < medium_skill_rating
+						}
+						add_stewardship_skill = 2
+					}
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:reeve_attribute
+							}
+						}
+						add_stewardship_skill = 1
+					}
+					#INTRIGUE
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:manipulator_attribute
+							}
+							intrigue < medium_skill_rating
+						}
+						add_intrigue_skill = 2
+					}
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:manipulator_attribute
+							}
+							intrigue < monumentally_high_skill_rating
+						}
+						
+						add_intrigue_skill = 1
+					}
+					#LEARNING
+					else_if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									scope:type = accolade_type:mentor_attribute
+									scope:type = accolade_type:gunpowder_attribute
+								}
+							}
+							learning < medium_skill_rating
+						}
+						add_learning_skill = 2
+					}
+					else_if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									scope:type = accolade_type:mentor_attribute
+									scope:type = accolade_type:gunpowder_attribute
+								}
+							}
+							learning < monumentally_high_skill_rating
+						}
+						add_learning_skill = 1
+					}
+					#Contender is with prowess gains below
+
+					#Commander/lifestyle XP
+
+					#COMMANDER/LIFESTYLE TRAITS AND XP
+					#ARCHER
+					if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:archer_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											OR = {
+												terrain = forest
+												terrain = taiga
+											}
+										}
+									}
+								}
+								has_trait = forest_fighter
+							}
+							add_trait_xp = {
+								trait = forest_fighter
+								value = 10
+							}
+						}
+					}
+					#SKIRMISHER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:skirmisher_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											terrain = jungle
+										}
+									}
+								}
+								has_trait = jungle_stalker
+							}
+							add_trait_xp = {
+								trait = jungle_stalker
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											location_has_harsh_winter_trigger = yes
+										}
+									}
+								}
+								has_trait = winter_soldier
+							}
+							add_trait_xp = {
+								trait = winter_soldier
+								value = 10
+							}
+						}
+					}
+					#PIKEMAN
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:pike_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											OR = {
+												terrain = hills
+												terrain = mountains
+												terrain = wetlands
+											}
+										}
+									}
+								}
+								has_trait = rough_terrain_expert
+							}
+							add_trait_xp = {
+								trait = rough_terrain_expert
+								value = 10
+							}
+						}
+					}
+					#OUTRIDER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:outrider_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											OR = {
+												terrain = plains
+												terrain = farmlands
+												terrain = steppe
+											}
+										}
+									}
+								}
+								has_trait = open_terrain_expert
+							}
+							add_trait_xp = {
+								trait = open_terrain_expert
+								value = 10
+							}
+						}
+					}
+					#LANCER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:lancer_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = aggressive_attacker
+							}
+							add_trait_xp = {
+								trait = aggressive_attacker
+								value = 10
+							}
+						}
+					}
+					#CROSSBOWMEN
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:crossbowmen_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = cautious_leader
+							}
+							add_trait_xp = {
+								trait = cautious_leader
+								value = 10
+							}
+						}
+					}
+					#BESIEGER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:besieger_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = military_engineer
+							}
+							add_trait_xp = {
+								trait = military_engineer
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								has_trait = logistician
+							}
+							add_trait_xp = {
+								trait = logistician
+								value = 10
+							}
+						}
+					}
+					#CAMELRY
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:camelry_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											OR = {
+												terrain = drylands
+												terrain = desert
+												terrain = desert_mountains
+											}
+										}
+									}
+								}
+								has_trait = desert_warrior
+							}
+							add_trait_xp = {
+								trait = desert_warrior
+								value = 10
+							}
+						}
+					}
+					#ELEPHANTS
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:elephantry_attribute
+							}
+						}
+						if = {
+							limit = {
+								scope:accolade.accolade_owner = {
+									any_held_title = {
+										title_tier = county
+										is_landless_type_title = no
+										any_county_province = {
+											terrain = jungle
+										}
+									}
+								}
+								has_trait = jungle_stalker
+							}
+							add_trait_xp = {
+								trait = jungle_stalker
+								value = 10
+							}
+						}
+					}
+					#HORSE ARCHER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:horse_archer_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = flexible_leader
+							}
+							add_trait_xp = {
+								trait = flexible_leader
+								value = 10
+							}
+						}
+					}
+					#THUG
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:thug_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = reaver
+							}
+							add_trait_xp = {
+								trait = reaver
+								value = 10
+							}
+						}
+					}
+					#DISCIPLINARIAN
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:disciplinarian_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = organizer
+							}
+							add_trait_xp = {
+								trait = organizer
+								value = 10
+							}
+						}
+					}
+					#FANATIC
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:fanatic_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = holy_warrior
+							}
+							add_trait_xp = {
+								trait = holy_warrior
+								value = 10
+							}
+						}
+					}
+					#STALWART
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:stalwart_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = unyielding_defender
+							}
+							add_trait_xp = {
+								trait = unyielding_defender
+								value = 10
+							}
+						}
+					}
+					#VALIANT
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:valiant_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = aggressive_attacker
+							}
+							add_trait_xp = {
+								trait = aggressive_attacker
+								value = 10
+							}
+						}
+					}
+					#HUNTSMASTER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:huntsmaster_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = lifestyle_hunter
+							}
+							add_trait_xp = {
+								trait = lifestyle_hunter
+								track = hunter
+								value = 8
+							}
+							add_trait_xp = {
+								trait = lifestyle_hunter
+								track = falconer
+								value = 8
+							}
+						}
+					}
+					#BLADEMASTER
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:blademaster_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = lifestyle_blademaster
+							}
+							add_trait_xp = {
+								trait = lifestyle_blademaster
+								value = 15
+							}
+						}
+					}
+					#MASTER OF REVELS
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:master_of_revels_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_trait = lifestyle_reveler
+							}
+							add_trait_xp = {
+								trait = lifestyle_reveler
+								value = 10
+							}
+						}
+					}
+
+					#Commander/lifestyle traits
+					if = {
+						limit = {
+							exists = scope:squire_commlife_trait
+							NOT = {
+								has_trait = scope:squire_commlife_trait
+							}
+							#Don't put martial trait on those abysmal at and uninterested in martial
+							trigger_if = {
+								limit = {
+									scope:squire_commlife_trait = { has_trait_category = commander }
+								}
+								OR = {
+									martial > low_skill_rating
+									has_focus = education_martial
+									has_lifestyle = martial_lifestyle
+									has_trait = education_martial
+								}
+							}
+						}
+						add_trait = scope:squire_commlife_trait
+					}
+
+					#Prowess - for everyone, extra for Contender
+					if = {
+						limit = {
+							OR = {
+								scope:accolade = {
+									scope:type = accolade_type:contender_attribute
+								}
+								prowess <= average_skill_rating
+							}
+						}
+						add_prowess_skill = 2
+					}
+					else_if = {
+						limit = {
+							prowess <= extremely_high_skill_rating
+						}
+						add_prowess_skill = 1
+					}
+					#Martial as a fallback
+					else_if = {
+						limit = {
+							martial <= extremely_high_skill_rating
+						}
+						add_martial_skill = 1
+					}
+					#prestige as ultimate fallback
+					else = {
+						add_prestige = medium_prestige_gain
+					}
+
+					#HASTILUDER XP
+					#BOW XP
+					if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									scope:type = accolade_type:archer_attribute
+									scope:type = accolade_type:crossbowmen_attribute
+								}
+							}
+						}
+						add_trait_xp = {
+							trait = tourney_participant
+							track = bow
+							value = 15
+						}
+					}
+					#FOOT XP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									scope:type = accolade_type:pike_attribute
+									scope:type = accolade_type:vanguard_attribute
+								}
+							}
+						}
+						add_trait_xp = {
+							trait = tourney_participant
+							track = foot
+							value = 15
+						}
+					}
+					#HORSE XP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								OR = {
+									scope:type = accolade_type:outrider_attribute
+									scope:type = accolade_type:lancer_attribute
+									scope:type = accolade_type:elephantry_attribute
+									scope:type = accolade_type:camelry_attribute
+								}
+							}
+						}
+						add_trait_xp = {
+							trait = tourney_participant
+							track = horse
+							value = 15
+						}
+					}
+					#HORSE AND BOW XP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:horse_archer_attribute
+							}
+						}
+						add_trait_xp = {
+							trait = tourney_participant
+							track = horse
+							value = 8
+						}
+						add_trait_xp = {
+							trait = tourney_participant
+							track = bow
+							value = 8
+						}
+					}
+					#FOOT AND BOW XP
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:skirmisher_attribute
+							}
+						}
+						add_trait_xp = {
+							trait = tourney_participant
+							track = foot
+							value = 8
+						}
+						add_trait_xp = {
+							trait = tourney_participant
+							track = bow
+							value = 8
+						}
+					}
+					#then generic fallback hastiluder
+					else_if = {
+						limit = {
+							scope:accolade = {
+								scope:type = accolade_type:contender_attribute
+							}
+						}
+						if = {
+							limit = {
+								has_character_flag = squire_foot
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_horse
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_bow
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 10
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_wit
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = wit
+								value = 10
+							}
+						}
+					}
+					#Lower quality generic fallback
+					else_if = {
+						limit = {
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+							}
+						}
+						if = {
+							limit = {
+								has_character_flag = squire_foot
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = foot
+								value = 5
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_horse
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = horse
+								value = 5
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_bow
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = bow
+								value = 5
+							}
+						}
+						else_if = {
+							limit = {
+								has_character_flag = squire_wit
+							}
+							add_trait_xp = {
+								trait = tourney_participant
+								track = wit
+								value = 5
+							}
+						}
+					}
+					#No XP for inexperienced squires, just the hastiluder trait
+				}
+			}
+		}
+	}
+}
+
+#Personality trait picking for above training effects
+accolade_personality_trait_picking_effect = {
+	#COMMON ATTRIBUTES - CHANGE PERSONALITY
+	#Only change personality if they aren't related to player
+	if = {
+		limit = {
+			#Only need to check relations if scope:owner is a squire
+			trigger_if = {
+				limit = {
+					exists = scope:squire
+				}
+				#Don't ever change PC personality with this
+				is_ai = yes
+				#Only change family members of players if they assigned knight as ward
+				OR = {
+					AND = {
+						liege ?= {
+							is_ai = no
+						}
+						has_relation_guardian = scope:acclaimed_knight
+					}
+					NOT = {
+						any_close_or_extended_family_member = {
+							is_ai = no
+						}
+					}
+				}
+				#Do not change personality of player's ward
+				NAND = {
+					has_relation_guardian = scope:accolade.accolade_owner
+					scope:accolade.accolade_owner = {
+						is_ai = no
+					}
+				}
+			}
+		}
+		#MARAUDER
+		if = {
+			limit = {
+				scope:accolade = {
+					scope:type = accolade_type:marauder_attribute
+				}
+				#Doesn't have all opposing traits
+				NAND = {
+					has_trait = forgiving
+					has_trait = compassionate
+				}
+				#Doesn't have all possible traits they could gain
+				NAND = {
+					has_trait = sadistic
+					has_trait = callous
+					has_trait = vengeful
+				}
+			}
+			trait:sadistic = { add_to_list = accolade_traits }
+			trait:vengeful = { add_to_list = accolade_traits }
+			trait:callous = { add_to_list = accolade_traits }
+			random_list = {
+				#Vengeful
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = vengeful
+							has_trait = forgiving
+						}
+					}
+					modifier = {
+						ai_vengefulness > 0
+						add = ai_vengefulness
+					}
+					modifier = {
+						ai_vengefulness < 0
+						add = -9
+					}
+					trait:vengeful = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#Sadistic
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = sadistic
+							has_trait = compassionate
+							has_trait = callous
+						}
+					}
+					modifier = {
+						ai_compassion < 0
+						add = {
+							value = ai_compassion
+							multiply = -1
+						}
+					}
+					modifier = {
+						ai_compassion > 0
+						add = -9
+					}
+					trait:sadistic = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#Callous
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = sadistic
+							has_trait = compassionate
+							has_trait = callous
+						}
+					}
+					modifier = {
+						ai_compassion < 0
+						add = {
+							value = ai_compassion
+							multiply = -1
+						}
+					}
+					modifier = {
+						ai_compassion > 0
+						add = -9
+					}
+					trait:callous = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+			}
+		}
+		#IDEALIST
+		if = {
+			limit = {
+				scope:accolade = {
+					scope:type = accolade_type:idealist_attribute
+				}
+				NOR = {
+					#Doesn't have all opposing traits
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:sadistic
+							this = trait:callous
+							this = trait:vengeful
+							this = trait:paranoid
+							this = trait:greedy
+						}
+					}
+					#Doesn't have all traits that already fit
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:compassionate
+							this = trait:forgiving
+							this = trait:trusting
+							this = trait:generous
+						}
+					}
+				}
+			}
+			trait:compassionate = { add_to_list = accolade_traits }
+			trait:forgiving = { add_to_list = accolade_traits }
+			trait:trusting = { add_to_list = accolade_traits }
+			trait:generous = { add_to_list = accolade_traits }
+			random_list = {
+				#Compassionate
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = sadistic
+							has_trait = callous
+							has_trait = compassionate
+						}
+					}
+					modifier = {
+						ai_compassion > 0
+						add = ai_compassion
+					}
+					modifier = {
+						ai_compassion < 0
+						add = -9
+					}
+					trait:compassionate = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#forgiving
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = vengeful
+							has_trait = forgiving
+						}
+					}
+					modifier = {
+						ai_vengefulness < 0
+						add = {
+							value = ai_vengefulness
+							multiply = 1
+						}
+					}
+					modifier = {
+						ai_vengefulness > 0
+						add = -9
+					}
+					trait:forgiving = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#trusting
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = trusting
+							has_trait = paranoid
+						}
+					}
+					modifier = {
+						ai_sociability > 0
+						add = {
+							value = ai_sociability
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_honor > 0
+						add = {
+							value = ai_honor
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_sociability < 0
+						add = -4
+					}
+					modifier = {
+						ai_honor < 0
+						add = -4
+					}
+					trait:callous = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#generous
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = greedy
+							has_trait = generous
+						}
+					}
+					modifier = {
+						ai_greed < 0
+						add = {
+							value = ai_greed
+							multiply = -1
+						}
+					}
+					modifier = {
+						ai_greed > 0
+						add = -9
+					}
+					trait:generous = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+			}
+		}
+		#CHARMER
+		if = {
+			limit = {
+				scope:accolade = {
+					scope:type = accolade_type:charmer_attribute
+				}
+				NOR = {
+					has_trait = lustful
+					has_trait = chaste
+					has_trait = celibate
+				}
+			}
+			trait:lustful = { add_to_list = accolade_traits }
+			#100% lust gain might be a bit much
+			random = {
+				chance = {
+					value = 60
+					#Knights being trained is at 100%, for squires is adjusted by squires aptitude
+					if = {
+						limit = {
+							NOT = { exists = scope:squire }
+						}
+						add = 40
+					}
+					if = {
+						limit = {
+							exists = scope:squire
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+							}
+						}
+						add = 20
+					}
+					if = {
+						limit = {
+							exists = scope:squire
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+							}
+						}
+						add = 20
+					}
+				}
+				trait:lustful = { save_scope_as = personality_trait_add }
+				add_character_flag = {
+					flag = squire_gained_trait
+					days = 30
+				}
+			}
+		}
+		#THUG
+		if = {
+			limit = {
+				scope:accolade = {
+					scope:type = accolade_type:thug_attribute
+				}
+				NOR = {
+					#Doesn't have all opposing traits
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:calm
+							this = trait:just
+							this = trait:patient
+							this = trait:humble
+						}
+					}
+					#Doesn't have all traits that already fit
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:wrathful
+							this = trait:arbitrary
+							this = trait:impatient
+							this = trait:arrogant
+						}
+					}
+				}
+			}
+			trait:wrathful = { add_to_list = accolade_traits }
+			trait:arbitrary = { add_to_list = accolade_traits }
+			trait:impatient = { add_to_list = accolade_traits }
+			trait:arrogant = { add_to_list = accolade_traits }
+			random_list = {
+				#wrathful
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = wrathful
+							has_trait = calm
+						}
+					}
+					modifier = {
+						ai_rationality < 0
+						add = {
+							value = ai_rationality
+							multiply = 1
+						}
+					}
+					modifier = {
+						ai_rationality > 0
+						add = -9
+					}
+					trait:wrathful = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#arbitrary
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = arbitrary
+							has_trait = just
+						}
+					}
+					modifier = {
+						ai_honor < 0
+						add = {
+							value = ai_honor
+							multiply = 1
+						}
+					}
+					modifier = {
+						ai_honor > 0
+						add = -9
+					}
+					trait:arbitrary = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#impatient
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = impatient
+							has_trait = patient
+						}
+					}
+					modifier = {
+						ai_boldness > 0
+						add = {
+							value = ai_boldness
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_rationality < 0
+						add = {
+							value = ai_rationality
+							multiply = -0.5
+						}
+					}
+					modifier = {
+						ai_boldness < 0
+						add = -4
+					}
+					modifier = {
+						ai_rationality > 0
+						add = -4
+					}
+					trait:impatient = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#arrogant
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = arrogant
+							has_trait = humble
+						}
+					}
+					modifier = {
+						ai_greed > 0
+						add = {
+							value = ai_greed
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_compassion < 0
+						add = {
+							value = ai_compassion
+							multiply = -0.5
+						}
+					}
+					modifier = {
+						ai_boldness < 0
+						add = -4
+					}
+					modifier = {
+						ai_compassion > 0
+						add = -4
+					}
+					trait:arrogant = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+			}
+		}
+		#DISCIPLINARIAN
+		if = {
+			limit = {
+				scope:accolade = {
+							scope:type = accolade_type:disciplinarian_attribute
+				}
+				NOR = {
+					#Doesn't have all opposing traits
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:fickle
+							this = trait:eccentric
+							this = trait:lazy
+							this = trait:gluttonous
+						}
+					}
+					#Doesn't have all traits that already fit
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:stubborn
+							this = trait:diligent
+							this = trait:temperate
+						}
+					}
+				}
+			}
+			trait:stubborn = { add_to_list = accolade_traits }
+			trait:diligent = { add_to_list = accolade_traits }
+			trait:temperate = { add_to_list = accolade_traits }
+			random_list = {
+				#stubborn
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = stubborn
+							has_trait = fickle
+							has_trait = eccentric
+						}
+					}
+					modifier = {
+						ai_vengefulness > 0
+						add = {
+							value = ai_vengefulness
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_honor > 0
+						add = {
+							value = ai_honor
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_vengefulness < 0
+						add = -4
+					}
+					modifier = {
+						ai_honor < 0
+						add = -4
+					}
+					trait:stubborn = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#diligent
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = diligent
+							has_trait = lazy
+						}
+					}
+					modifier = {
+						ai_energy > 0
+						add = {
+							value = ai_energy
+							multiply = 1
+						}
+					}
+					modifier = {
+						ai_energy < 0
+						add = -9
+					}
+					trait:diligent = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#temperate
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = temperate
+							has_trait = gluttonous
+						}
+					}
+					modifier = {
+						ai_greed < 0
+						add = {
+							value = ai_greed
+							multiply = -1
+						}
+					}
+					modifier = {
+						ai_greed > 0
+						add = -9
+					}
+					trait:temperate = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+			}
+		}
+		#FANATIC
+		if = {
+			limit = {
+				scope:accolade = {
+					scope:type = accolade_type:fanatic_attribute
+				}
+				NOR = {
+					has_trait = zealous
+					has_trait = cynical
+				}
+			}
+			trait:zealous = { add_to_list = accolade_traits }
+			#100% lust gain might be a bit much
+			random = {
+				chance = {
+					value = 50
+					#Knights being trained is at 100%, for squires is adjusted by squires aptitude
+					if = {
+						limit = {
+							NOT = { exists = scope:squire }
+						}
+						add = 50
+					}
+					if = {
+						limit = {
+							exists = scope:squire
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+							}
+						}
+						add = 25
+					}
+					if = {
+						limit = {
+							exists = scope:squire
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+							}
+						}
+						add = 25
+					}
+				}
+				trait:zealous = { save_scope_as = personality_trait_add }
+				add_character_flag = {
+					flag = squire_gained_trait
+					days = 30
+				}
+			}
+		}
+		#VALIANT
+		if = {
+			limit = {
+				scope:accolade = {
+					scope:type = accolade_type:valiant_attribute
+				}
+				NOR = {
+					has_trait = craven
+					has_trait = brave
+				}
+			}
+			trait:brave = { add_to_list = accolade_traits }
+			#100% lust gain might be a bit much
+			random = {
+				chance = {
+					value = 40
+					#Knights being trained is at 100%, for squires is adjusted by squires aptitude
+					if = {
+						limit = {
+							NOT = { exists = scope:squire }
+						}
+						add = 60
+					}
+					if = {
+						limit = {
+							exists = scope:squire
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value
+							}
+						}
+						add = 30
+					}
+					if = {
+						limit = {
+							exists = scope:squire
+							scope:accolade = {
+								accolade_squires_quality_value >= accolade_squires_capable_minimum_value
+							}
+						}
+						add = 30
+					}
+				}
+				trait:brave = { save_scope_as = personality_trait_add }
+				add_character_flag = {
+					flag = squire_gained_trait
+					days = 30
+				}
+			}
+		}
+		#STALWART
+		if = {
+			limit = {
+				scope:accolade = {
+					scope:type = accolade_type:stalwart_attribute
+				}
+				NOR = {
+					#Doesn't have all opposing traits
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:deceitful
+							this = trait:arbitrary
+							this = trait:impatient
+						}
+					}
+					#Doesn't have all traits that already fit
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:honest
+							this = trait:just
+							this = trait:patient
+						}
+					}
+				}
+			}
+			trait:honest = { add_to_list = accolade_traits }
+			trait:just = { add_to_list = accolade_traits }
+			trait:patient = { add_to_list = accolade_traits }
+			random_list = {
+				#honest
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = honest
+							has_trait = deceitful
+						}
+					}
+					modifier = {
+						ai_honor > 0
+						add = {
+							value = ai_honor
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_compassion > 0
+						add = {
+							value = ai_compassion
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_compassion < 0
+						add = -4
+					}
+					modifier = {
+						ai_honor < 0
+						add = -4
+					}
+					trait:honest = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#just
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = just
+							has_trait = arbitrary
+						}
+					}
+					modifier = {
+						ai_honor > 0
+						add = {
+							value = ai_honor
+							multiply = 1
+						}
+					}
+					modifier = {
+						ai_honor < 0
+						add = -9
+					}
+					trait:just = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#patient
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = patient
+							has_trait = impatient
+						}
+					}
+					modifier = {
+						ai_rationality > 0
+						add = {
+							value = ai_rationality
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_boldness < 0
+						add = {
+							value = ai_boldness
+							multiply = -0.5
+						}
+					}
+					modifier = {
+						ai_rationality < 0
+						add = -4
+					}
+					modifier = {
+						ai_boldness > 0
+						add = -4
+					}
+					trait:patient = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+			}
+		}
+		#SCOUNDREL
+		if = {
+			limit = {
+				scope:accolade = {
+					scope:type = accolade_type:scoundrel_attribute
+				}
+				NOR = {
+					#Doesn't have all opposing traits
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:content
+							this = trait:shy
+							this = trait:generous
+							this = trait:honest
+						}
+					}
+					#Doesn't have all traits that already fit
+					any_character_trait = {
+						count >= 3
+						OR = {
+							this = trait:ambitious
+							this = trait:gregarious
+							this = trait:greedy
+							this = trait:deceitful
+						}
+					}
+				}
+			}
+			trait:ambitious = { add_to_list = accolade_traits }
+			trait:gregarious = { add_to_list = accolade_traits }
+			trait:greedy = { add_to_list = accolade_traits }
+			trait:deceitful = { add_to_list = accolade_traits }
+			random_list = {
+				#ambitious
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = ambitious
+							has_trait = content
+						}
+					}
+					modifier = {
+						ai_energy > 0
+						add = {
+							value = ai_energy
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_greed > 0
+						add = {
+							value = ai_greed
+							multiply = 0.5
+						}
+					}
+					modifier = {
+						ai_energy < 0
+						add = -4
+					}
+					modifier = {
+						ai_greed < 0
+						add = -4
+					}
+					trait:ambitious = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#gregarious
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = gregarious
+							has_trait = shy
+						}
+					}
+					modifier = {
+						ai_sociability > 0
+						add = {
+							value = ai_sociability
+							multiply = 1
+						}
+					}
+					modifier = {
+						ai_sociability < 0
+						add = -9
+					}
+					trait:gregarious = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#greedy
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = greedy
+							has_trait = generous
+						}
+					}
+					modifier = {
+						ai_greed > 0
+						add = {
+							value = ai_greed
+							multiply = 1
+						}
+					}
+					modifier = {
+						ai_greed < 0
+						add = -9
+					}
+					trait:greedy = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+				#deceitful
+				10 = {
+					trigger = {
+						NOR = {
+							has_trait = deceitful
+							has_trait = honest
+						}
+					}
+					modifier = {
+						ai_compassion < 0
+						add = {
+							value = ai_compassion
+							multiply = -0.5
+						}
+					}
+					modifier = {
+						ai_honor < 0
+						add = {
+							value = ai_honor
+							multiply = -0.5
+						}
+					}
+					modifier = {
+						ai_compassion > 0
+						add = -4
+					}
+					modifier = {
+						ai_honor > 0
+						add = -4
+					}
+					trait:deceitful = { save_scope_as = personality_trait_add }
+					add_character_flag = {
+						flag = squire_gained_trait
+						days = 30
+					}
+				}
+			}
+		}
+	}
+	#Just gained a personality trait? Too many personality traits? Remove one
+	if = {
+		limit = {
+			has_character_flag = squire_gained_trait
+			number_of_personality_traits >= 3
+			#Don't want to remove traits unless we just added one
+		}
+		random_character_trait = {
+			limit = {
+				has_trait_category = personality
+				NOR = {
+					is_in_list = accolade_traits
+					#knights having these traits increases prowess, should avoid removing them if possible
+					this = trait:brave
+					#Only idealists want to remove these
+					AND = {
+						this = trait:sadistic
+						NOT = { scope:type = accolade_type:idealist_attribute }
+					}
+					AND = {
+						this = trait:vengeful
+						NOT = { scope:type = accolade_type:idealist_attribute }
+					}
+				}
+				#Try to avoid removing virtuous traits
+				save_temporary_scope_as = remove_temp
+				trigger_if = {
+					limit = {
+						exists = scope:squire
+					}
+					NOT = {
+						scope:squire.faith = { trait_is_virtue = scope:remove_temp }
+					}
+				}
+				trigger_else = {
+					scope:acclaimed_knight.faith = { trait_is_virtue = scope:remove_temp }
+				}
+			}
+			alternative_limit = {
+				has_trait_category = personality
+				NOR = {
+					is_in_list = accolade_traits
+					#knights having these traits increases prowess, should avoid removing them if possible
+					this = trait:brave
+					#Only idealists want to remove these
+					AND = {
+						this = trait:sadistic
+						NOT = { scope:type = accolade_type:idealist_attribute }
+					}
+					AND = {
+						this = trait:vengeful
+						NOT = { scope:type = accolade_type:idealist_attribute }
+					}
+				}
+			}
+			alternative_limit = {
+				has_trait_category = personality
+				NOT = {
+					is_in_list = accolade_traits
+				}
+			}
+			save_scope_as = personality_trait_remove
+		}
+	}
+}
+
+#Accolade successor picking/creation/adjusting effect, run in on_accolade_create_squire on_action
+accolade_create_squire_effect = {
+	save_scope_as = owner
+	if = {
+		limit = {
+			is_ai = no
+		}
+		#try to find a descendant of the knight
+		if = {
+			limit = {
+				exists = scope:knight_in_need
+			}
+			ordered_courtier_or_guest = {
+				order_by = prowess
+				limit = {
+					is_child_of = scope:knight_in_need
+					new_acclaimed_knight_search_trigger = yes
+
+					save_temporary_scope_as = candidate_temp
+					scope:accolade_in_need = {
+						has_variable_list = accolade_squire_chars
+						any_in_list = {
+							variable = accolade_squire_chars
+							this = scope:candidate_temp
+						}
+					}
+				}
+				alternative_limit = {
+					is_child_of = scope:knight_in_need
+					new_acclaimed_knight_search_trigger = yes
+				}
+				save_scope_as = chosen_knight
+			}
+			if = {
+				limit = {
+					NOT = { exists = scope:chosen_knight }
+				}
+				#Try to find former ward of knight
+				ordered_courtier_or_guest = {
+					order_by = prowess
+					limit = {
+						OR = {
+							any_memory = {
+								has_memory_type = childhood_education_guardian
+								has_memory_participant = scope:knight_in_need
+							}
+							has_relation_disciple = scope:knight_in_need
+							has_relation_elder = scope:knight_in_need
+						}
+
+						#Just to be sure this char was the ward in the memory, not the guardian
+						age < scope:knight_in_need.age
+						new_acclaimed_knight_search_trigger = yes
+
+						save_temporary_scope_as = candidate_temp
+						scope:accolade_in_need = {
+							has_variable_list = accolade_squire_chars
+							any_in_list = {
+								variable = accolade_squire_chars
+								this = scope:candidate_temp
+							}
+						}
+					}
+					alternative_limit = {
+						OR = {
+							any_memory = {
+								has_memory_type = childhood_education_guardian
+								has_memory_participant = scope:knight_in_need
+							}
+							has_relation_disciple = scope:knight_in_need
+							has_relation_elder = scope:knight_in_need
+						}
+
+						#Just to be sure this char was the ward in the memory, not the guardian
+						age < scope:knight_in_need.age
+						new_acclaimed_knight_search_trigger = yes
+					}
+					save_scope_as = chosen_knight
+				}
+			}
+			if = {
+				limit = {
+					NOT = { exists = scope:chosen_knight }
+				}
+				#Positive relation or family member knight of knight
+				ordered_knight = {
+					order_by = prowess
+					limit = {
+						culture_matches_accolade_specialization_trigger = { ACCOLADE = scope:accolade_in_need }
+						OR = {
+							has_any_moderate_good_relationship_with_character_trigger = { CHARACTER = scope:knight_in_need }
+							AND = {
+								exists = scope:knight_in_need.house
+								house ?= scope:knight_in_need.house
+							}
+							any_close_or_extended_family_member = {
+								this = scope:knight_in_need
+							}
+						}
+						new_acclaimed_knight_search_trigger = yes
+
+						save_temporary_scope_as = candidate_temp
+						scope:accolade_in_need = {
+							has_variable_list = accolade_squire_chars
+							any_in_list = {
+								variable = accolade_squire_chars
+								this = scope:candidate_temp
+							}
+						}
+					}
+					alternative_limit = {
+						culture_matches_accolade_specialization_trigger = { ACCOLADE = scope:accolade_in_need }
+						OR = {
+							has_any_moderate_good_relationship_with_character_trigger = { CHARACTER = scope:knight_in_need }
+							AND = {
+								exists = scope:knight_in_need.house
+								house ?= scope:knight_in_need.house
+							}
+							any_close_or_extended_family_member = {
+								this = scope:knight_in_need
+							}
+						}
+						new_acclaimed_knight_search_trigger = yes
+					}
+					alternative_limit = {
+						OR = {
+							has_any_moderate_good_relationship_with_character_trigger = { CHARACTER = scope:knight_in_need }
+							AND = {
+								exists = scope:knight_in_need.house
+								house ?= scope:knight_in_need.house
+							}
+							any_close_or_extended_family_member = {
+								this = scope:knight_in_need
+							}
+						}
+						new_acclaimed_knight_search_trigger = yes
+
+						save_temporary_scope_as = candidate_temp
+						scope:accolade_in_need = {
+							has_variable_list = accolade_squire_chars
+							any_in_list = {
+								variable = accolade_squire_chars
+								this = scope:candidate_temp
+							}
+						}
+					}
+					alternative_limit = {
+						OR = {
+							has_any_moderate_good_relationship_with_character_trigger = { CHARACTER = scope:knight_in_need }
+							AND = {
+								exists = scope:knight_in_need.house
+								house ?= scope:knight_in_need.house
+							}
+							any_close_or_extended_family_member = {
+								this = scope:knight_in_need
+							}
+						}
+						new_acclaimed_knight_search_trigger = yes
+					}
+					save_scope_as = chosen_knight
+				}
+			}
+		}
+		#try to find another knight
+		if = {
+			limit = {
+				NOT = {
+					exists = scope:chosen_knight
+				}
+			}
+			ordered_knight = {
+				order_by = {
+					value = prowess
+					if = {
+						limit = {
+							exists = scope:knight_in_need
+							is_close_or_extended_family_of = scope:knight_in_need
+						}
+						add = 20
+					}
+					if = {
+						limit = {
+							save_temporary_scope_as = candidate_temp
+							scope:accolade_in_need = {
+								has_variable_list = accolade_squire_chars
+								any_in_list = {
+									variable = accolade_squire_chars
+									this = scope:candidate_temp
+								}
+							}
+						}
+						add = 1000
+					}
+				}
+				limit = {
+					culture_matches_accolade_specialization_trigger = { ACCOLADE = scope:accolade_in_need }
+					new_acclaimed_knight_search_trigger = yes
+				}
+				alternative_limit = {
+					new_acclaimed_knight_search_trigger = yes
+				}
+				save_scope_as = chosen_knight
+			}
+		}
+		#Positive relation or family member of knight
+		if = {
+			limit = {
+				NOT = {
+					exists = scope:chosen_knight
+				}
+				exists = scope:knight_in_need
+			}
+			ordered_courtier_or_guest = {
+				order_by = {
+					value = prowess
+					if = {
+						limit = {
+							save_temporary_scope_as = candidate_temp
+							scope:accolade_in_need = {
+								has_variable_list = accolade_squire_chars
+								any_in_list = {
+									variable = accolade_squire_chars
+									this = scope:candidate_temp
+								}
+							}
+						}
+						add = 1000
+					}
+				}
+				limit = {
+					culture_matches_accolade_specialization_trigger = { ACCOLADE = scope:accolade_in_need }
+					OR = {
+						has_any_moderate_good_relationship_with_character_trigger = { CHARACTER = scope:knight_in_need }
+						AND = {
+							exists = scope:knight_in_need.house
+							house ?= scope:knight_in_need.house
+						}
+						any_close_or_extended_family_member = {
+							this = scope:knight_in_need
+						}
+					}
+					new_acclaimed_knight_search_trigger = yes
+				}
+				alternative_limit = {
+					OR = {
+						has_any_moderate_good_relationship_with_character_trigger = { CHARACTER = scope:knight_in_need }
+						AND = {
+							exists = scope:knight_in_need.house
+							house ?= scope:knight_in_need.house
+						}
+						any_close_or_extended_family_member = {
+							this = scope:knight_in_need
+						}
+					}
+					new_acclaimed_knight_search_trigger = yes
+				}
+				save_scope_as = chosen_knight
+			}
+		}
+		#any valid courtier
+		if = {
+			limit = {
+				NOT = {
+					exists = scope:chosen_knight
+				}
+			}
+			ordered_courtier = {
+				order_by = {
+					value = prowess
+					if = {
+						limit = {
+							save_temporary_scope_as = candidate_temp
+							scope:accolade_in_need = {
+								has_variable_list = accolade_squire_chars
+								any_in_list = {
+									variable = accolade_squire_chars
+									this = scope:candidate_temp
+								}
+							}
+						}
+						add = 1000
+					}
+				}
+				limit = {
+					culture_matches_accolade_specialization_trigger = { ACCOLADE = scope:accolade_in_need }
+					new_acclaimed_knight_search_trigger = yes
+				}
+				alternative_limit = {
+					new_acclaimed_knight_search_trigger = yes
+				}
+				save_scope_as = chosen_knight
+			}
+		}
+		if = {
+			limit = {
+				NOT = {
+					exists = scope:chosen_knight
+				}
+			}
+			# try to find a pool character
+			ordered_pool_guest = {
+			 	order_by = {
+					value = prowess
+					if = {
+						limit = {
+							save_temporary_scope_as = candidate_temp
+							scope:accolade_in_need = {
+								has_variable_list = accolade_squire_chars
+								any_in_list = {
+									variable = accolade_squire_chars
+									this = scope:candidate_temp
+								}
+							}
+						}
+						add = 1000
+					}
+				}
+				limit = {
+					culture_matches_accolade_specialization_trigger = { ACCOLADE = scope:accolade_in_need }
+					new_acclaimed_knight_search_trigger = yes
+				}
+				alternative_limit = {
+					new_acclaimed_knight_search_trigger = yes
+				}
+				save_scope_as = chosen_knight
+			}
+		}
+		if = {
+			limit = {
+				NOT = {
+					exists = scope:chosen_knight
+				}
+			}
+			# try to find a pool character
+			ordered_pool_character = {
+			 	order_by = {
+					value = prowess
+					if = {
+						limit = {
+							save_temporary_scope_as = candidate_temp
+							scope:accolade_in_need = {
+								has_variable_list = accolade_squire_chars
+								any_in_list = {
+									variable = accolade_squire_chars
+									this = scope:candidate_temp
+								}
+							}
+						}
+						add = 1000
+					}
+				}
+				province = capital_province
+				limit = {
+					culture_matches_accolade_specialization_trigger = { ACCOLADE = scope:accolade_in_need }
+					new_acclaimed_knight_search_trigger = yes
+				}
+				alternative_limit = {
+					new_acclaimed_knight_search_trigger = yes
+				}
+				save_scope_as = chosen_knight
+			}
+		}
+		#Create character if we failed to find one
+		if = {
+			limit = {
+				NOT = { exists = scope:chosen_knight }
+			}
+			accolade_character_creation_effect = yes
+		}
+	}
+	else = {
+		ordered_courtier = {
+			order_by = {
+				value = prowess
+				if = {
+					limit = {
+						save_temporary_scope_as = candidate_temp
+						scope:accolade_in_need = {
+							has_variable_list = accolade_squire_chars
+							any_in_list = {
+								variable = accolade_squire_chars
+								this = scope:candidate_temp
+							}
+						}
+					}
+					add = 1000
+				}
+			}
+			limit = {
+				culture_matches_accolade_specialization_trigger = { ACCOLADE = scope:accolade_in_need }
+				new_acclaimed_knight_search_trigger = yes
+			}
+			alternative_limit = {
+				new_acclaimed_knight_search_trigger = yes
+			}
+			save_scope_as = chosen_knight
+		}
+		#Create character if we failed to find one
+		if = {
+			limit = {
+				NOT = { exists = scope:chosen_knight }
+			}
+			accolade_character_creation_effect = yes
+		}
+	}
+	#Boost stats of picked or created char based on squire quality
+	scope:chosen_knight = {
+		accolade_squires_boost_martial_tourney_effect = yes
+
+		accolade_squires_boost_prowess_effect = yes
+		#Make them nobles if they're not... they are knights now, after all
+		if = {
+			limit = {
+				is_lowborn = yes
+			}
+			create_dynasty = {
+				spread_to_descendants = yes
+			}
+		}
+	}
+
+	if = {
+		limit = {
+			exists = scope:chosen_knight
+		}
+		if = {
+			limit = {
+				can_recruit_character_to_court_trigger = {
+					RECRUITER = scope:owner
+					RECRUITEE = scope:chosen_knight
+				}
+				# make sure the chosen knight is not already a courtier
+				scope:chosen_knight = {
+					NOT = {
+						is_courtier_of = scope:owner
+					}
+					is_ruler = no
+				}
+			}
+			add_courtier = scope:chosen_knight
+		}
+		
+		scope:chosen_knight = {
+			set_knight_status = force
+		}
+		
+		scope:accolade_in_need = {
+			set_accolade_successor = scope:chosen_knight
+		}
+	}
+}
+
+accolade_knight_notification_effect = {
+	scope:succeeding_accolade = {
+		var:old_knight = {
+			save_scope_as = old_knight
+		}
+		initial_type = { save_scope_as = main_type }
+	}
+	if = {
+		limit = {
+			exists = scope:new_acclaimed_knight
+		}
+		scope:new_acclaimed_knight = {
+			save_scope_as = portrait
+		}
+	}
+	else = {
+		scope:old_knight = {
+			save_scope_as = portrait
+		}
+	}
+	send_interface_message = {
+		type = msg_accolade_succession
+		title = accolade_notification_$REASON$.old_acclaimed_knight.tt
+		left_icon = scope:portrait
+		desc = accolade_notification_$REASON$.old_acclaimed_knight_name.tt
+
+		#Tooltip about how squires modified character
+		if = {
+			limit = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+			}
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_accomplished
+		}
+		else_if = {
+			limit = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+			}
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_capable
+		}
+		else_if = {
+			limit = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+			}
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_inexperienced
+		}
+		else_if = {
+			limit = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_feckless_minimum_value }
+			}
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_feckless
+		}
+		else = {
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_pathetic
+		}
+		if = {
+			limit = {
+				exists = scope:glory
+				scope:glory < 0
+			}
+			custom_tooltip = accolade.glory_loss.tt
+		}
+		else = {
+			custom_tooltip = accolade.no_glory_loss.tt
+		}
+	}
+}
+
+accolade_knight_notification_with_glory_reset_effect = {
+	scope:succeeding_accolade = {
+		var:old_knight = {
+			save_scope_as = old_knight
+		}
+		initial_type = { save_scope_as = main_type }
+	}
+	if = {
+		limit = {
+			exists = scope:new_acclaimed_knight
+		}
+		scope:new_acclaimed_knight = {
+			save_scope_as = portrait
+		}
+	}
+	else = {
+		scope:old_knight = {
+			save_scope_as = portrait
+		}
+	}
+	send_interface_message = {
+		type = msg_accolade_succession
+		title = accolade_notification_$REASON$.old_acclaimed_knight.tt
+		left_icon = scope:portrait
+		desc = accolade_notification_$REASON$.old_acclaimed_knight_name.tt
+
+		#Tooltip about how squires modified character
+		if = {
+			limit = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_accomplished_minimum_value }
+			}
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_accomplished
+		}
+		else_if = {
+			limit = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_capable_minimum_value }
+			}
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_capable
+		}
+		else_if = {
+			limit = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_inexperienced_minimum_value }
+			}
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_inexperienced
+		}
+		else_if = {
+			limit = {
+				scope:succeeding_accolade = { accolade_squires_quality_value >= accolade_squires_feckless_minimum_value }
+			}
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_feckless
+		}
+		else = {
+			custom_tooltip = accolade_notification_$REASON$.squires_quality_pathetic
+		}
+	}
+	scope:succeeding_accolade = {
+		#Reset the lifetime glory so we can refresh the squires stat
+		if = {
+			limit = {
+				exists = var:lifetime_glory
+			}
+			change_variable = {
+				name = lifetime_glory
+				multiply = 0
+			}
+		}
+		if = {
+			limit = {
+				exists = var:old_knight
+			}
+			remove_variable = old_knight
+		}
+	}
+}
+
+accolade_ward_education_notification_effect = {
+    show_as_tooltip = {
+        if = {
+            limit = {
+                scope:guardian = {
+                    is_acclaimed = yes
+                }
+                scope:ward = {
+                    OR = {
+                        can_be_combatant_based_on_gender_trigger = { ARMY_OWNER = liege }
+                        #Player can ignore gender triggers
+                        is_ai = no
+                        any_close_family_member = {
+                            is_ai = no
+                        }
+                    }
+                    NOR = {
+                        has_trait = infirm
+                        has_trait = physique_bad_3
+                        has_trait = blind
+                        has_trait = maimed
+                    }
+                }
+            }
+            scope:ward = {
+                custom_tooltip = accolade_education_tt
+            }
+        }
+    }
+}

--- a/common/scripted_effects/00_accolades_scripted_effects.txt
+++ b/common/scripted_effects/00_accolades_scripted_effects.txt
@@ -3854,7 +3854,31 @@ accolade_squires_boost_prowess_effect = {
 		}
 	}
 	#If prowess is too low, get up to minimum
+	#Unop The minimum must match the knight requirement, otherwise the new acclaimed knight is rejected as a knight
 	if = {
+		limit = {
+			scope:owner.culture ?= {
+				has_cultural_parameter = minimum_prowess_for_knights
+			}
+			prowess < 12
+		}
+		save_scope_value_as = {
+			name = prowess
+			value = prowess
+		}
+
+		if = {
+			limit = {
+				prowess > 0
+			}
+			add_prowess_skill = {
+				value = scope:prowess
+				multiply = -1
+			}
+		}
+		add_prowess_skill = 12
+	}
+	else_if = {
 		limit = {
 			prowess < 8
 		}
@@ -4989,7 +5013,9 @@ accolade_squire_training_effect = {
 							title_tier = county
 							is_landless_type_title = no
 							any_county_province = {
-								location_has_harsh_winter_trigger = yes
+								#Unop Already in province scope here, so `location` does not resolve
+								#location_has_harsh_winter_trigger = yes
+								has_province_modifier = winter_harsh_modifier
 							}
 						}
 					}
@@ -5805,7 +5831,9 @@ accolade_squire_training_effect = {
 										title_tier = county
 										is_landless_type_title = no
 										any_county_province = {
-											location_has_harsh_winter_trigger = yes
+											#Unop Already in province scope here, so `location` does not resolve
+											#location_has_harsh_winter_trigger = yes
+											has_province_modifier = winter_harsh_modifier
 										}
 									}
 								}
@@ -7537,7 +7565,9 @@ accolade_knight_training_effect = {
 							title_tier = county
 							is_landless_type_title = no
 							any_county_province = {
-								location_has_harsh_winter_trigger = yes
+								#Unop Already in province scope here, so `location` does not resolve
+								#location_has_harsh_winter_trigger = yes
+								has_province_modifier = winter_harsh_modifier
 							}
 						}
 					}
@@ -8232,7 +8262,9 @@ accolade_knight_training_effect = {
 										title_tier = county
 										is_landless_type_title = no
 										any_county_province = {
-											location_has_harsh_winter_trigger = yes
+											#Unop Already in province scope here, so `location` does not resolve
+											#location_has_harsh_winter_trigger = yes
+											has_province_modifier = winter_harsh_modifier
 										}
 									}
 								}


### PR DESCRIPTION
Fixes #576

**fixer:** With the `only_the_strong` tradition (`minimum_prowess_for_knights`), knighthood requires `prowess >= 12`, but acclaimed-knight successor selection only requires `prowess >= 8`. `new_acclaimed_knight_search_trigger` does apply `can_be_knight_trigger`, but exempts characters who are *already a knight of the owner* (`trigger_if NOT is_knight_of`). An existing knight whose prowess is 8–11 (e.g. knighted before the culture took the tradition, or whose prowess later dropped) thus passes successor selection but is invalid as a knight, so gets rejected — triggering another succession, and looping.

Fix: enforce the knight prowess minimum (`prowess >= 12` when the owner's culture has `minimum_prowess_for_knights`) unconditionally in `new_acclaimed_knight_search_trigger`, so already-knighted low-prowess characters are excluded from selection. This targets the real invariant rather than widening the existing exemption. All 20 selection paths funnel through this one trigger.

Adding the vanilla file as a new override surfaced 5 unrelated latent vanilla `strict-scopes` warnings (`fanatic_attribute_trigger` etc. reference `scope:owner`, guarded by `?=`); flagged as false positives in `ck3-tiger.conf`.