### PR TITLE
Fix physician treatment events not firing when appointed outside the hire decision

### DIFF
--- a/common/scripted_effects/00_court_position_effects.txt
+++ b/common/scripted_effects/00_court_position_effects.txt
@@ -112,6 +112,10 @@ basic_invalidated_court_position_effect = {
 # COURT PHYSICIAN
 court_physician_title_accepted_effect = {
 	basic_gained_court_position_effect = yes
+	#Unop Trigger treatments here so every appointment route works, not just the paid hire event
+	scope:liege = {
+		unop_trigger_physician_treatments_effect = yes
+	}
 }
 court_physician_title_revoked_effect = {
 	basic_revoked_court_position_effect = yes

--- a/common/scripted_effects/00_unop_effects.txt
+++ b/common/scripted_effects/00_unop_effects.txt
@@ -739,3 +739,50 @@ unop_distribute_determined_court_position_effect = {
 		}
 	}
 }
+
+#Unop Trigger physician treatments for the employer and their court; called from the court physician's on_court_position_received hook so every appointment route works, not just the paid hire event
+unop_trigger_physician_treatments_effect = {
+	hidden_effect = {
+		if = {
+			limit = {
+				has_treatable_disease_trigger = yes
+				has_recent_treatment_trigger = no
+			}
+			save_scope_as = sick_character
+			trigger_event = {
+				id = health.3101
+				days = { physician_treatment_delay_ruler_min physician_treatment_delay_ruler_max }
+			}
+		}
+		else_if = {
+			limit = {
+				has_recent_wound_treatment_trigger = no
+				has_wounds_trigger = yes
+			}
+			save_scope_as = sick_character
+			trigger_event = {
+				id = health.4001
+				days = { physician_treatment_delay_ruler_min physician_treatment_delay_ruler_max }
+			}
+		}
+		every_courtier_or_guest = {
+			if = {
+				limit = {
+					has_treatable_disease_trigger = yes
+					has_recent_treatment_trigger = no
+				}
+				set_worst_disease_effect = yes
+				save_scope_as = sick_character
+				decide_who_picks_disease_treatment_effect = yes #Sends health.3101 to them or 3102 to liege (you)
+			}
+			else_if = {
+				limit = {
+					has_recent_wound_treatment_trigger = no
+					has_wounds_trigger = yes
+				}
+				save_scope_as = sick_character
+				decide_who_picks_wound_treatment_effect = yes
+			}
+		}
+	}
+}

--- a/common/scripted_effects/20_health_effects.txt
+++ b/common/scripted_effects/20_health_effects.txt
@@ -1361,49 +1361,50 @@ set_court_physician_effect = {
 		}
 	
 		#Trigger treatments if needed
-		hidden_effect = {
-			if = {
-				limit = {
-					has_treatable_disease_trigger = yes
-					has_recent_treatment_trigger = no
-				}
-				save_scope_as = sick_character
-				trigger_event = {
-					id = health.3101
-					days = { physician_treatment_delay_ruler_min physician_treatment_delay_ruler_max }
-				}
-			}
-			else_if = {
-				limit = {
-					has_recent_wound_treatment_trigger = no
-					has_wounds_trigger = yes
-				}
-				save_scope_as = sick_character
-				trigger_event = {
-					id = health.4001
-					days = { physician_treatment_delay_ruler_min physician_treatment_delay_ruler_max }
-				}
-			}
-			every_courtier_or_guest = {
-				if = {
-					limit = {
-						has_treatable_disease_trigger = yes
-						has_recent_treatment_trigger = no
-					}
-					set_worst_disease_effect = yes
-					save_scope_as = sick_character
-					decide_who_picks_disease_treatment_effect = yes #Sends health.3101 to them or 3102 to liege (you)
-				}
-				else_if = {
-					limit = {
-						has_recent_wound_treatment_trigger = no
-						has_wounds_trigger = yes
-					}
-					save_scope_as = sick_character
-					decide_who_picks_wound_treatment_effect = yes
-				}
-			}
-		}
+		#Unop Moved to the court physician on_court_position_received hook so all appointment routes trigger treatments
+#		hidden_effect = {
+#			if = {
+#				limit = {
+#					has_treatable_disease_trigger = yes
+#					has_recent_treatment_trigger = no
+#				}
+#				save_scope_as = sick_character
+#				trigger_event = {
+#					id = health.3101
+#					days = { physician_treatment_delay_ruler_min physician_treatment_delay_ruler_max }
+#				}
+#			}
+#			else_if = {
+#				limit = {
+#					has_recent_wound_treatment_trigger = no
+#					has_wounds_trigger = yes
+#				}
+#				save_scope_as = sick_character
+#				trigger_event = {
+#					id = health.4001
+#					days = { physician_treatment_delay_ruler_min physician_treatment_delay_ruler_max }
+#				}
+#			}
+#			every_courtier_or_guest = {
+#				if = {
+#					limit = {
+#						has_treatable_disease_trigger = yes
+#						has_recent_treatment_trigger = no
+#					}
+#					set_worst_disease_effect = yes
+#					save_scope_as = sick_character
+#					decide_who_picks_disease_treatment_effect = yes #Sends health.3101 to them or 3102 to liege (you)
+#				}
+#				else_if = {
+#					limit = {
+#						has_recent_wound_treatment_trigger = no
+#						has_wounds_trigger = yes
+#					}
+#					save_scope_as = sick_character
+#					decide_who_picks_wound_treatment_effect = yes
+#				}
+#			}
+#		}
 	}
 }
 


### PR DESCRIPTION
Fixes #605

**fixer:** `health.3101`/`health.4001` treatment events only fired when the court physician was hired through the paid `health.3001` decision chain. The kick-off logic lived inside `set_court_physician_effect`, which is only reachable from that chain's event options — appointing an existing courtier via the court-position UI went through `on_court_position_received` instead, which was a bare pass-through. Since the `health.3100` gate self-terminates when no physician is available, the player was then stuck permanently.

Moved the treatment kick-off to the position's accepted hook, which the engine runs for *every* appointment route:

- Extracted the block verbatim into `unop_trigger_physician_treatments_effect` in `00_unop_effects.txt`.
- Commented out the inline copy in `set_court_physician_effect` and call the new effect from `court_physician_title_accepted_effect` on `scope:liege` instead.

Moving rather than duplicating avoids double-firing on the paid path: `set_court_physician_effect` itself calls `appoint_court_position`/`replace_court_position`, so the hook already covers it, and `has_recent_treatment_trigger` only checks post-treatment modifiers — it would not have suppressed a second queued event.

This makes the vanilla comment at `health_events.txt:7300` ("if we hire a new physician, they will treat everyone upon being hired") actually true, and mirrors how `wet_nurse_title_accepted_effect` already puts its on-hire logic in the hook.