### PR TITLE
Fix Roman restoration converting reformed Hellenists to the unreformed faith

### DIFF
--- a/events/dlc/ep3/ep3_roman_restoration_events.txt
+++ b/events/dlc/ep3/ep3_roman_restoration_events.txt
@@ -1,0 +1,533 @@
+﻿namespace = ep3_roman_restoration
+
+#######################################
+###
+###	EP3 RESTORE ROME STORY CYCLE EVENTS
+### by Chad Uhl
+###
+### 0100 		Justinian's Dream
+### 0101-0109 	Rome Reformed Notifications
+### 0300-0590 	Post-Restoration Difficulties
+###
+#######################################
+
+# Justinian's Dream
+# Event fired on story cycle setup informing the player that they can form the roman empire
+ep3_roman_restoration.0001 = {
+	type = character_event
+	title = ep3_roman_restoration.0001.t
+	desc = ep3_roman_restoration.0001.desc
+	theme = emperor
+
+	override_background = {
+		trigger = { capital_county = title:c_byzantion }
+		reference = ep3_constantinople
+	}
+
+	left_portrait = {
+		character = root
+		animation = emotion_thinking_scepter
+	}
+
+	trigger = {
+		NOT = { has_global_variable = flag_restored_roman_empire }
+	}
+
+	option = { 
+		name = ep3_roman_restoration.0001.a
+		custom_tooltip = ep3_roman_restoration.0001.a.tt
+		decision:restore_roman_empire_decision = {
+			open_view_data = {
+				view = decision_detail
+				player = root
+			}
+		}
+	}
+}
+
+# Should I LARP or nah?
+ep3_roman_restoration.0100 = {
+	type = character_event
+	window = fullscreen_event
+	title = ep3_roman_restoration.0100.t
+	desc = ep3_roman_restoration.0100.desc
+	theme = emperor
+	override_background = { reference = ep3_fullscreen_restore_rome }
+
+	immediate = {
+		save_scope_as = scoped_emperor
+	}
+
+	option = { # LARP (Hard Mode)
+		name = ep3_roman_restoration.0100.a
+		custom_tooltip = ep3_roman_restoration.hard_mode
+		custom_tooltip = ep3_roman_restoration.end_hard_mode
+		custom_tooltip = ep3_roman_restoration.invasion_cb
+		every_held_title = {
+			limit = {
+				is_head_of_faith = yes
+			}
+			root = {
+				destroy_title = prev
+			}
+		}
+		set_character_faith = faith:hellenic_pagan
+		if = {
+			limit = { 
+				faith:hellenic_pagan = { has_doctrine = doctrine_monotheist }
+			}
+			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
+		}
+		primary_title = { set_state_faith = faith:hellenic_pagan }
+		every_held_title = {
+			custom = custom.every_held_county
+			title_tier = county
+			set_county_faith = faith:hellenic_pagan
+		}
+		every_vassal = {
+			custom = custom.every_vassal
+			limit = {
+				NOT = {
+					any_held_title = {
+						is_head_of_faith = yes # you cannot convert the Ecumenical Patriarch, sorry
+					}
+				}
+			}
+			custom_tooltip = {
+				text = may_choose_to_convert_hellenic_desc
+				run_interaction = { # We use the same interaction as when creating a new faith to keep a consistent behaviour, since that is essentially what you're doing here
+					interaction = ask_for_conversion_interaction
+					actor = root
+					recipient = this
+					execute_threshold = accept
+				}
+			}
+		}
+		custom_tooltip = {
+			text = ep3_roman_restoration.household_gods_tenet
+			set_global_variable = household_gods_tenet_unlocked
+		}
+		custom_tooltip = {
+			text = uses_custom_caesar_flavourization_tt
+			set_variable = uses_custom_caesar_flavourization
+		}
+		if = {
+			limit = {
+				any_owned_story = { type = ep3_story_cycle_restoring_rome }
+			}
+			random_owned_story = {
+				type = ep3_story_cycle_restoring_rome
+				set_variable = roman_empire_hard_mode
+			}
+		}
+	}
+
+	option = { # Roleplay option (become Hellenic without Hard Mode)
+		name = ep3_roman_restoration.0100.c
+		custom_tooltip = ep3_roman_restoration.easy_mode
+		every_held_title = {
+			limit = {
+				is_head_of_faith = yes
+			}
+			root = {
+				destroy_title = prev
+			}
+		}
+		set_character_faith = faith:hellenic_pagan
+		if = {
+			limit = { 
+				faith:hellenic_pagan = { has_doctrine = doctrine_monotheist }
+			}
+			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
+		}
+		primary_title = { set_state_faith = faith:hellenic_pagan }
+		every_held_title = {
+			custom = custom.every_held_county
+			title_tier = county
+			set_county_faith = faith:hellenic_pagan
+		}
+		every_vassal = {
+			custom = custom.every_vassal
+			limit = {
+				NOT = {
+					any_held_title = {
+						is_head_of_faith = yes # you cannot convert the Ecumenical Patriarch, sorry
+					}
+				}
+			}
+			custom_tooltip = {
+				text = may_choose_to_convert_hellenic_desc
+				run_interaction = { # We use the same interaction as when creating a new faith to keep a consistent behaviour, since that is essentially what you're doing here
+					interaction = ask_for_conversion_interaction
+					actor = root
+					recipient = this
+					execute_threshold = accept
+				}
+			}
+		}
+		custom_tooltip = {
+			text = ep3_roman_restoration.household_gods_tenet
+			set_global_variable = household_gods_tenet_unlocked
+		}
+		custom_tooltip = {
+			text = uses_custom_caesar_flavourization_tt
+			set_variable = uses_custom_caesar_flavourization
+		}
+	}
+
+	option = { # Easy Mode
+		name = ep3_roman_restoration.0100.b
+		custom_tooltip = ep3_roman_restoration.easy_mode
+	}
+
+	after = {
+		create_roman_empire_scripted_effect = yes
+		set_nickname_effect = { NICKNAME = nick_the_glorious }
+		# Send narrative fluff to other players (if any).
+		every_player = {
+			limit = { this != root }
+			trigger_event = ep3_roman_restoration.0101
+		}
+	}
+}
+
+# Some chucklefuck restored Rome
+ep3_roman_restoration.0101 = {
+	type = character_event
+	window = fullscreen_event
+	title = roman_restoration.0002.t
+	desc = {
+		desc = ep3_roman_restoration.0101.intro
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:scoped_emperor.primary_title.state_faith ?= faith:hellenic_pagan }
+				desc = ep3_roman_restoration.0101.hellenic
+			}
+			triggered_desc = {
+				trigger = { scope:scoped_emperor.primary_title.state_faith ?= faith:orthodox }
+				desc = ep3_roman_restoration.0101.orthodox
+			}
+			desc = ep3_roman_restoration.0101.fallback
+		}
+		desc = ep3_roman_restoration.0101.outro
+	}
+	theme = emperor
+	override_background = { reference = ep3_fullscreen_restore_rome }
+	
+	immediate = {
+		#Same-faith non-empire tier rulers are over-awed.
+		if = {
+			limit = { faith = scope:scoped_emperor.primary_title.state_faith }
+			play_music_cue = "mx_cue_epic_sacral_moment"
+		}
+		#Otherwise, this is a tacit statement of imperial threat.
+		else = { play_music_cue = "mx_cue_combat_2" }
+	}
+
+	option = { 
+		name = ep3_roman_restoration.0101.a
+	}
+}
+
+
+#######################################
+### POST-ROME DIFFICULTIES
+
+# Your inefficient governor messed up, causing mass loss in popular opinion. Can you fix it?
+ep3_roman_restoration.0300 = {
+	type = character_event
+	title = ep3_roman_restoration.0300.t
+	desc = ep3_roman_restoration.0300.desc
+	theme = emperor
+
+	left_portrait = {
+		character = root
+		animation = anger
+	}
+	right_portrait = {
+		character = scope:inefficient_governor
+		animation = shock
+	}
+
+	cooldown = { years = 20 }
+
+	immediate = {
+		ordered_vassal = {
+			limit = {
+				is_governor = yes
+				is_ai = yes
+			}
+			order_by = { # Mostly sort by governor efficiency
+				value = governor_efficiency
+				multiply = -10
+				# Prefer governors with a larger realm size for more difficulty
+				add = sub_realm_size
+			}
+			save_scope_as = inefficient_governor
+		}
+		custom_tooltip = ep3_roman_restoration.0300.efficiency
+	}
+
+	option = { # Stewardship Challenge
+		name = ep3_roman_restoration.0300.a
+		duel = {
+			skill = stewardship
+			value = excellent_skill_level
+
+			50 = {
+				compare_modifier = {
+					value = scope:duel_value
+					multiplier = 3.5
+					min = -49
+				}
+				send_interface_toast = {
+					type = event_toast_effect_good
+					title = ep3_roman_restoration.0300.a.success
+					left_icon = scope:inefficient_governor
+					right_icon = scope:inefficient_governor.primary_title
+
+					scope:inefficient_governor = {
+						every_sub_realm_county = {
+							custom = ep3_roman_restoration.0300.every_sub_realm_county
+							add_county_modifier = {
+								modifier = restore_rome_recuperated_county_opinion_modifier
+								years = 10
+							}
+						}
+					}
+				}
+			}
+			50 = {
+				compare_modifier = {
+					value = scope:duel_value
+					multiplier = -3.5
+					min = -49
+				}
+				send_interface_toast = {
+					type = event_toast_effect_bad
+					title = ep3_roman_restoration.0300.a.failure
+					left_icon = scope:inefficient_governor
+					right_icon = scope:inefficient_governor.primary_title
+
+					scope:inefficient_governor = {
+						every_sub_realm_county = {
+							custom = ep3_roman_restoration.0300.every_sub_realm_county
+							add_county_modifier = {
+								modifier = restore_rome_devastated_county_opinion_modifier
+								years = 10
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	option = { # Fire the Governor
+		name = ep3_roman_restoration.0300.b
+		change_influence = massive_influence_loss
+		save_scope_as = actor
+		scope:inefficient_governor = {
+			save_scope_as = recipient
+			primary_title = { save_scope_as = landed_title }
+		}
+		save_scope_value_as = {
+			name = hook
+			value = no
+		}
+		scope:inefficient_governor = {
+			every_sub_realm_county = {
+				custom = ep3_roman_restoration.0300.every_sub_realm_county
+				add_county_modifier = {
+					modifier = restore_rome_recuperated_county_opinion_modifier
+					years = 10
+				}
+			}
+			force_step_down_landed_titles = yes
+		}
+	}
+	
+	option = { # Opt-Out
+		name = ep3_roman_restoration.0300.c
+
+		scope:inefficient_governor = {
+			every_sub_realm_county = {
+				custom = ep3_roman_restoration.0300.every_sub_realm_county
+				add_county_modifier = {
+					modifier = restore_rome_lowered_county_opinion_modifier
+					years = 10
+				}
+			}
+		}
+
+		stress_impact = {
+			base = medium_stress_impact_loss
+			lazy = minor_stress_impact_loss
+			diligent = medium_stress_impact_gain
+			ambitious = minor_stress_impact_gain 
+		}
+	}
+}
+
+# Every 10-30 years, a random kingdom will raid you
+ep3_roman_restoration.0500 = {
+	type = character_event
+	title = ep3_roman_restoration.0500.t
+	desc = ep3_roman_restoration.0500.desc
+	theme = emperor
+
+	left_portrait = {
+		character = root
+		animation = emotion_thinking_scepter
+	}
+
+	right_portrait = {
+		character = scope:marshal
+		animation = inspect_weapon
+	}
+
+	lower_center_portrait = scope:target_kingdom
+
+	cooldown = { years = { 10 30 } }
+	
+	trigger = {
+		exists = cp:councillor_marshal
+		any_neighboring_top_liege_realm_owner = {
+			is_ai = yes
+			is_at_war = no
+			primary_title = { tier >= tier_kingdom }
+			NOR = {
+				is_allied_to = root
+				any_truce_target = { this = root }
+				has_relation_friend = root
+				has_relation_lover = root
+			}
+			any_top_realm_border_county = {
+				any_neighboring_county = {
+					holder.top_liege = root
+					NOT = {
+						title_province = { has_province_modifier = recently_looted_modifier }
+					}
+				}
+			}
+		}
+	}
+
+	immediate = {
+		cp:councillor_marshal = { save_scope_as = marshal }
+		ordered_neighboring_top_liege_realm_owner = {
+			limit = {
+				is_ai = yes
+				is_at_war = no
+				primary_title = { tier >= tier_kingdom }
+				any_top_realm_border_county = {
+					any_neighboring_county = {
+						holder.top_liege = root
+						NOT = {
+							title_province = { has_province_modifier = recently_looted_modifier }
+						}
+					}
+				}
+			}
+			order_by = {
+				value = 1
+				add = { # inverted opinion since we're looking for ppl who hate you
+					value = "opinion(root)"
+					multiply = -1
+				}
+				if = {
+					limit = { can_raid_trigger = yes }
+					add = 50
+				}
+			}
+			save_scope_as = target_kingdom
+		}
+		scope:target_kingdom = {
+			random_top_realm_border_county = {
+				limit = {
+					any_neighboring_county = {
+						holder.top_liege = root
+						NOT = {
+							title_province = { has_province_modifier = recently_looted_modifier }
+						}
+					}
+				}
+				random_neighboring_county = {
+					limit = {
+						holder.top_liege = root
+						NOT = {
+							title_province = { has_province_modifier = recently_looted_modifier }
+						}
+					}
+					save_scope_as = target_county
+				}
+			}
+		}
+	}
+
+	option = {
+		name = ep3_roman_restoration.0500.a
+	}
+
+	after = {
+		scope:target_kingdom = {
+			start_war = {
+				cb = ep3_roman_empire_border_war
+				target = root
+				target_title = scope:target_county
+			}
+		}
+	}
+}
+
+# Special Bubonic Plague Spawns - Commented out and disabled because this is not very fun
+#ep3_roman_restoration.0510 = {
+#	hidden = yes
+#
+#	immediate = {
+#		random_realm_county = {
+#			limit = { exists = holder }
+#			holder = { save_scope_as = target_holder }
+#			save_scope_as = infected_county
+#			title_province = {
+#				save_scope_as = target_province
+#				create_epidemic_outbreak = {
+#					type = bubonic_plague
+#					intensity = major
+#					save_scope_as = epidemic
+#				}
+#			}
+#		}
+#		trigger_event = epidemic_events.1100
+#	}
+#}
+
+# Mongol Invasion Spawns
+ep3_roman_restoration.0520 = {
+	scope = none
+	hidden = yes
+
+	trigger = {
+		NOR = {
+			has_global_variable = mongols_have_appeared
+			any_player = {
+				THIS = culture:mongol.culture_head
+				realm_size >= 100
+			}
+		}
+	}
+
+	immediate = {
+		set_global_variable = {
+			name = mongols_have_appeared
+			value = yes
+		}
+		debug_log = "Mongols appeared!"
+		debug_log_date = yes
+		spawn_temujin_character_effect = yes
+		scope:temujin = {
+			save_scope_as = story_owner
+			create_story = story_mongol_invasion
+		}
+	}
+}

--- a/events/dlc/ep3/ep3_roman_restoration_events.txt
+++ b/events/dlc/ep3/ep3_roman_restoration_events.txt
@@ -71,18 +71,24 @@ ep3_roman_restoration.0100 = {
 				destroy_title = prev
 			}
 		}
-		set_character_faith = faith:hellenic_pagan
+		#Unop Don't convert an already Hellenic ruler, so reformed Hellenic faiths are preserved
+		if = {
+			limit = {
+				NOT = { faith.religion = faith:hellenic_pagan.religion }
+			}
+			set_character_faith = faith:hellenic_pagan
+		}
 		if = {
 			limit = { 
-				faith:hellenic_pagan = { has_doctrine = doctrine_monotheist }
+				faith = { has_doctrine = doctrine_monotheist }
 			}
 			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
 		}
-		primary_title = { set_state_faith = faith:hellenic_pagan }
+		primary_title = { set_state_faith = root.faith }
 		every_held_title = {
 			custom = custom.every_held_county
 			title_tier = county
-			set_county_faith = faith:hellenic_pagan
+			set_county_faith = root.faith
 		}
 		every_vassal = {
 			custom = custom.every_vassal
@@ -133,18 +139,24 @@ ep3_roman_restoration.0100 = {
 				destroy_title = prev
 			}
 		}
-		set_character_faith = faith:hellenic_pagan
+		#Unop Don't convert an already Hellenic ruler, so reformed Hellenic faiths are preserved
+		if = {
+			limit = {
+				NOT = { faith.religion = faith:hellenic_pagan.religion }
+			}
+			set_character_faith = faith:hellenic_pagan
+		}
 		if = {
 			limit = { 
-				faith:hellenic_pagan = { has_doctrine = doctrine_monotheist }
+				faith = { has_doctrine = doctrine_monotheist }
 			}
 			custom_description_no_bullet = { text = mandala_monotheist_warning_tt }
 		}
-		primary_title = { set_state_faith = faith:hellenic_pagan }
+		primary_title = { set_state_faith = root.faith }
 		every_held_title = {
 			custom = custom.every_held_county
 			title_tier = county
-			set_county_faith = faith:hellenic_pagan
+			set_county_faith = root.faith
 		}
 		every_vassal = {
 			custom = custom.every_vassal
@@ -200,7 +212,8 @@ ep3_roman_restoration.0101 = {
 		desc = ep3_roman_restoration.0101.intro
 		first_valid = {
 			triggered_desc = {
-				trigger = { scope:scoped_emperor.primary_title.state_faith ?= faith:hellenic_pagan }
+				#Unop Also match reformed Hellenic faiths
+				trigger = { scope:scoped_emperor.primary_title.state_faith.religion ?= faith:hellenic_pagan.religion }
 				desc = ep3_roman_restoration.0101.hellenic
 			}
 			triggered_desc = {


### PR DESCRIPTION
Fixes #602

**fixer:** `ep3_roman_restoration.0100` options A ("LARP / Hard Mode") and C ("Roleplay") hardcoded `faith:hellenic_pagan` when setting character, state and county faith. That faith is specifically the *unreformed* one — it's the sole scripted faith in `hellenism_religion` and carries `unreformed_faith_doctrine`. A reformed Hellenic faith is a different faith object, so restoring Rome stripped reformed Hellenists of their own faith, permanently (the decision is once-per-game and irreversible).

The decision itself already admits reformed Hellenists at *religion* level — `restore_roman_empire_decision_religion_culture_trigger` tests `this = religion:hellenism_religion` — so the eligibility gate and the effect disagreed about what "Hellenic" means, and the effect was wrong.

**Fix:** skip the conversion when the ruler is already Hellenic, and derive the downstream faiths from the ruler instead of the literal:

- `set_character_faith` is now wrapped in `NOT = { faith.religion = faith:hellenic_pagan.religion }` — a reformed Hellenist keeps their faith; everyone else converts exactly as before.
- `set_state_faith` / `set_county_faith` now use `root.faith`, which resolves to the same `faith:hellenic_pagan` for every previously-working case, and to the retained reformed faith otherwise.
- The `doctrine_monotheist` check tested the literal `faith:hellenic_pagan` for a doctrine it can never have; it now tests the ruler's actual resulting faith.
- Vassal conversion needed no change — `ask_for_conversion_interaction` converts toward `scope:actor.faith`, so it follows the retained faith automatically.

Also fixed `ep3_roman_restoration.0101`'s desc trigger (same root cause, cosmetic): a reformed-Hellenic emperor fell through to the generic `fallback` text instead of the `hellenic` one.

This keeps to "fix, don't add" — it avoids inventing a policy for *which* reformed faith to pick when several exist, since no conversion is needed for someone already Hellenic.

Vanilla file added unmodified in a separate first commit. `make tiger` is clean.

Worth verifying in-game: with a reformed Hellenic faith, confirm options A/C preserve it and that state/county faith and vassal-conversion offers follow it; confirm unreformed Hellenic and Abrahamic rulers are unchanged.