### PR TITLE
Let Japanese independent regent form a cadet house when house head is elsewhere

### DIFF
--- a/common/decisions/00_dynasty_decisions.txt
+++ b/common/decisions/00_dynasty_decisions.txt
@@ -1,0 +1,320 @@
+﻿### Create Cadet Branch ###
+create_cadet_branch_decision = {
+	picture = {
+		trigger = {
+			government_is_japanese_trigger = yes
+		}
+		reference = "gfx/interface/illustrations/decisions/tgp_poet.dds"
+	}
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_dynasty_house.dds"
+	}
+
+	decision_group_type = major
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 6
+		duchy = 6
+		kingdom = 6
+		empire = 6
+		hegemony = 6
+	}
+
+	is_shown = {
+		is_playable_character = yes
+		exists = house.house_head
+		is_house_head = no
+		highest_held_title_tier > tier_barony
+		NOR = {
+			government_has_flag = government_is_holy_order
+			government_has_flag = government_is_theocracy
+			AND = {
+				faith = { has_doctrine = doctrine_theocracy_temporal }
+				has_council_position = councillor_court_chaplain
+			}
+			AND = {
+				has_tgp_dlc_trigger = yes
+				tgp_is_in_ceremonial_house_trigger = yes
+			}
+		}
+	}
+
+	is_valid = {
+		is_adult = yes
+		government_allows = create_cadet_branches
+		# Must have living children of same house
+		custom_tooltip = {
+			text = create_cadet_branch_decision_living_children
+			any_child = {
+				count >= 1
+				is_alive = yes
+				house ?= root.house
+			}
+		}
+		# No direct descendant is liege or above
+		custom_tooltip = {
+			text = create_cadet_branch_decision_liege_is_descendant
+			any_liege_or_above_is_descendant = no
+		}
+		# If you are Clan, you cannot be in the same realm as your House Head. For simplicity, we'll just force you to be independent.
+		trigger_if = {
+			limit = {
+				government_has_flag = government_is_clan
+			}
+			top_liege = this
+		}
+		# If you are Administrative, we let the player create a new House much easier, as to have easy access to their own Family Title and Estate.
+		trigger_else_if = {
+			limit = { government_allows = administrative }
+			trigger_if = {
+				limit = {
+					is_ai = yes # We don't want the AI to create cadet branches willy nilly, so they have additional restrictions.
+					top_liege = house.house_head.top_liege # But we do want the AI to create a cadet branch ASAP if the house head is in a different realm
+				}
+				NOT = { is_close_or_extended_family_of = house.house_head }
+				custom_description = {
+					text = create_cadet_branch_decision_succession_line
+					house.house_head = {
+						NOT = {
+							any_held_title = {
+								place_in_line_of_succession = {
+									target = root
+									value <=3
+								}
+							}
+						}
+					}
+				}
+			}
+			# No triggers for players.
+		}
+		# For everyone else, you cannot be too close in the line of succession.
+		trigger_else = {
+			custom_description = {
+				text = create_cadet_branch_decision_succession_line
+				house.house_head = {
+					NOT = {
+						any_held_title = {
+							place_in_line_of_succession = {
+								target = root
+								value <= 3
+							}
+						}
+					}
+				}
+			}
+		}
+		# Marriage restrictions
+		trigger_if = {
+			limit = { is_male = yes }
+			trigger_if = {
+				limit = {
+					OR = {
+						is_married = yes
+						faith = { has_doctrine = doctrine_gender_female_dominated }
+					}
+				}
+				patrilinear_marriage = yes
+			}
+		}
+		trigger_else = {
+			trigger_if = {
+				limit = {
+					OR = {
+						is_married = yes
+						faith = { has_doctrine = doctrine_gender_male_dominated }
+					}
+				}
+				matrilinear_marriage = yes
+			}
+		}
+		# Monks need not apply
+		trigger_if = {
+			limit = { has_trait = devoted }
+			NOT = { has_trait = devoted }
+		}
+		trigger_if = {
+			limit = { has_trait = bastard }
+			NOT = { has_trait = bastard }
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_available_adult = yes
+		is_playable_character = yes
+	}
+
+	effect = {
+		house.house_head ?= { save_scope_as = old_head }
+		if = {
+			limit = {
+				has_tgp_dlc_trigger = yes
+				culture = {
+					OR = {
+						has_cultural_pillar = language_japonic
+						has_name_list = name_list_yamato
+					}
+				}
+			}
+			add_character_flag = found_cadet_branch
+			trigger_event = tgp_japan_decision.9001
+			show_as_tooltip = {
+				create_cadet_branch = { save_scope_as = new_house }
+				if = {
+					limit = { government_allows = create_cadet_branches }
+					create_noble_family_effect = { GOVERNMENT_GIVER = scope:old_head }
+				}
+			}
+		}
+		else = {
+			found_cadet_house_decision_effect = {
+				CHARACTER = root
+				PRESTIGE = major_prestige_gain
+			}
+		}
+	}
+	
+	ai_potential = {
+		exists = house.house_head
+		is_adult = yes
+		highest_held_title_tier > tier_barony
+		any_child = { is_alive = yes }
+	}
+
+	ai_will_do = {
+		base = 30
+		
+		modifier = { # Dukes and above are more keen
+			add = 70
+			exists = primary_title
+			primary_title.tier > tier_county
+		}
+
+		modifier = { # Prefer to stay in liege's dynasty
+			add = -50
+			government_is_japanese_trigger = no
+			top_liege != this
+			any_liege_or_above = {
+				dynasty = root.dynasty
+			}
+		}
+		
+		modifier = { # Childless rulers should not found houses
+			factor = 0
+			any_child = {
+				is_alive = yes
+				count < 3
+			}
+		}
+		
+		modifier = { # Stop stealing player's house members
+			factor = 0
+			any_player = {
+				OR = {
+					any_child = {
+						OR = {
+							is_child_of = root
+							is_grandchild_of = root
+							is_great_grandchild_of = root
+						}
+					}
+					any_child = {
+						even_if_dead = yes
+						any_child = {
+							OR = {
+								is_child_of = root
+								is_grandchild_of = root
+								is_great_grandchild_of = root
+							}
+						}
+					}
+					any_child = {
+						even_if_dead = yes
+						any_child = {
+							even_if_dead = yes
+							any_child = {
+								OR = {
+									is_child_of = root
+									is_grandchild_of = root
+									is_great_grandchild_of = root
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		# we don't want AI to split from their House unless they dislike their house head
+		modifier = {
+			factor = 0
+			government_has_flag = government_is_clan
+			opinion = {
+				target = house.house_head
+				value >= -50
+			}
+		}
+		
+		# If an admin top liege ever ends up having their house head in a different realm, they should create a cadet branch ASAP
+		modifier = {
+			add = 1000
+			government_allows = administrative
+			top_liege = this
+			this != house.house_head.top_liege
+		}
+
+		modifier = {
+			add = -250
+			years_from_game_start < 5
+		}
+
+		### TGP
+
+		modifier = { # Prefer not to branch away from ruling close family
+			government_is_japanese_trigger = yes
+			top_liege.primary_title = {
+				any_past_holder = { is_close_family_of = root }
+			}
+			add = -25
+		}
+
+		modifier = { # Prefer to branch away from leading house if distant to split up blocs
+			government_is_japanese_trigger = yes
+			is_landed = yes
+			top_liege.house = root.house
+			NOT = { is_close_or_extended_family_of = top_liege }
+			add = 50
+		}
+
+		modifier = { # Prefer to branch away from house head
+			government_is_japanese_trigger = yes
+			NOT = { is_close_or_extended_family_of = house.house_head }
+			add = 50
+		}
+
+		modifier = { # Ruler should not break family apart
+			government_is_japanese_trigger = yes
+			is_independent_ruler = yes
+			add = -1000
+		}
+
+		modifier = { # Close and extended family prefer to stay with Ritsuryo house heads
+			government_is_japanese_trigger = yes
+			government_allows = administrative
+			OR = {
+				is_close_or_extended_family_of = house.house_head
+				AND = {
+					top_liege.house ?= house
+					is_close_or_extended_family_of = top_liege
+				}
+				house.house_head = {
+					any_held_title = {
+						is_noble_family_title = yes
+						any_past_holder = { is_close_or_extended_family_of = root }
+					}
+				}
+			}
+			add = -1000
+		}
+	}
+}

--- a/common/decisions/00_dynasty_decisions.txt
+++ b/common/decisions/00_dynasty_decisions.txt
@@ -292,7 +292,7 @@ create_cadet_branch_decision = {
 			add = 50
 		}
 
-		modifier = { #Unop Don't penalize breaking apart a family that isn't in the ruler's realm
+		modifier = { # Ruler should not break family apart
 			government_is_japanese_trigger = yes
 			is_independent_ruler = yes
 			top_liege = house.house_head.top_liege #Unop Skip when the house head is in a different realm (mirrors the +1000 booster above)

--- a/common/decisions/00_dynasty_decisions.txt
+++ b/common/decisions/00_dynasty_decisions.txt
@@ -292,9 +292,10 @@ create_cadet_branch_decision = {
 			add = 50
 		}
 
-		modifier = { # Ruler should not break family apart
+		modifier = { #Unop Don't penalize breaking apart a family that isn't in the ruler's realm
 			government_is_japanese_trigger = yes
 			is_independent_ruler = yes
+			top_liege = house.house_head.top_liege #Unop Skip when the house head is in a different realm (mirrors the +1000 booster above)
 			add = -1000
 		}
 


### PR DESCRIPTION
Fixes #560

**fixer:** In `create_cadet_branch_decision`'s `ai_will_do`, the `# Ruler should not break family apart` modifier applied `-1000` to *every* independent Japanese ruler (`government_is_japanese_trigger = yes` + `is_independent_ruler = yes`), with no family-relationship condition. For an independent Japanese admin regent whose realm was inherited by a foreign house, this unconditional penalty cancels the intended `+1000` booster ("admin top liege with house head in a different realm should create a cadet branch ASAP"), so the AI never reliably forms the cadet house and the Japanese government stays broken. Celestial Empire has no such penalty and works fine.

Fix: gate the penalty on `top_liege = house.house_head.top_liege`, so it no longer fires when the ruler's house head is in a different realm — the exact case the `+1000` booster targets. This is vanilla's own idiom for "house head is in a different realm" (see the `is_valid` admin branch). When the family *is* in-realm, the penalty still applies as before.