### PR TITLE
Fix retirement decisions not transferring gold to the heir

### DIFF
--- a/common/scripted_effects/10_dlc_tgp_japan_scripted_effects.txt
+++ b/common/scripted_effects/10_dlc_tgp_japan_scripted_effects.txt
@@ -3910,6 +3910,31 @@ tgp_renounce_estate_effect = {
 				set_house_head = scope:new_player
 			}
 		}
+		#Unop Also hand over the treasury/gold, otherwise the heir inherits everything except the wealth
+		if = {
+			limit = {
+				trigger_if = {
+					limit = { has_treasury = yes }
+					treasury > 0
+				}
+				trigger_else = {
+					gold > 0
+				}
+			}
+			pay_treasury_or_gold = {
+				target = scope:new_player
+				value = {
+					value = 0
+					if = {
+						limit = { has_treasury = yes }
+						add = treasury
+					}
+					else = {
+						add = gold
+					}
+				}
+			}
+		}
 		if = {
 			limit = {
 				exists = scope:new_human_player_character


### PR DESCRIPTION
Fixes #609

**fixer:** `tgp_renounce_estate_effect` moves held titles, vassals, house headship and player control to the heir, but never the retiree's wealth — so the new player character starts broke while the retiree lives on as a `devoted` courtier holding the whole treasury. The decision is a scripted imitation of succession, so anything the engine does implicitly on death has to be done explicitly here, and gold was overlooked.

Added a transfer next to `set_house_head`, inside the existing `exists = scope:new_player` branch:

- Uses `pay_treasury_or_gold` because these are administrative-family rulers (`decision_group_type = admin`); Administrative/Celestial/Meritocratic/Steppe governments spend *treasury*, so a bare `add_gold` would mishandle them.
- The value branches on `has_treasury`, mirroring the vanilla `*_treasury_or_gold_value` idiom.
- Guarded with a `> 0` check, matching `07_ep3_wars.txt:5119` — without it a retiree in debt would drain the heir instead.

Full transfer matches the decision's loc ("Entrust everything to your house's heir"); a partial remainder would be a balance choice and out of scope. Fixing the shared effect covers both entry points — the retirement decision and `tgp_japan_become_a_monk_decision`.

Closest vanilla precedent is `game_start.txt:4592`, which handles the same title-handover-plus-player-swap and pairs it with `pay_short_term_gold = { gold = gold }`.