### PR TITLE
Fix terrain inspector decisions being available to all landless governments

### DIFF
--- a/common/decisions/dlc_decisions/bp3/00_bp3_other_decisions.txt
+++ b/common/decisions/dlc_decisions/bp3/00_bp3_other_decisions.txt
@@ -1,0 +1,994 @@
+﻿### End Pious Investments ###
+end_investments_minor_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_spend_money.dds"
+	}
+	sort_order = 1
+
+	is_shown = {
+		has_character_modifier = church_investment_cost_modifier
+	}
+
+	effect = {
+		remove_character_modifier = church_investment_modifier
+		remove_character_modifier = church_investment_cost_modifier
+	}
+
+	ai_potential = {
+		always = no
+	}
+
+	ai_check_interval = 0
+}
+
+### Designated Terrain ###
+choose_designated_terrain_decision = {
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 120
+		kingdom = 0
+		empire = 0
+		hegemony = 0
+	}
+
+	picture = { reference = "gfx/interface/illustrations/decisions/ep3_decision_laamp_neutral_mountain.dds" }
+
+	sort_order = 10
+	decision_group_type = major
+
+	is_shown = {
+		OR = {
+			is_landed = no
+			government_has_flag = government_is_nomadic
+		}
+		has_perk = mustering_the_troops_perk
+		NOR = {
+			landless_inspector_terrain_master_trigger = { TERRAIN = woodlands }
+			landless_inspector_terrain_master_trigger = { TERRAIN = highlands }
+			landless_inspector_terrain_master_trigger = { TERRAIN = lowlands }
+			landless_inspector_terrain_master_trigger = { TERRAIN = drylands }
+		}
+	}
+
+	widget = {
+		gui = "decision_view_widget_option_list_generic"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "CHOOSE_DESIGNATED_TERRAIN_DECISION_NEXT_STEP_BUTTON"
+		show_from_start = yes
+
+		item = { # Woodlands
+			value = master_forest_terrain
+			current_description = designated_terrain_forest_decision
+			localization = designated_terrain_forest_decision
+			icon = "gfx/interface/icons/terrain_types/forest.dds"
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = {
+							OR = {
+								terrain = forest
+								terrain = jungle
+								terrain = taiga
+								terrain = wetlands
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Highlands
+			value = master_mountain_terrain
+			current_description = designated_terrain_mountain_decision
+			localization = designated_terrain_mountain_decision
+			icon = "gfx/interface/icons/terrain_types/mountains.dds"
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = {
+							OR = {
+								terrain = mountains
+								terrain = hills
+								terrain = desert_mountains
+								terrain = terraced_hills
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Lowlands
+			value = master_plains_terrain
+			current_description = designated_terrain_plains_decision
+			localization = designated_terrain_plains_decision
+			icon = "gfx/interface/icons/terrain_types/plains.dds"
+			ai_chance = { 
+				value = 5
+				if = {
+					limit = {
+						location = {
+							OR = {
+								terrain = plains
+								terrain = steppe
+								terrain = farmlands
+								terrain = floodplains
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Drylands
+			value = master_drylands_terrain
+			current_description = designated_terrain_drylands_decision
+			localization = designated_terrain_drylands_decision
+			icon = "gfx/interface/icons/terrain_types/drylands.dds"
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = {
+							OR = {
+								terrain = drylands
+								terrain = desert
+								terrain = oasis
+							}
+						}
+					}
+					add = 100
+				}
+			}
+		}
+	}
+
+	effect = {
+		switch = {
+			trigger = yes
+			scope:master_forest_terrain = {
+				custom_tooltip = master_forest_terrain_effect_tooltip
+				landless_inspector_assign_terrain_effect = { TERRAIN = woodlands }
+			}
+			scope:master_mountain_terrain = {
+				custom_tooltip = master_mountain_terrain_effect_tooltip
+				landless_inspector_assign_terrain_effect = { TERRAIN = highlands }
+			}
+			scope:master_plains_terrain = {
+				custom_tooltip = master_plains_terrain_effect_tooltip
+				landless_inspector_assign_terrain_effect = { TERRAIN = lowlands }
+			}
+			scope:master_drylands_terrain = {
+				custom_tooltip = master_drylands_terrain_effect_tooltip
+				landless_inspector_assign_terrain_effect = { TERRAIN = drylands }
+			}
+		}
+	}
+
+	ai_potential = {
+		location = {
+			NOR = {
+				terrain = sea
+				terrain = coastal_sea
+			}
+		}
+	}
+
+	ai_will_do = { base = 10 }
+}
+
+### Master Terrain ###
+choose_master_terrain_decision = {
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 120
+		kingdom = 0
+		empire = 0
+		hegemony = 0
+	}
+
+	picture = { reference = "gfx/interface/illustrations/decisions/ep3_decision_laamp_neutral_mountain.dds" }
+
+	sort_order = 10
+	decision_group_type = major
+
+	is_shown = {
+		is_landed = no
+		has_perk = personal_touch_perk
+		NOR = {
+			# Woodlands
+			has_character_modifier = master_terrain_forest_modifier
+			has_character_modifier = master_terrain_jungle_modifier
+			has_character_modifier = master_terrain_taiga_modifier
+			has_character_modifier = master_terrain_wetlands_modifier
+			# Highlands
+			has_character_modifier = master_terrain_mountains_modifier
+			has_character_modifier = master_terrain_hills_modifier
+			has_character_modifier = master_terrain_desert_mountains_modifier
+			# Lowlands
+			has_character_modifier = master_terrain_plains_modifier
+			has_character_modifier = master_terrain_steppe_modifier
+			has_character_modifier = master_terrain_farmlands_modifier
+			has_character_modifier = master_terrain_floodplains_modifier
+			# Drylands
+			has_character_modifier = master_terrain_drylands_modifier
+			has_character_modifier = master_terrain_desert_modifier
+			has_character_modifier = master_terrain_oasis_modifier
+		}
+		OR = {
+			landless_inspector_terrain_master_trigger = { TERRAIN = woodlands }
+			landless_inspector_terrain_master_trigger = { TERRAIN = highlands }
+			landless_inspector_terrain_master_trigger = { TERRAIN = lowlands }
+			landless_inspector_terrain_master_trigger = { TERRAIN = drylands }
+		}
+	}
+
+	widget = {
+		gui = "decision_view_widget_option_list_generic"
+		controller = decision_option_list_controller
+		decision_to_second_step_button = "CHOOSE_MASTER_TERRAIN_DECISION_NEXT_STEP_BUTTON"
+		show_from_start = yes
+
+		### Woodlands 
+		item = { # Forest
+			value = master_terrain_forest_terrain
+			current_description = master_terrain_forest_decision
+			localization = master_terrain_forest_decision
+			icon = "gfx/interface/icons/terrain_types/forest.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = woodlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = forest }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Jungle
+			value = master_terrain_jungle_terrain
+			current_description = master_terrain_jungle_decision
+			localization = master_terrain_jungle_decision
+			icon = "gfx/interface/icons/terrain_types/jungle.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = woodlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = jungle }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Taiga
+			value = master_terrain_taiga_terrain
+			current_description = master_terrain_taiga_decision
+			localization = master_terrain_taiga_decision
+			icon = "gfx/interface/icons/terrain_types/taiga.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = woodlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = taiga }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Wetlands
+			value = master_terrain_wetlands_terrain
+			current_description = master_terrain_wetlands_decision
+			localization = master_terrain_wetlands_decision
+			icon = "gfx/interface/icons/terrain_types/wetlands.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = woodlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = wetlands }
+					}
+					add = 100
+				}
+			}
+		}
+
+		### Highlands
+		item = { # Mountains
+			value = master_terrain_mountains_terrain
+			current_description = master_terrain_mountains_decision
+			localization = master_terrain_mountains_decision
+			icon = "gfx/interface/icons/terrain_types/mountains.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = highlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = mountains }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Hills
+			value = master_terrain_hills_terrain
+			current_description = master_terrain_hills_decision
+			localization = master_terrain_hills_decision
+			icon = "gfx/interface/icons/terrain_types/hills.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = highlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = hills }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Desert Mountains
+			value = master_terrain_desert_mountains_terrain
+			current_description = master_terrain_desert_mountains_decision
+			localization = master_terrain_desert_mountains_decision
+			icon = "gfx/interface/icons/terrain_types/desert_mountains.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = highlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = desert_mountains }
+					}
+					add = 100
+				}
+			}
+		}
+
+		### Lowlands
+		item = { # Plains
+			value = master_terrain_plains_terrain
+			current_description = master_terrain_plains_decision
+			localization = master_terrain_plains_decision
+			icon = "gfx/interface/icons/terrain_types/plains.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = lowlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = plains }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Steppe
+			value = master_terrain_steppe_terrain
+			current_description = master_terrain_steppe_decision
+			localization = master_terrain_steppe_decision
+			icon = "gfx/interface/icons/terrain_types/steppe.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = lowlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = steppe }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Farmlands
+			value = master_terrain_farmlands_terrain
+			current_description = master_terrain_farmlands_decision
+			localization = master_terrain_farmlands_decision
+			icon = "gfx/interface/icons/terrain_types/farmlands.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = lowlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = farmlands }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Floodplains
+			value = master_terrain_floodplains_terrain
+			current_description = master_terrain_floodplains_decision
+			localization = master_terrain_floodplains_decision
+			icon = "gfx/interface/icons/terrain_types/floodplains.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = lowlands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = floodplains }
+					}
+					add = 100
+				}
+			}
+		}
+
+
+		### Drylands
+		item = { # Drylands
+			value = master_terrain_drylands_terrain
+			current_description = master_terrain_drylands_decision
+			localization = master_terrain_drylands_decision
+			icon = "gfx/interface/icons/terrain_types/drylands.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = drylands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = drylands }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Desert
+			value = master_terrain_desert_terrain
+			current_description = master_terrain_desert_decision
+			localization = master_terrain_desert_decision
+			icon = "gfx/interface/icons/terrain_types/desert.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = drylands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = desert }
+					}
+					add = 100
+				}
+			}
+		}
+		item = { # Oasis
+			value = master_terrain_oasis_terrain
+			current_description = master_terrain_oasis_decision
+			localization = master_terrain_oasis_decision
+			icon = "gfx/interface/icons/terrain_types/oasis.dds"
+			is_shown = { 
+				landless_inspector_terrain_master_trigger = { TERRAIN = drylands } 
+			}
+			ai_chance = { 
+				value = 0
+				if = {
+					limit = {
+						location = { terrain = oasis }
+					}
+					add = 100
+				}
+			}
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				landless_inspector_terrain_master_trigger = { TERRAIN = woodlands }
+			}
+			switch = {
+				trigger = yes
+				scope:master_terrain_forest_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = forest }
+				}
+				scope:master_terrain_jungle_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = jungle }
+				}
+				scope:master_terrain_taiga_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = taiga }
+				}
+				scope:master_terrain_wetlands_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = wetlands }
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				landless_inspector_terrain_master_trigger = { TERRAIN = highlands }
+			}
+			switch = {
+				trigger = yes 
+				scope:master_terrain_mountains_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = mountains }
+				}
+				scope:master_terrain_hills_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = hills }
+				}
+				scope:master_terrain_desert_mountains_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = desert_mountains }
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				landless_inspector_terrain_master_trigger = { TERRAIN = lowlands }
+			}
+			switch = {
+				trigger = yes
+				scope:master_terrain_plains_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = plains }
+				}
+				scope:master_terrain_steppe_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = steppe }
+				}
+				scope:master_terrain_farmlands_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = farmlands }
+				}
+				scope:master_terrain_floodplains_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = floodplains }
+				}
+			}
+		}
+		else_if = {
+			limit = {
+				landless_inspector_terrain_master_trigger = { TERRAIN = drylands }
+			}
+			switch = {
+				trigger = yes
+				scope:master_terrain_drylands_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = drylands }
+				}
+				scope:master_terrain_desert_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = desert }
+				}
+				scope:master_terrain_oasis_terrain = {
+					landless_inspector_master_terrain_effect = { TERRAIN = oasis }
+				}
+			}
+		}
+	}
+
+	ai_potential = {
+		location = {
+			NOR = {
+				terrain = sea
+				terrain = coastal_sea
+			}
+		}
+	}
+
+	ai_will_do = { base = 10 }
+}
+
+# Form Bosporan Kingdom 
+### Restore the Bosporan Kingdom ###
+form_bosporan_kingdom_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/event_scenes/ep3_medi_estate.dds"
+	}
+	decision_group_type = major
+	sort_order = 50
+
+	is_shown = {
+		NOT = {
+			is_target_in_global_variable_list = {
+				name = unavailable_unique_decisions
+				target = flag:flag_bosporan_kingdom
+			}
+		}
+		culture = {
+			OR = {
+				has_cultural_pillar = heritage_central_germanic
+				has_cultural_pillar = heritage_byzantine
+			}
+		}
+		highest_held_title_tier <= tier_kingdom
+		any_held_title = {
+			OR = {
+				de_jure_liege = title:d_crimea
+				de_jure_liege = title:d_azov
+				this = title:d_crimea
+				this = title:d_azov
+			}
+		}
+	}
+
+	is_valid = {
+		completely_controls = title:d_crimea
+		completely_controls = title:d_azov
+		top_liege = this
+		prestige_level >= 3
+	}
+	
+	is_valid_showing_failures_only = {
+		is_landed = yes
+	}
+
+	effect = {
+		add_to_global_variable_list = {
+			name = unavailable_unique_decisions
+			target = flag:flag_bosporan_kingdom
+		}
+
+		house = {
+			add_house_modifier = {
+				modifier = bp3_bosporan_kingdom_modifier
+				years = 100
+			}
+		}
+
+		custom_tooltip = unlocks_black_sea_naval_conquest
+
+		hidden_effect = {
+			title:k_bosporan_kingdom = { set_de_jure_liege_title = title:d_crimea.empire }
+		}
+
+		create_title_and_vassal_change = {
+			type = created
+			save_scope_as = title_change
+			add_claim_on_loss = yes
+		}
+		title:k_bosporan_kingdom = {
+			change_title_holder = {
+				holder = root
+				change = scope:title_change
+			}
+		}
+		resolve_title_and_vassal_change = scope:title_change
+
+		add_character_modifier = bp3_conqueror_black_sea_modifier
+		
+		title:d_crimea = { set_de_jure_liege_title = title:k_bosporan_kingdom }
+		title:d_azov = { set_de_jure_liege_title = title:k_bosporan_kingdom }
+		# Additional DeJures
+		adjust_de_jure_effect = {
+			TITLE = title:d_bugeac
+			DE_JURE = title:k_bosporan_kingdom
+		}
+		adjust_de_jure_effect = {
+			TITLE = title:d_yedisan
+			DE_JURE = title:k_bosporan_kingdom
+		}
+		adjust_de_jure_effect = {
+			TITLE = title:d_levedia
+			DE_JURE = title:k_bosporan_kingdom
+		}
+		adjust_de_jure_effect = {
+			TITLE = title:d_don_valley
+			DE_JURE = title:k_bosporan_kingdom
+		}
+		adjust_de_jure_effect = {
+			TITLE = title:d_kizilyedisan
+			DE_JURE = title:k_bosporan_kingdom
+		}
+		adjust_de_jure_effect = {
+			TITLE = title:d_red_levedia
+			DE_JURE = title:k_bosporan_kingdom
+		}
+		adjust_de_jure_effect = {
+			TITLE = title:d_tana
+			DE_JURE = title:k_bosporan_kingdom
+		}
+		if = {
+			limit = {
+				province:5330 = {
+					has_holding_type = castle_holding
+				}
+				province:5277 = {
+					has_holding = no
+				}
+			}
+			province:5277 = {
+				begin_create_holding = castle_holding
+			}
+		}		
+	}
+
+	cost = {
+		gold = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = no
+				}
+				add = 250
+			}
+		}
+		treasury = {
+			value = 0
+			if = {
+				limit = {
+					has_treasury = yes
+				}
+				add = 250
+			}
+		}
+		prestige = {
+			value = 2000
+		}
+	}
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 60
+		kingdom = 0
+		empire = 0
+		hegemony = 0
+	}
+
+	ai_potential = {
+		is_ruler = yes
+		short_term_gold >= {
+			value = major_gold_value
+			multiply = 1.5
+			round = yes
+		}
+		prestige >= {
+			value = major_prestige_gain
+			multiply = 3
+			round = yes
+		}
+	}
+
+	ai_will_do = {
+		base = 100
+	}
+}
+
+# Merging France and Aquitaine
+### France as One ###
+merge_aquitaine_decision = {
+	picture = {
+		reference = "gfx/interface/illustrations/decisions/decision_found_kingdom.dds"
+	}
+	title = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					primary_title = title:k_aquitaine
+				}
+				desc = merge_aquitaine_decision_alt
+			}
+			desc = merge_aquitaine_decision
+		}
+	}
+	desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					primary_title = title:k_aquitaine
+				}
+				desc = merge_aquitaine_decision_desc_aquitaine
+			}
+			desc = merge_aquitaine_decision_desc
+		}
+		desc = merge_aquitaine_decision_desc_outro
+	}
+	decision_group_type = major
+	sort_order = 50
+
+	is_shown = {
+		NOT = {
+			is_target_in_global_variable_list = {
+				name = unavailable_unique_decisions
+				target = flag:merged_aquitaine
+			}
+		}
+		culture = { has_cultural_pillar = heritage_frankish }
+		OR = {
+			has_title = title:k_aquitaine
+			has_title = title:k_france
+		}
+		NOR = {
+			title:k_aquitaine = { is_titular = yes }
+			title:k_france = { is_titular = yes }
+		}
+	}
+
+	is_valid = {
+		has_title = title:k_aquitaine
+		has_title = title:k_france
+		top_liege = this
+		prestige_level >= 3
+	}
+
+	effect = {
+		add_to_global_variable_list = {
+			name = unavailable_unique_decisions
+			target = flag:merged_aquitaine
+		}
+
+		save_scope_as = rightful_liege
+
+		add_legitimacy_effect = { LEGITIMACY = massive_legitimacy_gain }
+		dynasty ?= { add_dynasty_prestige = massive_dynasty_prestige_value }
+
+		if = {
+			limit = {
+				primary_title = { this = title:k_aquitaine}
+			}
+			merge_aquitaine_effect = {
+				PRIMARY = k_aquitaine
+				SECONDARY = k_france
+				TEXT = alt
+			}
+		}
+		else = {
+			merge_aquitaine_effect = {
+				PRIMARY = k_france
+				SECONDARY = k_aquitaine
+				TEXT = original
+			}
+		}
+
+		trigger_event = major_decisions.3200
+		every_vassal_or_below = {
+			trigger_event = major_decisions.3200
+		}
+	}
+
+	cost = {
+		prestige = {
+			if = {
+				limit = {
+					is_ai = no
+				}
+				value = 1000
+			}
+			else = {
+				value = 0
+			}
+		}
+	}
+
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 0
+		kingdom = 60
+		empire = 60
+		hegemony = 60
+	}
+
+	ai_potential = {
+		is_ruler = yes
+	}
+
+	ai_will_do = {
+		base = 100
+	}
+}
+
+# The Legacy of the Adventurer
+# By Ariana Tranumn
+### Legacy of [GetPlayer.GetHouse.GetBaseNameNoTooltip] ###
+enact_legacy_of_adventurer_decision = {
+	picture = { # pic
+		reference = "gfx/interface/illustrations/decisions/ep3_decision_laamp_neutral_mountain.dds"
+	}
+	desc = enact_legacy_of_adventurer_decision_desc
+	decision_group_type = adventurer
+	ai_check_interval_by_tier = {
+		barony = 0
+		county = 0
+		duchy = 36
+		kingdom = 0
+		empire = 0
+		hegemony = 0
+	}
+
+	ai_potential = {
+		government_has_flag = government_is_landless_adventurer
+	}
+
+	is_shown = {
+		# DLC check.
+		has_ep3_dlc_trigger = yes
+		is_landless_adventurer = yes
+		NOT = { has_trait = gallowsbait }
+		NOT = { 
+			house = {
+				has_house_modifier = legacy_adventurer_house_modifier
+			}
+		}
+	}
+
+	is_valid = {
+		prestige_level >= 4
+		custom_tooltip = {
+			text = have_enough_followers_tt
+			any_courtier = { count >= 15 }
+		}
+		custom_tooltip = {
+			text = have_enough_patrons_tt
+			any_contact = { count >= 5 }
+		}
+		custom_tooltip = {
+			text = has_max_level_pavilion_tt
+			domicile = { has_domicile_building_or_higher = camp_main_04 }
+		}
+		trigger_if = {
+			limit = {
+				has_variable = laamp_total_noncrim_contracts_successfully_completed
+			}
+			save_temporary_scope_value_as = {
+				name = contract_tally
+				value = var:laamp_total_noncrim_contracts_successfully_completed
+			}
+		}
+		trigger_else = {
+			save_temporary_scope_value_as = {
+				name = contract_tally
+				value = 0
+			}				
+		}
+		custom_tooltip = {
+			text = has_enough_contracts_tt
+			has_variable = laamp_total_noncrim_contracts_successfully_completed
+			var:laamp_total_noncrim_contracts_successfully_completed >= 50
+		}
+	}
+
+	is_valid_showing_failures_only = {
+		is_alive = yes
+		is_available_adult = yes
+	}
+
+	cost = {
+		prestige = 1000
+	}
+
+	effect = {
+		custom_tooltip = criminal_contracts_blocked_tt
+		show_as_tooltip = {
+			house = {
+				add_house_modifier = {
+					modifier = legacy_adventurer_house_modifier
+				}
+			}
+		}
+		custom_tooltip = legacy_adventurer_legitimacy_on_landing
+		trigger_event = bp3_decisions.0100
+	}
+
+	ai_will_do = {
+		base = 100
+		modifier = {
+			factor = 0.5
+			has_trait = ambitious
+		}
+		modifier = {
+			factor = 1.5
+			has_trait = lifestyle_traveler
+		}
+	}
+
+}
+

--- a/common/decisions/dlc_decisions/bp3/00_bp3_other_decisions.txt
+++ b/common/decisions/dlc_decisions/bp3/00_bp3_other_decisions.txt
@@ -40,7 +40,9 @@ choose_designated_terrain_decision = {
 
 	is_shown = {
 		OR = {
-			is_landed = no
+			#Unop Only adventurers, not every landless government
+			#is_landed = no
+			is_landless_adventurer = yes
 			government_has_flag = government_is_nomadic
 		}
 		has_perk = mustering_the_troops_perk
@@ -199,7 +201,12 @@ choose_master_terrain_decision = {
 	decision_group_type = major
 
 	is_shown = {
-		is_landed = no
+		#Unop Only adventurers and nomads, not every landless government
+		#is_landed = no
+		OR = {
+			is_landless_adventurer = yes
+			government_has_flag = government_is_nomadic
+		}
 		has_perk = personal_touch_perk
 		NOR = {
 			# Woodlands


### PR DESCRIPTION
Fixes #600

**fixer:** `choose_designated_terrain_decision` gated on `is_landed = no`, which is much wider than "adventurer". Six governments set `landless_playable = yes` — including `administrative_government` — so an unlanded Administrative Head of Family passes the gate while being neither adventurer nor nomad. Nothing downstream re-checks: `wanderer_lifestyle` is gated only on `has_dlc_feature = wandering_nobles`, so they can genuinely take `mustering_the_troops_perk` and reach the decision.

**The effect layer shows the intended audience unambiguously.** In `landless_inspector_assign_terrain_effect`, every tier-2 and tier-3 branch requires `government_is_landless_adventurer` or `government_is_nomadic`; only the final `else_if` has no government check, and that is what an Admin HoF falls through to. In `landless_inspector_upgrade_terrain_tier_extrapolated_effect`, *all four* upgrade branches require adventurer or nomad. So an affected character gets a tier-1 modifier and is then permanently stuck there — the `local_inspection_perk` and `no_stone_unturned_perk` payoffs can never apply. The decision is also explicitly a permanent choice, so that dead end is irreversible.

**Fix:** replaced `is_landed = no` with vanilla's own idiom for this, `is_landless_adventurer = yes`, which `enact_legacy_of_adventurer_decision` uses in the same file. The `government_is_nomadic` branch is preserved — nomads are landed, which is the only reason the `OR` existed.

Also fixed `choose_master_terrain_decision` (same root cause, found during analysis): it gated on a bare `is_landed = no` with no nomad branch at all, so it both leaked to the same governments and would have needed the nomad branch anyway. It's reachable only by someone holding a tier-1+ inspector modifier — precisely the population the first bug creates — so fixing only the first decision would leave this one reachable in existing saves. Both now use the same explicit adventurer-or-nomad test.

Vanilla file added unmodified in a separate first commit. `make tiger` is clean.

Note: a character who already took the decision keeps a tier-1 modifier; cleaning up existing saves is out of scope for a guard fix.

Worth verifying in-game: as an unlanded Admin Head of Family with `mustering_the_troops_perk`, confirm the decision no longer appears; as a landless adventurer and as a nomad, confirm both decisions still do.