### PR TITLE
Fix palace_of_ctesiphon_02 being locked behind unreformed Hellenism

### DIFF
--- a/common/buildings/00_special_buildings.txt
+++ b/common/buildings/00_special_buildings.txt
@@ -5314,7 +5314,7 @@ palace_of_ctesiphon_02 = {
 					zoroastrian_or_syncretic_with_eastern_trigger = { CHARACTER = scope:holder }
 					faith = faith:manichean
 					faith = faith:nestorian
-					faith = faith:hellenic_pagan
+					faith.religion = faith:hellenic_pagan.religion #Unop Also allow reformed Hellenic faiths
 				}
 				highest_held_title_tier >= tier_kingdom
 				top_liege = this


### PR DESCRIPTION
Fixes #601

**fixer:** `palace_of_ctesiphon_02`'s `can_construct` tested `faith = faith:hellenic_pagan`, which is faith-level. `hellenic_pagan` is the only scripted faith in `hellenism_religion` and carries `unreformed_faith_doctrine`, so a faith created through the reformation UI is a *new* faith object and fails the equality test — locking the upgrade behind unreformed Hellenism. Changed that one branch to religion-level, mirroring the sibling Hellenic special building `parthenon` in the same file, which already uses `faith.religion = faith:hellenic_pagan.religion`.

The other three branches are deliberately left alone: `zoroastrian_or_syncretic_with_eastern_trigger` is already religion-level, while `manichean` and `nestorian` are ordinary faiths inside `dualism_religion` (8 faiths) and `christianity_religion` (19 faiths) — broadening those would wrongly admit all Dualists and all Christians.

Note the building has no `is_enabled` faith check, unlike `parthenon`, so it doesn't switch off on faith change. Adding one would be an addition rather than a fix, so it's out of scope here.

`make tiger` is clean.