### PR TITLE
Let a settling nomad GOK reform reach the Meritocratic Khanate government

### DIFF
--- a/ck3-tiger.conf
+++ b/ck3-tiger.conf
@@ -96,6 +96,11 @@ filter = {
 				file = events/dlc/ep3/ep3_laamp_decision_events.txt
 			}
 		}
+		NAND = { # treasury = 0 deliberately detects a newly-granted admin feature (exactly-zero treasury)
+			key = logic
+			text = "`treasury =` means exactly equal to that amount, which is usually not what you want"
+			file = common/scripted_effects/00_administrative_effects.txt
+		}
 		NAND = { # overwriting the previous value seems correct here
 			key = logic
 			text = "setting value here will overwrite the previous calculations"

--- a/common/scripted_effects/00_administrative_effects.txt
+++ b/common/scripted_effects/00_administrative_effects.txt
@@ -195,6 +195,12 @@ change_to_administrative_effect = {
 					# There's a separate decision to go from Nomad to Meritocratic Khanate, so you cannot pick it from here
 					always = no
 				}
+				trigger_else_if = { #Unop An independent settling nomad should reach the Meritocratic Khanate, not skip it for plain Meritocratic
+					limit = {
+						scope:governor_liege ?= this
+					}
+					unop_should_become_steppe_admin_trigger = yes
+				}
 				trigger_else = {
 					scope:governor_liege = { government_has_flag = government_is_steppe_admin }
 				}

--- a/common/scripted_effects/00_administrative_effects.txt
+++ b/common/scripted_effects/00_administrative_effects.txt
@@ -1,0 +1,550 @@
+﻿
+change_to_administrative_hereditary_effect = {
+	scope:recipient = {
+		save_scope_as = petition_vassal
+		every_held_title = {
+			limit = {
+				tier = scope:petition_vassal.highest_held_title_tier
+				is_landless_type_title = no
+				is_noble_family_title = no
+			}
+			custom_tooltip = {
+				text = petition_liege_house_governorship_rights_tt
+				set_variable = {
+					name = petition_house_rights
+					value = scope:petition_vassal.house
+					years = 100
+				}
+			}
+		}
+	}
+}
+
+change_to_administrative_holding_effect = {
+	# Structured like this for clean tooltips
+	capital_province = {
+		if = {
+			limit = {
+				OR = {
+					has_holding_type = tribal_holding
+					has_holding_type = herder_holding
+					has_holding_type = nomad_holding
+				}
+			}
+			county.holder = { custom_tooltip = change_to_administrative_holding_tt }
+			hidden_effect = { set_holding_type = castle_holding }
+		}
+		county = {
+			if = {
+				limit = { has_county_modifier = mpo_siberian_permafrost_modifier }
+				holder = { custom_tooltip = change_to_administrative_permafrost_tt }
+				hidden_effect = { remove_county_modifier = mpo_siberian_permafrost_modifier }
+			}
+			else_if = {
+				limit = { has_county_modifier = mpo_siberian_permafrost_modifier_bad }
+				holder = { custom_tooltip = change_to_administrative_permafrost_bad_tt }
+				hidden_effect = { remove_county_modifier = mpo_siberian_permafrost_modifier_bad }
+			}
+		}
+	}
+}
+
+change_to_administrative_effect = {
+	save_scope_as = governor
+	if = {
+		limit = { exists = scope:new_liege }
+		scope:new_liege = { save_scope_as = governor_liege }
+	}
+	else = {
+		top_liege = { save_scope_as = governor_liege }
+	}
+	# exactly 0 treasury,  i.e. newly get this feature
+	if = {
+		limit = {
+			OR = {
+				has_treasury = no
+				treasury = 0
+			}
+		}
+		save_scope_as = new_treasury
+	}
+	# Set the correct government
+	if = {
+		limit = {
+			OR = {
+				NOT = { government_allows = administrative }
+				AND = {
+					government_allows = administrative
+					scope:governor_liege = { government_has_flag = government_is_japan_administrative }
+					NOT = { government_has_flag = government_is_japan_administrative }
+				}
+				AND = {
+					government_allows = administrative
+					scope:governor_liege = { government_has_flag = government_is_meritocratic }
+					NOT = { government_has_flag = government_is_meritocratic }
+				}
+				AND = {
+					government_allows = administrative
+					scope:governor_liege = { government_has_flag = government_is_celestial }
+					NOT = { government_has_flag = government_is_celestial }
+				}
+				AND = {
+					government_allows = administrative
+					scope:governor_liege = { government_has_flag = government_is_steppe_admin }
+					NOT = { government_has_flag = government_is_steppe_admin }
+				}
+			}
+		}
+		# Only case where Estate type is shared between Admin and non-Admin
+		if = {
+			limit = {
+				NAND = {
+					government_has_flag = government_is_japan_feudal
+					scope:governor_liege = { government_has_flag = government_is_japan_administrative }
+				}
+			}
+			save_scope_as = new_admin
+		}
+		# If we are greek, let's ensure we become administrative
+		if = {
+			limit = {
+				NOT = { exists = scope:has_selected_a_government }
+				scope:governor_liege = {
+					this = scope:governor # not vassal of some other admin liege
+					culture = {
+						OR = {
+							this = culture:greek
+							any_parent_culture_or_above = { this = culture:greek }
+						}
+					}
+				}
+			}
+			save_scope_value_as = {
+				name = has_selected_a_government
+				value = flag:administrative
+			}
+		}
+		# Change government
+		# We first check if you have a selected government, then if you are independent, then what your liege has
+		if = { # Ritsuryo
+			limit = {
+				trigger_if = {
+					limit = {
+						exists = scope:has_selected_a_government
+					}
+					scope:has_selected_a_government = flag:japan_administrative
+				}
+				trigger_else_if = {
+					limit = {
+						top_liege = this
+					}
+					has_tgp_dlc_trigger = yes
+					tgp_can_become_japan_administrative_trigger = yes
+				}
+				trigger_else = {
+					scope:governor_liege = { government_has_flag = government_is_japan_administrative }
+				}
+			}
+			change_to_administrative_holding_effect = yes
+			tgp_domicile_conversion_when_changing_government_type = {
+				NEW_DOMICILE_TYPE = japanese_manor
+				NEW_GOVERNMENT_TYPE = japan_administrative_government
+			}
+			change_government = japan_administrative_government
+		}
+		else_if = { # Celestial
+			limit = {
+				trigger_if = {
+					limit = {
+						exists = scope:has_selected_a_government
+					}
+					scope:has_selected_a_government = flag:celestial
+				}
+				trigger_else_if = {
+					limit = {
+						scope:governor_liege ?= this
+					}
+					has_tgp_dlc_trigger = yes
+					OR = {
+						tgp_can_become_celestial_trigger = yes
+						#This is Mongol breakup and they are hegemon
+						AND = {
+							exists = scope:great_yuan_ruler
+							this = scope:great_yuan_ruler
+							primary_title = title:h_china
+						}
+					}
+				}
+				trigger_else = {
+					scope:governor_liege = { government_has_flag = government_is_celestial }
+				}
+			}
+			change_to_administrative_holding_effect = yes
+			tgp_domicile_conversion_when_changing_government_type = {
+				NEW_DOMICILE_TYPE = east_asian_estate
+				NEW_GOVERNMENT_TYPE = celestial_government
+			}
+			change_government = celestial_government
+		}
+		else_if = { # Meritocratic Khanate
+			limit = {
+				trigger_if = {
+					limit = {
+						exists = scope:has_selected_a_government
+					}
+					# There's a separate decision to go from Nomad to Meritocratic Khanate, so you cannot pick it from here
+					always = no
+				}
+				trigger_else = {
+					scope:governor_liege = { government_has_flag = government_is_steppe_admin }
+				}
+			}
+			change_to_administrative_holding_effect = yes
+			tgp_domicile_conversion_when_changing_government_type = {
+				NEW_DOMICILE_TYPE = east_asian_estate
+				NEW_GOVERNMENT_TYPE = steppe_admin_government
+			}
+			change_government = steppe_admin_government
+		}
+		else_if = { # Meritocratic
+			limit = {
+				trigger_if = {
+					limit = {
+						exists = scope:has_selected_a_government
+					}
+					scope:has_selected_a_government = flag:meritocratic
+				}
+				trigger_else_if = {
+					limit = {
+						scope:governor_liege ?= this
+					}
+					has_tgp_dlc_trigger = yes
+					tgp_should_become_meritocratic_trigger = yes
+				}
+				trigger_else = {
+					scope:governor_liege = { government_has_flag = government_is_meritocratic }
+				}
+			}
+			change_to_administrative_holding_effect = yes
+			tgp_domicile_conversion_when_changing_government_type = {
+				NEW_DOMICILE_TYPE = east_asian_estate
+				NEW_GOVERNMENT_TYPE = meritocratic_government
+			}
+			change_government = meritocratic_government
+		}
+		else = { # Administrative
+			add_character_flag = new_government_is_byz_admin
+			change_to_administrative_holding_effect = yes
+			tgp_domicile_conversion_when_changing_government_type = {
+				NEW_DOMICILE_TYPE = estate
+				NEW_GOVERNMENT_TYPE = administrative_government
+			}
+			change_government = administrative_government 
+			remove_character_flag = new_government_is_byz_admin
+		}
+	}
+	# Set up a noble family title
+	if = {
+		limit = {
+			primary_title.tier >= min_appointment_tier
+			liege = {
+				scope:governor_liege = this
+				government_allows = administrative
+			}
+			house.house_head = {
+				top_liege = scope:governor_liege
+				NOT = {
+					any_held_title = { is_noble_family_title = yes }
+				}
+			}
+		}
+		create_noble_family_effect = { GOVERNMENT_GIVER = top_liege }
+	}
+	# Add the governor trait if applicable
+	hidden_effect = {
+		if = {
+			limit = {
+				is_governor = yes
+				NOT = { has_trait = governor }
+			}
+			add_trait = governor
+		}
+	}
+	# Set up the domicile
+	if = {
+		limit = {
+			exists = scope:new_admin
+			exists = domicile
+		}
+		domicile ?= {
+			set_up_domicile_estate_effect = yes
+		}
+	}
+	if = {
+		limit = {
+			has_treasury = yes
+			exists = scope:new_treasury  # do not give it mutiple times
+		}
+		add_treasury = {
+			value = gold
+			min = 100
+		}
+	}
+}
+
+change_to_administrative_interaction_effect = {
+	scope:actor = {
+		if = {
+			limit = { has_treasury = yes }
+			pay_short_term_treasury = {
+				target = scope:recipient
+				treasury = {
+					value = 50
+					scope:recipient = {
+						if = {
+							limit = { highest_held_title_tier >= tier_kingdom }
+							multiply = 10
+						}
+						else_if = {
+							limit = { highest_held_title_tier >= tier_duchy }
+							multiply = 6
+						}
+						else_if = {
+							limit = { highest_held_title_tier >= tier_county }
+							multiply = 3
+						}
+					}
+					if = {
+						limit = { scope:gold ?= yes }
+						add = scope:actor.medium_gold_value
+					}
+					if = {
+						limit = {
+							scope:actor = { has_realm_law_flag = admin_change_vassal_gov_cheaper }
+						}
+						multiply = 0.5
+					}
+				}
+			}
+		}
+		else = {
+			pay_short_term_gold = {
+				target = scope:recipient
+				gold = {
+					value = 50
+					scope:recipient = {
+						if = {
+							limit = { highest_held_title_tier >= tier_kingdom }
+							multiply = 10
+						}
+						else_if = {
+							limit = { highest_held_title_tier >= tier_duchy }
+							multiply = 6
+						}
+						else_if = {
+							limit = { highest_held_title_tier >= tier_county }
+							multiply = 3
+						}
+					}
+					if = {
+						limit = { scope:gold ?= yes }
+						add = scope:actor.medium_gold_value
+					}
+					if = {
+						limit = {
+							scope:actor = { has_realm_law_flag = admin_change_vassal_gov_cheaper }
+						}
+						multiply = 0.5
+					}
+				}
+			}
+		}
+	}
+	scope:recipient = {
+		change_to_administrative_effect = yes
+
+		#And now we also convert all the administrative vassals below so they also match the actor's form of admin.
+		#For non admin sub-vassals the newly converted main vassal can still ask using the same interaction but we 
+		hidden_effect = {
+			every_vassal_or_below = {
+				limit = {
+					government_allows = administrative
+					is_ai = yes #Humans get to be asked directly
+				}
+				change_to_administrative_effect = yes
+			}
+		}
+	}
+	if = {
+		limit = {
+			scope:hook = yes
+			scope:actor = { has_usable_hook = scope:recipient }
+		}
+		scope:actor = { use_hook = scope:recipient }
+	}
+	if = {
+		limit = { scope:hereditary = yes }
+		scope:recipient = { save_scope_as = petition_vassal }
+		change_to_administrative_hereditary_effect = yes
+	}
+	if = {
+		limit = { scope:influence = yes }
+		scope:actor = {
+			change_influence = {
+				value = massive_influence_loss
+			}
+		}
+	}
+}
+
+give_new_noble_family_title_effect = {
+	if = {
+		limit = {
+			is_house_head = yes
+			trigger_if = {
+				limit = {
+					government_has_flag = government_has_county_tier_noble_families
+				}
+				highest_held_title_tier >= tier_county
+			}
+			trigger_else = { highest_held_title_tier >= tier_duchy }
+			liege = {
+				government_allows = noble_families
+			}
+			trigger_if = {
+				limit = { any_held_title = { is_noble_family_title = yes } }
+				has_domicile = no
+			}
+		}
+		create_noble_family_effect = { GOVERNMENT_GIVER = this }
+		domicile ?= { set_up_domicile_estate_effect = yes }
+	}
+}
+
+set_up_domicile_estate_effect = {
+	if = {
+		limit = { is_domicile_type = estate }
+		# Intentionally one level lower than what you can get
+		if = {
+			limit = {
+				NOT = { has_domicile_building_or_higher = estate_main_02 }
+				owner.culture ?= { has_innovation = innovation_city_planning }
+			}
+			add_domicile_building = estate_main_02
+		}
+		if = {
+			limit = {
+				has_domicile_building = estate_main_02
+				NOT = { has_domicile_building_or_higher = estate_main_03 }
+				owner.culture ?= { has_innovation = innovation_manorialism }
+			}
+			add_domicile_building = estate_main_03
+		}
+		hidden_effect = {
+			switch = {
+				trigger = has_domicile_building
+				estate_main_03 = {
+					while = {
+						count = 2
+						add_random_internal_estate_building = yes
+					}
+				}
+				estate_main_02 = {
+					add_random_internal_estate_building = yes
+				}
+			}
+		}
+		fill_external_estate_building_effect = yes
+	}
+	else_if = {
+		limit = { is_domicile_type = japanese_manor }
+		# Intentionally one level lower than what you can get
+		if = {
+			limit = {
+				NOT = { has_domicile_building_or_higher = japanese_manor_main_02 }
+				owner.culture ?= { has_innovation = innovation_city_planning }
+			}
+			add_domicile_building = japanese_manor_main_02
+		}
+		if = {
+			limit = {
+				has_domicile_building = japanese_manor_main_02
+				NOT = { has_domicile_building_or_higher = japanese_manor_main_03 }
+				owner.culture ?= { has_innovation = innovation_manorialism }
+			}
+			add_domicile_building = japanese_manor_main_03
+		}
+		hidden_effect = {
+			switch = {
+				trigger = has_domicile_building
+				japanese_manor_main_03 = {
+					while = {
+						count = 2
+						add_random_internal_japanese_manor_building = yes
+					}
+				}
+				japanese_manor_main_02 = {
+					add_random_internal_japanese_manor_building = yes
+				}
+			}
+		}
+		fill_external_japanese_manor_building_effect = yes
+	}
+	else_if = {
+		limit = { is_domicile_type = east_asian_estate }
+		# Intentionally one level lower than what you can get
+		if = {
+			limit = {
+				NOT = { has_domicile_building_or_higher = east_asian_estate_main_02 }
+				owner.culture ?= { has_innovation = innovation_city_planning }
+			}
+			add_domicile_building = east_asian_estate_main_02
+		}
+		if = {
+			limit = {
+				has_domicile_building = east_asian_estate_main_02
+				NOT = { has_domicile_building_or_higher = east_asian_estate_main_03 }
+				owner.culture ?= { has_innovation = innovation_manorialism }
+			}
+			add_domicile_building = east_asian_estate_main_03
+		}
+		hidden_effect = {
+			switch = {
+				trigger = has_domicile_building
+				east_asian_estate_main_03 = {
+					while = {
+						count = 2
+						add_random_internal_east_asian_estate_building = yes
+					}
+				}
+				east_asian_estate_main_02 = {
+					add_random_internal_east_asian_estate_building = yes
+				}
+			}
+		}
+		fill_external_east_asian_estate_building_effect = yes
+	}
+}
+
+noble_family_title_realm_setup_effect = {
+	save_scope_as = top_liege
+	every_noble_family = {
+		save_scope_as = nf_title
+		holder ?= {
+			save_scope_as = nf_holder
+			house ?= {
+				save_scope_as = nf_house
+				# Ensure holders of historical noble family titles are the default house heads
+				if = {
+					limit = { house_head != scope:nf_holder }
+					set_house_head = scope:nf_holder
+				}
+			}
+		}
+		scope:nf_title = {
+			set_color_from_title = scope:nf_holder.capital_county
+			# Ensure Noble Family CoA match House
+			set_coa = scope:nf_house
+		}
+	}
+}

--- a/common/scripted_effects/00_administrative_effects.txt
+++ b/common/scripted_effects/00_administrative_effects.txt
@@ -198,6 +198,7 @@ change_to_administrative_effect = {
 				trigger_else_if = { #Unop An independent settling nomad should reach the Meritocratic Khanate, not skip it for plain Meritocratic
 					limit = {
 						scope:governor_liege ?= this
+						NOT = { exists = scope:great_yuan_ruler }
 					}
 					unop_should_become_steppe_admin_trigger = yes
 				}

--- a/common/scripted_effects/00_mongol_invasion_effects.txt
+++ b/common/scripted_effects/00_mongol_invasion_effects.txt
@@ -5811,7 +5811,7 @@ shift_counties_on_mongol_succession_effect = {
 				limit = {
 					exists = global_var:great_yuan_handed_out
 					is_in_list = great_yuan_counties
-					NOT = { holder = { has_title = scope:great_yuan_title } }
+					NOT = { holder = { has_title = title:e_great_yuan } } #Unop scope:great_yuan_title is not set here, use title directly like the other entry
 				}
 				add_to_list = great_yuan_titles_for_transfer
 				# Also mark duchies for transfer if relevant

--- a/common/scripted_triggers/unop_triggers.txt
+++ b/common/scripted_triggers/unop_triggers.txt
@@ -59,3 +59,16 @@ unop_war_of_defiance_notified_player_trigger = {
 		}
 	}
 }
+
+# An independent nomad settling into administration should reach the Meritocratic Khanate (steppe_admin)
+# government - the natural steppe-admin form - rather than skipping it for plain Meritocratic/Administrative.
+# Used in change_to_administrative_effect to give the steppe_admin branch an independent-ruler resolution path,
+# mirroring the meritocratic/celestial/ritsuryo branches. Restricted to current nomads so other callers are unaffected.
+unop_should_become_steppe_admin_trigger = {
+	government_has_flag = government_is_nomadic
+	has_tgp_dlc_trigger = yes
+	is_independent_ruler = yes
+	capital_province = {
+		geographical_region = world_steppe
+	}
+}

--- a/common/scripted_triggers/unop_triggers.txt
+++ b/common/scripted_triggers/unop_triggers.txt
@@ -60,10 +60,8 @@ unop_war_of_defiance_notified_player_trigger = {
 	}
 }
 
-# An independent nomad settling into administration should reach the Meritocratic Khanate (steppe_admin)
-# government - the natural steppe-admin form - rather than skipping it for plain Meritocratic/Administrative.
 # Used in change_to_administrative_effect to give the steppe_admin branch an independent-ruler resolution path,
-# mirroring the meritocratic/celestial/ritsuryo branches. Restricted to current nomads so other callers are unaffected.
+# mirroring the other branches. Restricted to current nomads so other callers are unaffected.
 unop_should_become_steppe_admin_trigger = {
 	government_has_flag = government_is_nomadic
 	has_tgp_dlc_trigger = yes


### PR DESCRIPTION
Fixes #552

**fixer:** The "Reform Great Khanate" reform (`mpo_gok_world_conquest_decision` → event `mpo_greatest_of_khans.0030` option b) converts a GOK to administration via `convert_to_administrative_from_feudalism_effect` with `flag:dynamic`, whose government is resolved in `change_to_administrative_effect`. In that resolver, the **Meritocratic Khanate** (`steppe_admin_government`) branch is the only administrative sub-government lacking an independent-ruler resolution path — Ritsuryo, Celestial, and Meritocratic all have a `trigger_else_if` for the independent case, but the steppe_admin branch only fires when the ruler is already a vassal of a `steppe_admin` liege (the selected-government case is deliberately `always = no`). So an independent settling steppe nomad can never reach the Meritocratic Khanate via the reform and instead skips to plain Meritocratic/Administrative — despite Meritocratic Khanate being the natural steppe-admin form.

Fix: add an independent-ruler `trigger_else_if` to the steppe_admin branch (evaluated before the Meritocratic branch), mirroring the sibling branches, gated on a new `unop_should_become_steppe_admin_trigger` (independent nomad with a steppe capital). Restricted to current nomads so the many other callers of this shared effect are unaffected.

Adding `00_administrative_effects.txt` as a new override surfaced two unrelated latent tiger warnings, both handled here: a `treasury = 0` "exactly equal" logic warning (deliberate vanilla check — flagged false positive) and, via the `on_death` call path, a real unset-`scope:great_yuan_title` bug in `shift_counties_on_mongol_succession_effect` — a second occurrence of a block already Unop-fixed elsewhere in that effect, now fixed to use `title:e_great_yuan` directly.

Reads on the bug/enhancement line: this adds no player-facing option or new government, only restores the resolver symmetry so an existing dynamic destination becomes reachable. **Needs in-game verification** with a settling nomad GOK reforming.