### PR TITLE
Fix civil war authority loss skipping Administrative and Nomad rulers

### DIFF
--- a/common/casus_belli_types/00_civil_war.txt
+++ b/common/casus_belli_types/00_civil_war.txt
@@ -1,0 +1,2608 @@
+﻿# Triggers as a result of the Independence Faction demand
+# Note: Wars for Independence started by individual characters is a separate CB
+independence_faction_war = {
+	icon = independence_faction_war
+	group = civil_war
+	ai_only_against_liege = yes
+	target_titles = independence_domain
+	allow_hostages = no
+	allowed_for_character = {
+		scope:attacker = {
+			is_leading_faction_type = independence_faction
+			NOT = {
+				government_has_flag = government_is_landless_adventurer
+			}
+		}
+	}
+
+	allowed_against_character = {
+		scope:attacker = {
+			liege = scope:defender
+		}
+	}
+
+	target_de_jure_regions_above = yes
+
+	valid_to_start = {
+
+	}
+
+	on_declaration = {
+		#on_declared_war = yes
+		# Remove offending HumSac modifiers.
+		scope:attacker = {
+			hidden_effect = { fp1_remove_humsac_offended_counties_effect = yes }
+		}
+
+		# If no faction exists because we created it through history, we add a flag on the attackers to free them at the end
+		if = {
+			limit = { NOT = { exists = scope:attacker.joined_faction } }
+			war = {
+				every_war_attacker = {
+					if = {
+						limit = { NOT = { has_character_flag = should_become_independent } }
+						add_character_flag = should_become_independent
+					}
+				}
+			}
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { # Desc for only one player attacker
+					scope:attacker = {
+						is_local_player = yes
+						exists = joined_faction
+						joined_faction = {
+							any_faction_member = {
+								count = 1
+							}
+						}
+					}
+				}
+				desc = independence_war_victory_desc_local_player_attacker_alone
+			}
+			triggered_desc = { # Desc for only one attacker, player defender
+				trigger = {
+					scope:defender = {
+						is_local_player = yes
+					}
+					scope:attacker = {
+						exists = joined_faction
+						joined_faction = {
+							any_faction_member = {
+								count = 1
+							}
+						}
+					}
+				}
+				desc = independence_war_victory_desc_local_player_defender_attacker_alone
+			}
+			triggered_desc = { # Desc for player attacker
+				trigger = {
+					OR = {
+						AND = {
+							exists = scope:attacker.joined_faction
+							scope:attacker.joined_faction = {
+								any_faction_member = { is_local_player = yes }
+							}
+						}
+						scope:attacker = {
+								is_local_player = yes
+								has_character_flag = should_become_independent
+							}
+					}
+				}
+				desc = independence_war_victory_desc_local_player_attacker
+			}
+			triggered_desc = { # Desc for player defender
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = independence_war_victory_desc_local_player_defender
+			}
+			desc = independence_war_victory_desc # Desc for a third party involved
+		}
+
+	}
+
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 Accolade glory gain from winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+
+		create_title_and_vassal_change = {
+			type = independency
+			save_scope_as = change
+		}
+		if = {
+			limit = { exists = scope:attacker.joined_faction }
+			scope:attacker.joined_faction = {
+				every_faction_member = {
+					change_liege_or_become_independent = {
+						CHANGE = scope:change
+						VASSAL = this
+					}
+
+					hidden_effect = {
+						set_variable = {
+							name = independence_war_former_liege
+							value = scope:defender
+						}
+						add_truce_both_ways = {
+							character = scope:defender
+							days = 1825
+							war = root.war
+							result = victory
+						}
+						save_scope_as = current_member
+
+						# Struggle Catalyst
+						if = {
+							limit = {
+								catalyst_gave_independence_to_powerful_diff_faith_culture_vassal_preliminary_trigger = {
+									CHAR1 = scope:defender
+									CHAR2 = scope:current_member
+								}
+								any_character_struggle = {
+									involvement = involved
+									activate_struggle_catalyst_secondary_character_involvement_involved_trigger = {
+										CATALYST = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+										CHAR = scope:current_member
+									}
+								}
+							}
+							every_character_struggle = {
+								involvement = involved
+								limit = {
+									activate_struggle_catalyst_secondary_character_involvement_either_trigger = {
+										CATALYST = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+										CHAR = scope:current_member
+									}
+								}
+								activate_struggle_catalyst = {
+									catalyst = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+									character = scope:defender
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		else_if = {
+			# Free character with the flag
+			limit = { exists = war }
+			war = {
+				every_war_attacker = {
+					if = {
+						limit = { has_character_flag = should_become_independent }
+
+						change_liege_or_become_independent = {
+							CHANGE = scope:change
+							VASSAL = this
+						}
+
+						hidden_effect = {
+							set_variable = {
+								name = independence_war_former_liege
+								value = scope:defender
+							}
+							add_truce_both_ways = {
+								character = scope:defender
+								days = 1825
+								war = root.war
+								result = victory
+							}
+							save_scope_as = current_member
+
+							# Struggle Catalyst
+							if = {
+								limit = {
+									catalyst_gave_independence_to_powerful_diff_faith_culture_vassal_preliminary_trigger = {
+										CHAR1 = scope:defender
+										CHAR2 = scope:current_member
+									}
+									any_character_struggle = {
+										involvement = involved
+										activate_struggle_catalyst_secondary_character_involvement_involved_trigger = {
+											CATALYST = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+											CHAR = scope:current_member
+										}
+									}
+								}
+								every_character_struggle = {
+									involvement = involved
+									limit = {
+										activate_struggle_catalyst_secondary_character_involvement_either_trigger = {
+											CATALYST = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+											CHAR = scope:current_member
+										}
+									}
+									activate_struggle_catalyst = {
+										catalyst = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+										character = scope:defender
+									}
+								}
+							}
+
+							remove_character_flag = should_become_independent
+						}
+					}
+				}
+			}
+		}
+
+		scope:attacker = {
+			add_prestige = medium_prestige_value
+		}
+		scope:defender = {
+			add_prestige = {
+				value = medium_prestige_value
+				multiply = -1
+			}
+			
+			if = {
+				limit = { has_realm_law = crown_authority_1 }
+				add_realm_law = crown_authority_0
+			}
+			if = {
+				limit = { has_realm_law = crown_authority_2 }
+				add_realm_law = crown_authority_1
+			}
+			if = {
+				limit = { has_realm_law = crown_authority_3 }
+				add_realm_law = crown_authority_2
+			}
+			if = {
+				limit = { has_realm_law = tribal_authority_1 }
+				add_realm_law = tribal_authority_0
+			}
+			if = {
+				limit = { has_realm_law = tribal_authority_2 }
+				add_realm_law = tribal_authority_1
+			}
+			if = {
+				limit = { has_realm_law = tribal_authority_3 }
+				add_realm_law = tribal_authority_2
+			}
+		}
+		resolve_title_and_vassal_change = scope:change
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_victory_effects = yes
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = independence_war_white_peace_defender_desc
+			}
+			triggered_desc = {
+				trigger = {
+					OR = {
+						AND = {
+							exists = scope:attacker.joined_faction
+							scope:attacker.joined_faction = {
+								any_faction_member = { is_local_player = yes }
+							}
+						}
+						scope:attacker = {
+								is_local_player = yes
+								has_character_flag = should_become_independent
+							}
+					}
+				}
+				desc = independence_war_white_peace_attacker_desc
+			}
+			desc = independence_war_white_peace_desc
+		}
+		desc = independence_war_white_peace_end_desc
+
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = white_peace
+				}
+			}
+		}
+
+		scope:defender = {
+			stress_impact = {
+ 				arrogant = medium_stress_impact_gain
+ 			}
+
+			add_character_flag = {
+				flag = recent_independence_faction_war
+				years = faction_war_white_peace_cooldown
+			}
+			add_prestige = minor_prestige_value
+		}
+
+		on_white_peace_faction_revolt_war = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = independence_defeat_defender_desc
+			}
+			triggered_desc = {
+				trigger = {
+					OR = {
+						AND = {
+							exists = scope:attacker.joined_faction
+							scope:attacker.joined_faction = {
+								any_faction_member = { is_local_player = yes }
+							}
+						}
+						scope:attacker = {
+								is_local_player = yes
+								has_character_flag = should_become_independent
+							}
+					}
+				}
+				desc = independence_defeat_attacker_desc
+			}
+			desc = player_independence_war_defeat_desc #same loc as for player
+		}
+		desc = independence_defeat_end_desc
+
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_character_flag = {
+				flag = recent_independence_faction_war
+				years = faction_war_defeat_cooldown
+			}
+			add_dread = medium_dread_gain
+			# Prestige for Defender
+			add_prestige_war_defender_effect = {
+				PRESTIGE_VALUE = medium_prestige_value
+			}
+			add_achievement_flag_effect = { FLAG = achievement_know_your_place_flag }
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+		on_lost_faction_revolt_war = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_defeat_effects = yes
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	check_defender_inheritance_validity = no
+
+	on_primary_attacker_death = inherit_faction
+	on_primary_defender_death = inherit
+
+	transfer_behavior = transfer
+
+	attacker_allies_inherit = no
+	defender_allies_inherit = yes
+
+	war_name = "INDEPENDENCE_WAR_NAME"
+
+	interface_priority = 80
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 1.0
+	defender_wargoal_percentage = 0.0 # A single occupation will do
+	defender_ticking_warscore_delay = { days = 0 } # No need for a delay here since the defender actually needs to occupy something rather than starting in control
+
+	max_attacker_score_from_battles = 100
+	max_defender_score_from_battles = 50
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}
+
+# Triggers as a result of the Liberty Faction demand
+liberty_faction_war = {
+	icon = dissolution_war
+	group = civil_war
+	ai_only_against_liege = yes
+	allow_hostages = no
+	allowed_for_character = {
+		scope:attacker = {
+			is_leading_faction_type = liberty_faction
+		}
+	}
+
+	allowed_against_character = {
+		scope:attacker = {
+			liege = scope:defender
+		}
+	}
+
+	target_de_jure_regions_above = yes
+	target_top_liege_if_outside_realm = no # In case of adventurers starting faction wars
+
+	valid_to_start = {
+	}
+
+	on_declaration = {
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:defender = {
+						is_local_player = yes
+						government_has_flag = government_is_administrative
+					}
+				}
+				desc = liberty_war_victory_defender_desc_admin
+			}
+			triggered_desc = {
+				trigger = {
+					scope:defender = { government_has_flag = government_is_administrative }
+				}
+				desc = liberty_war_victory_desc_admin
+			}
+			triggered_desc = {
+				trigger = {
+					scope:defender = {
+						is_local_player = yes
+						government_has_flag = government_is_tribal
+					}
+				}
+				desc = liberty_war_victory_defender_desc_tribal
+			}
+			triggered_desc = {
+				trigger = {
+					scope:defender = { government_has_flag = government_is_tribal }
+				}
+				desc = liberty_war_victory_desc_tribal
+			}
+			triggered_desc = {
+				trigger = {
+					scope:defender = { is_local_player = yes }
+				}
+				desc = liberty_war_victory_defender_desc
+			}
+			desc = liberty_war_victory_desc
+		}
+	}
+
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 Accolade glory gain from winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		scope:defender = {
+			switch = {
+				trigger = has_realm_law_in_group
+				celestial_bureaucracy = {
+					change_realm_law_level = {
+						law_group = celestial_bureaucracy
+						change = -1
+					}
+				}
+				imperial_bureaucracy = {
+					change_realm_law_level = {
+						law_group = imperial_bureaucracy
+						change = -1
+					}
+				}
+				japanese_bureaucracy = {
+					change_realm_law_level = {
+						law_group = japanese_bureaucracy
+						change = -1
+					}
+				}
+				meritocratic_bureaucracy = {
+					change_realm_law_level = {
+						law_group = meritocratic_bureaucracy
+						change = -1
+					}
+				}
+				crown_authority = {
+					change_realm_law_level = {
+						law_group = crown_authority
+						change = -1
+					}
+				}
+				tribal_authority = {
+					change_realm_law_level = {
+						law_group = tribal_authority
+						change = -1
+					}
+				}
+			}
+
+			# MERITOCRATIC EMPIRE CEREMONIAL MONARCH/REGENCY CREATION
+			tgp_create_meritocratic_ruling_regent_title_effect = yes
+
+			add_prestige = -500
+
+			every_character_war = {
+				limit = {
+					is_attacker = scope:attacker
+					is_defender = scope:defender
+				}
+				every_war_attacker = {
+					if = {
+						limit = {
+							can_add_hook = {
+								type = favor_hook
+								target = scope:defender
+							}
+						}
+						add_hook = {
+							type = favor_hook
+							target = scope:defender
+						}
+					}
+				}
+			}
+
+			add_character_flag = {
+				flag = recent_liberty_faction_war
+				years = liberty_war_victory_cooldown
+			}
+		}
+
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = victory
+				}
+				joined_faction = {
+					save_scope_as = saved_faction
+					add_faction_discontent = -200
+					every_faction_member = {
+						if = {
+							limit = {
+								exists = scope:attacker.joined_faction # Can get destroyed as we loop through
+							}
+							leave_faction_with_cooldown_effect = {
+								FACTION = scope:attacker.joined_faction
+								YEARS = liberty_war_victory_cooldown
+							}
+						}
+						else = {
+							add_faction_cooldown_effect = { YEARS = liberty_war_victory_cooldown }
+						}
+					}
+				}
+				# The faction should have already been destroyed due to all members leaving above, but in case it hasn't, destroy it now.
+				if = {
+					limit = { exists = scope:saved_faction }
+					scope:saved_faction = {
+						destroy_faction = yes
+					}
+				}
+			}
+		}
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_victory_effects = yes
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = liberty_war_white_peace_defender_desc
+			}
+			triggered_desc = {
+				trigger = {
+					scope:attacker.joined_faction = {
+						any_faction_member = { is_local_player = yes }
+					}
+				}
+				desc = liberty_war_white_peace_attacker_desc
+			}
+			desc = liberty_war_white_peace_desc
+		}
+		desc = liberty_war_white_peace_end_desc
+
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = white_peace
+				}
+			}
+		}
+		scope:defender = {
+			stress_impact = {
+ 				arrogant = medium_stress_impact_gain
+ 			}
+			add_character_flag = {
+				flag = recent_liberty_faction_war
+				years = faction_war_white_peace_cooldown
+			}
+		}
+		on_white_peace_faction_revolt_war = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = liberty_war_defeat_defender_desc
+			}
+			triggered_desc = {
+				trigger = {
+					scope:attacker.joined_faction = {
+						any_faction_member = { is_local_player = yes }
+					}
+				}
+				desc = liberty_war_defeat_attacker_desc
+			}
+			desc = liberty_war_defeat_desc
+		}
+		desc = liberty_war_defeat_end_desc
+
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_character_flag = {
+				flag = recent_liberty_faction_war
+				years = faction_war_defeat_cooldown
+			}
+			add_dread = medium_dread_gain
+			add_achievement_flag_effect = { FLAG = achievement_know_your_place_flag }
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+		on_lost_faction_revolt_war = yes
+
+		# EP3: note gold gained from military assistance/join war contracts and their war contribution threshold
+		laamp_as_mercenary_payout_tooltip_effect = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_defeat_effects = yes
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	check_attacker_inheritance_validity = no
+
+	on_primary_attacker_death = inherit_faction
+	on_primary_defender_death = inherit
+
+	transfer_behavior = transfer
+
+	attacker_allies_inherit = no
+	defender_allies_inherit = yes
+
+	war_name = "LIBERTY_WAR_NAME"
+
+	interface_priority = 80
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 0.8
+
+	max_attacker_score_from_battles = 100
+	max_defender_score_from_battles = 50
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}
+
+populist_war = {
+	icon = peasant_war
+	group = civil_war
+	ai_only_against_liege = yes
+	target_titles = claim
+	allow_hostages = no
+	allowed_for_character =	{
+		scope:attacker = {
+			OR = {
+				is_leading_faction_type = populist_faction
+				is_leading_faction_type = escalated_peasant_faction
+			}
+		}
+	}
+
+	allowed_against_character = {
+	}
+
+	target_de_jure_regions_above = yes
+	target_top_liege_if_outside_realm = no
+
+	valid_to_start = {
+	}
+
+	should_invalidate = {
+		NOT = {
+			scope:attacker = {
+				exists = joined_faction
+			}
+		}
+	}
+
+	on_declaration = {
+		#on_declared_war = yes
+
+		# Generate extra troops if the rebellion was financed
+		generate_troops_from_revolt_county_modifiers_effect = yes
+
+		# Struggle stuffs
+		scope:defender = {
+			if = {
+				limit = {
+					any_character_struggle = {
+						phase_has_catalyst = catalyst_populist_uprise
+						involvement = involved
+					}
+				}
+				every_character_struggle = {
+					involvement = involved
+					activate_struggle_catalyst = {
+						catalyst = catalyst_populist_uprise
+						character = this
+					}
+				}
+			}
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:defender = { government_has_flag = government_is_administrative }
+				}
+				desc = populist_war_victory_desc_admin
+			}
+			desc = populist_war_victory_desc
+		}
+	}
+
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:defender = {
+
+			add_prestige_level = -1
+
+			# Struggle Catalysts
+			hidden_effect = {
+				if = {
+					limit = {
+						is_important_or_vip_struggle_character = yes
+						any_character_struggle = {
+							involvement = involved
+							activate_struggle_catalyst_secondary_character_involvement_either_trigger = {
+								CATALYST = catalyst_accepted_demand_from_faction_requesting_culture_faith_conversion
+								CHAR = scope:attacker
+							}
+						}
+					}
+					every_character_struggle = {
+						involvement = involved
+						limit = {
+							activate_struggle_catalyst_secondary_character_involvement_either_trigger = {
+								CATALYST = catalyst_accepted_demand_from_faction_requesting_culture_faith_conversion
+								CHAR = scope:attacker
+							}
+						}
+						activate_struggle_catalyst = {
+							catalyst = catalyst_accepted_demand_from_faction_requesting_culture_faith_conversion
+							character = scope:defender
+						}
+					}
+				}
+			}
+		}
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		random_in_list = {
+			list = target_titles
+			save_scope_as = target_title
+		}
+
+		scope:attacker = {
+			remove_variable = rebel_leader_peasants
+			joined_faction = {
+				every_faction_member = {
+					# Everyone involved gets a 5-year truce.
+					add_truce_both_ways = {
+						character = scope:defender
+						days = 1825
+						war = root.war
+						result = victory
+					}
+				}
+			}
+		}
+
+		successful_popular_revolt_outcome_effect = {
+			FACTION_LEADER = scope:attacker
+			TARGET_TITLE = scope:target_title
+			SOURCE_GOVERNMENT = scope:defender
+		}
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:defender = { government_has_flag = government_is_administrative }
+				}
+				desc = populist_war_white_peace_desc_admin
+			}
+			desc = populist_war_white_peace_desc
+		}
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		on_white_peace_faction_revolt_war = yes
+		hidden_effect = {
+			scope:attacker = {
+				# Destroy the populist faction
+				if = {
+					limit = {
+						exists = joined_faction
+					}
+					joined_faction = {
+						destroy_faction = yes
+					}
+				}
+
+				# Destroy or clean-up flags on faction leader
+				if = {
+					limit = {
+						has_character_flag = peasant_faction_random_peasant
+					}
+					death = {
+						death_reason = death_vanished
+					}
+				}
+				else = {
+					remove_variable = rebel_leader_peasants
+					add_truce_both_ways = {
+						character = scope:defender
+						days = 1825
+						war = root.war
+						result = victory
+					}
+				}
+			}
+		}
+	}
+
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:defender = { government_has_flag = government_is_administrative }
+				}
+				desc = populist_war_defeat_desc_admin
+			}
+			desc = populist_war_defeat_desc
+		}
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:attacker = {
+			joined_faction = {
+				every_faction_county_member = {
+					custom = peasant_faction_every_county
+					add_county_modifier = {
+						modifier = county_increased_opinion_modifier
+						years = 25
+					}
+					if = {
+						limit = {
+							has_county_modifier = peasant_war_lost_county_modifier
+						}
+						remove_county_modifier = peasant_war_lost_county_modifier
+					}
+				}
+			}
+			add_character_flag = peasant_revolt_do_not_kill
+			remove_variable = rebel_leader_peasants
+		}
+		on_lost_faction_revolt_war = yes # Imprison all faction members, including the faction leader.
+		scope:attacker = { # Imprison any war participant that isn't already in the faction.
+			every_character_war = {
+				limit = {
+					is_defender = scope:defender
+				}
+				every_war_attacker = {
+					limit = {
+						is_imprisoned = no
+					}
+					hidden_effect = {
+						hard_imprison_character_effect = {
+							TARGET = this
+							IMPRISONER = scope:defender
+						}
+					}
+				}
+			}
+		}
+		hidden_effect = {
+			scope:attacker = {
+				if = {
+					limit = { exists = joined_faction }
+					joined_faction = {
+						destroy_faction = yes # Destroy the faction if it wasn't already destroyed automatically.
+					}
+				}
+			}
+		}
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_dread = medium_dread_gain
+			add_achievement_flag_effect = { FLAG = achievement_know_your_place_flag }
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	on_primary_attacker_death = invalidate
+	on_primary_defender_death = inherit
+
+	transfer_behavior = transfer
+
+	attacker_allies_inherit = no
+	defender_allies_inherit = yes
+
+	war_name = "POPULIST_WAR_NAME"
+
+	interface_priority = 80
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 0.8
+
+	max_attacker_score_from_battles = 100
+	max_defender_score_from_battles = 50
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}
+
+# Triggers as a result of a Claimant Faction demand being refused
+claimant_faction_war = {
+	icon = claim_cb
+	group = civil_war
+	ai_only_against_liege = no
+	target_titles = claim
+	allow_hostages = no
+	target_top_liege_if_outside_realm = no
+	allowed_for_character = {
+		scope:attacker = {
+			is_leading_faction_type = claimant_faction
+		}
+	}
+
+	allowed_against_character = {
+		exists = scope:attacker.joined_faction
+		scope:attacker.joined_faction = {
+			special_title.holder = scope:defender
+		}
+	}
+
+	target_de_jure_regions_above = yes
+
+	valid_to_start = {}
+
+	should_invalidate = {
+		OR = {
+			NOT = { exists = scope:attacker.joined_faction }
+			NOT = {
+				scope:attacker.joined_faction = {
+					exists = special_character
+					special_character = { is_alive = yes }
+					has_special_title = yes
+				}
+			}
+			scope:attacker.joined_faction.special_character = scope:attacker.joined_faction.special_title.holder
+		}
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	on_declaration = {
+		#on_declared_war = yes
+	}
+
+	on_victory_desc = {
+		desc = claimant_faction_war_victory_desc
+
+	}
+
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 Accolade glory gain from winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = victory
+				}
+			}
+		}
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		on_claimant_faction_war_win_common = {
+			TARGET_TITLES = target_titles
+			ATTACKER = scope:attacker
+			DEFENDER = scope:defender
+			CLAIMANT = scope:attacker.joined_faction.special_character
+			#ATTACKER_PRESTIGE = 10
+			#DEFENDER_PRESTIGE = -10
+		}
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_victory_effects = yes
+	}
+
+	on_white_peace_desc = {
+		desc = claimant_faction_war_white_peace_desc
+
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+
+		scope:defender = {
+			stress_impact = {
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		on_white_peace_faction_revolt_war = yes
+
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = white_peace
+				}
+				if = {
+					limit = { exists = joined_faction }
+					joined_faction = {
+						destroy_faction = yes # Destroy the faction if it wasn't already destroyed automatically.
+					}
+				}
+			}
+		}
+	}
+
+	on_defeat_desc = {
+		desc = claimant_faction_war_defeat_desc
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		on_lost_faction_revolt_war = yes
+
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_dread = medium_dread_gain
+			add_achievement_flag_effect = { FLAG = achievement_know_your_place_flag }
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_defeat_effects = yes
+	}
+
+	check_attacker_inheritance_validity = no
+
+	on_primary_attacker_death = inherit_faction
+	on_primary_defender_death = inherit
+
+	transfer_behavior = transfer
+
+	attacker_allies_inherit = no
+	defender_allies_inherit = yes
+
+	war_name = "CLAIMANT_WAR_NAME"
+
+	interface_priority = 80
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 0.8
+
+	max_attacker_score_from_battles = 50
+	max_defender_score_from_battles = 100
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}
+
+depose_war = {
+	icon = dissolution_war
+	group = civil_war
+	ai_only_against_liege = yes
+	target_titles = none
+	allow_hostages = no
+	allowed_for_character = {
+	}
+
+	allowed_against_character = {
+	}
+
+	target_de_jure_regions_above = yes
+
+	valid_to_start = {
+	}
+
+	on_declaration = {
+		#on_declared_war = yes
+		if = {
+			limit = { NOT = { exists = scope:attacker.var:initial_target } }
+			scope:attacker = {
+				set_variable = {
+					name = initial_target
+					value = scope:defender
+				}
+
+				set_variable = {
+					name = target_tier
+					value = scope:defender.primary_title.tier
+				}
+			}
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:defender = { 
+						government_has_flag = government_is_mandala
+						is_local_player = yes 
+					}
+				}
+				desc = mandala_depose_war_victory_desc_defender
+			}
+			triggered_desc = {
+				trigger = {
+					scope:defender = { 
+						government_has_flag = government_is_mandala
+						is_local_player = no 
+					}
+				}
+				desc = mandala_depose_war_victory_desc
+			}
+			triggered_desc = {
+				trigger = {
+					scope:defender = { is_local_player = yes }
+					OR = {
+						NOT = { exists = scope:attacker.var:initial_target }
+						scope:defender = scope:attacker.var:initial_target
+						scope:defender.primary_title.tier <= scope:attacker.var:target_tier
+					}
+				}
+				desc = depose_war_victory_desc_defender
+			}
+			triggered_desc = {
+				trigger = {
+					OR = {
+						NOT = { exists = scope:attacker.var:initial_target }
+						scope:defender = scope:attacker.var:initial_target
+						scope:defender.primary_title.tier <= scope:attacker.var:target_tier
+					}
+				}
+				desc = depose_war_victory_desc
+			}
+		}
+	}
+
+	on_victory = {
+		scope:attacker = { 
+			show_pow_release_message_effect = yes
+			#EP2 Accolade glory gain from winning against higher ranked enemy
+			accolade_attacker_war_end_glory_gain_med_effect = yes
+			#Mandala rebels become independent
+			if = {
+				limit = {
+					scope:defender = { government_has_flag = government_is_mandala }
+					is_vassal_or_below_of = scope:defender
+				}
+				mandala_rebel_attacker_independency_effect = yes
+			}
+			hidden_effect = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = victory
+				}
+			}
+		}
+		
+		scope:defender = {
+			#Mandalas don't get deposed like everyone else ... but you lose everything that you care about
+			if = {
+				limit = { government_has_flag = government_is_mandala }
+				mandala_not_quite_depose_effect = yes
+			}
+			else = {
+				set_variable = {
+					name = deposed_primary_title
+					value = primary_title
+					months = 1
+				}
+				# Then our liege is deposed (but the imprisonment loss remains true for their heir).
+				if = {
+					limit = { NOT = { exists = scope:attacker.var:initial_target } }
+					depose_effect = { DEPOSER = scope:attacker }
+				}
+				else = {
+					if = {
+						limit = { this = scope:attacker.var:initial_target }
+						depose_effect = { DEPOSER = scope:attacker }
+					}
+					else_if = {
+						limit = { primary_title.tier <= scope:attacker.var:target_tier}
+						depose_effect = { DEPOSER = scope:attacker }
+					}	
+				}
+			}
+
+			# Remove offending HumSac modifiers.
+			hidden_effect = { fp1_remove_humsac_offended_counties_effect = yes }
+
+			# If we win the rebellion, our liege loses any legal right to imprison us/banish us/revoke our titles.
+			consume_all_criminal_reasons_effect = {
+				LIEGE = scope:defender
+				CRIMINAL = scope:attacker
+			}
+
+			# remove variables
+			scope:attacker = {
+				remove_variable = initial_target
+				remove_variable = target_tier
+			}
+			
+		}
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_victory_effects = yes
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { 
+					scope:defender = { is_local_player = yes } 
+				}
+				desc = depose_war_white_peace_desc_defender
+			}
+			desc = depose_war_white_peace_desc
+		}
+
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		scope:defender = {
+			stress_impact = {
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		on_white_peace_faction_revolt_war = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = depose_war_defeat_desc_defender
+			}
+			desc = depose_war_defeat_desc
+		}
+
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		on_lost_faction_revolt_war = yes
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_dread = medium_dread_gain
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_defeat_effects = yes
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	check_attacker_inheritance_validity = no
+
+	on_primary_attacker_death = inherit_faction
+	on_primary_defender_death = inherit
+
+	transfer_behavior = transfer
+
+	attacker_allies_inherit = no
+	defender_allies_inherit = yes
+
+	war_name = "DEPOSE_WAR_NAME"
+
+	interface_priority = 80
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 0.8
+
+	attacker_score_from_occupation_scale = 50
+	defender_score_from_occupation_scale = 50
+	max_attacker_score_from_battles = 100
+	max_defender_score_from_battles = 100
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}
+
+refused_liege_demand_war = {
+	icon = dissolution_war
+	group = civil_war
+	ai_only_against_liege = yes
+	allow_hostages = no
+	allowed_for_character = {
+		scope:attacker = {
+			is_leading_faction_type = liberty_faction
+		}
+	}
+
+	allowed_against_character = {
+		scope:attacker = {
+			liege = scope:defender
+		}
+	}
+
+	target_de_jure_regions_above = yes
+
+	valid_to_start = {
+	}
+
+	should_invalidate = {
+		scope:attacker = {
+			OR = {
+				NOT = {
+					any_liege_or_above = { this = scope:defender }
+				}
+				is_landed = no
+			}
+		}
+	}
+
+	on_declaration = {
+		#on_declared_war = yes
+		# save the initial target and their tier for conditioning the depose effect
+		if = {
+			limit = { NOT = { exists = scope:attacker.var:initial_target } }
+			scope:attacker = {
+				set_variable = {
+					name = initial_target
+					value = scope:defender
+				}
+
+				set_variable = {
+					name = target_tier
+					value = scope:defender.primary_title.tier
+				}
+			}
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = {
+					scope:defender = { 
+						government_has_flag = government_is_mandala
+						is_local_player = yes 
+					}
+				}
+				desc = mandala_depose_war_victory_desc_defender
+			}
+			triggered_desc = {
+				trigger = {
+					scope:defender = { 
+						government_has_flag = government_is_mandala
+						is_local_player = no 
+					}
+				}
+				desc = mandala_depose_war_victory_desc
+			}
+			triggered_desc = {
+				trigger = {
+					scope:defender = { is_local_player = yes }
+					OR = {
+						NOT = { exists = scope:attacker.var:initial_target }
+						scope:defender = scope:attacker.var:initial_target
+						scope:defender.primary_title.tier <= scope:attacker.var:target_tier
+					}
+				}
+				desc = depose_war_victory_desc_defender
+			}
+			triggered_desc = {
+				trigger = {
+					OR = {
+						NOT = { exists = scope:attacker.var:initial_target }
+						scope:defender = scope:attacker.var:initial_target
+						scope:defender.primary_title.tier <= scope:attacker.var:target_tier
+					}
+				}
+				desc = depose_war_victory_desc
+			}
+		}
+	}
+
+	on_victory = {
+		scope:attacker = { 
+			show_pow_release_message_effect = yes
+			#EP2 Accolade glory gain from winning against higher ranked enemy
+			accolade_attacker_war_end_glory_gain_med_effect = yes
+			#Mandala rebels become independent
+			if = {
+				limit = {
+					scope:defender = { government_has_flag = government_is_mandala }
+					is_vassal_or_below_of = scope:defender
+				}
+				mandala_rebel_attacker_independency_effect = yes
+			}
+		}
+
+		scope:defender = {
+			#Mandalas don't get deposed like everyone else ... but you lose everything that you care about
+			if = {
+				limit = { government_has_flag = government_is_mandala }
+				mandala_not_quite_depose_effect = yes
+			}
+			else = {
+				set_variable = {
+					name = deposed_primary_title
+					value = primary_title
+					months = 1
+				}
+				if = {
+					limit = { has_realm_law = crown_authority_1 }
+					add_realm_law = crown_authority_0
+				}
+				if = {
+					limit = { has_realm_law = crown_authority_2 }
+					add_realm_law = crown_authority_1
+				}
+				if = {
+					limit = { has_realm_law = crown_authority_3 }
+					add_realm_law = crown_authority_2
+				}
+				if = {
+					limit = { has_realm_law = tribal_authority_1 }
+					add_realm_law = tribal_authority_0
+				}
+				if = {
+					limit = { has_realm_law = tribal_authority_2 }
+					add_realm_law = tribal_authority_1
+				}
+				if = {
+					limit = { has_realm_law = tribal_authority_3 }
+					add_realm_law = tribal_authority_2
+				}
+
+				add_prestige = -500
+
+				# Then our liege is deposed (but the imprisonment loss remains true for their heir).
+				if = {
+					limit = { NOT = { exists = scope:attacker.var:initial_target } }
+					depose_effect = { DEPOSER = scope:attacker }
+				}
+				else = {
+					if = {
+						limit = { this = scope:attacker.var:initial_target }
+						depose_effect = { DEPOSER = scope:attacker }
+					}
+					else_if = {
+						limit = { primary_title.tier <= scope:attacker.var:target_tier }
+						depose_effect = { DEPOSER = scope:attacker }
+					}
+				}
+			}
+
+			add_character_flag = {
+				flag = recent_liberty_faction_war
+				years = 5
+			}
+
+			# If we win the rebellion, our liege loses any legal right to imprison us/banish us/revoke our titles.
+			consume_all_criminal_reasons_effect = {
+				LIEGE = scope:defender
+				CRIMINAL = scope:attacker
+			}
+
+			# remove variables
+			scope:attacker = {
+				remove_variable = initial_target
+				remove_variable = target_tier
+			}
+		}
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = victory
+				}
+			}
+		}
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_victory_effects = yes
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = refused_liege_demand_war_white_peace_desc_defender
+			}
+			desc = refused_liege_demand_war_white_peace_desc
+		}
+
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+
+		scope:defender = {
+			stress_impact = {
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = white_peace
+				}
+			}
+		}
+		on_white_peace_request_revolt_war = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = refused_liege_demand_war_defeat_desc_defender
+			}
+			desc = refused_liege_demand_war_defeat_desc
+		}
+
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_character_flag = {
+				flag = recent_liberty_faction_war
+				years = 10
+			}
+			add_dread = medium_dread_gain
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+
+		# For revoking titles of character's imprisoned abroard who have lost a revocation war
+		hidden_effect = {
+			if = {
+				limit = {
+					scope:attacker = {
+						is_imprisoned = yes
+						NOT = { is_imprisoned_by = scope:defender }
+					}
+				}
+				scope:defender = {
+					add_opinion = {
+						target = scope:attacker
+						modifier = foreign_prison_revocation_opinion
+					}
+				}
+			}
+		}
+		
+		on_lost_request_revolt_war = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_defeat_effects = yes
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	check_attacker_inheritance_validity = no
+
+	on_primary_attacker_death = invalidate
+	on_primary_defender_death = inherit
+
+	transfer_behavior = transfer
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	war_name = "DEPOSE_WAR_NAME"
+
+	interface_priority = 80
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 0.8
+
+	max_attacker_score_from_battles = 100
+	max_defender_score_from_battles = 50
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}
+
+independence_war = {
+	icon = independence_faction_war
+	group = independence
+	ai = no # AI targeting is handled through game_rule events.
+
+	target_top_liege_if_outside_realm = no # In case of Adventurers starting this war
+
+	allow_hostages = no
+	allowed_for_character = {
+		scope:attacker = {
+			NOT = { government_allows = administrative }
+		}
+	}
+	allowed_against_character = {
+		scope:attacker = {
+			liege = scope:defender
+		}
+	}
+
+	cost = {
+		piety = {
+			value = 0
+			add = common_cb_impious_piety_cost
+		}
+		prestige = {
+			value = 0
+			add = {
+				value = 500
+				desc = CB_BASE_COST
+			}
+			multiply = common_cb_prestige_cost_multiplier
+		}
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+		# Remove offending HumSac modifiers.
+		scope:attacker = {
+			hidden_effect = { fp1_remove_humsac_offended_counties_effect = yes }
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { # Desc for only one player attacker
+					scope:attacker = {
+						is_local_player = yes
+					}
+				}
+				desc = independence_war_victory_desc_local_player_attacker_alone
+			}
+			triggered_desc = { # Desc for only one attacker, player defender
+				trigger = {
+					scope:defender = {
+						is_local_player = yes
+					}
+				}
+				desc = player_independence_war_victory_desc_local_player_defender_attacker_alone
+			}
+			desc = independence_war_victory_desc_local_player_attacker_alone # Desc for a third party involved
+		}
+
+	}
+
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 Accolade glory gain from winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_high_effect = yes }
+
+		scope:attacker = {
+			add_character_flag = ai_should_not_transfer
+		}
+		create_title_and_vassal_change = {
+			type = independency
+			save_scope_as = change
+		}
+		scope:attacker = {
+			change_liege_or_become_independent = {
+				CHANGE = scope:change
+				VASSAL = this
+			}
+
+			hidden_effect = {
+				set_variable = {
+					name = independence_war_former_liege
+					value = scope:defender
+				}
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = victory
+				}
+			}
+		}
+
+		scope:defender = {
+
+			# Struggle Catalyst
+			hidden_effect = {
+				if = {
+					limit = {
+						catalyst_gave_independence_to_powerful_diff_faith_culture_vassal_preliminary_trigger = {
+							CHAR1 = scope:defender
+							CHAR2 = scope:attacker
+						}
+						any_character_struggle = {
+							involvement = involved
+							activate_struggle_catalyst_secondary_character_involvement_involved_trigger = {
+								CATALYST = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+								CHAR = scope:attacker
+							}
+						}
+					}
+					every_character_struggle = {
+						involvement = involved
+						limit = {
+							activate_struggle_catalyst_secondary_character_involvement_either_trigger = {
+								CATALYST = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+								CHAR = scope:attacker
+							}
+						}
+						activate_struggle_catalyst = {
+								catalyst = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+								character = scope:defender
+							}
+					}
+				}
+			}
+		}
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_victory_effects = yes
+
+		resolve_title_and_vassal_change = scope:change
+
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = player_independence_war_white_peace_defender_desc
+			}
+			triggered_desc = {
+				trigger = {
+					scope:attacker = {
+						is_local_player = yes
+					}
+				}
+				desc = player_independence_war_white_peace_attacker_desc
+			}
+			desc = player_independence_war_white_peace_desc
+		}
+
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = white_peace
+				}
+			}
+		}
+
+		scope:defender = {
+			add_prestige = minor_prestige_value
+			stress_impact = {
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = player_independence_defeat_defender_desc
+			}
+			triggered_desc = {
+				trigger = {
+					scope:attacker = {
+						is_local_player = yes
+					}
+				}
+				desc = player_independence_defeat_attacker_desc
+			}
+			desc = player_independence_war_defeat_desc
+		}
+
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_dread = medium_dread_gain
+			# Prestige for Defender
+			add_prestige_war_defender_effect = {
+				PRESTIGE_VALUE = medium_prestige_value
+			}
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+
+		scope:attacker = {
+			hard_imprison_character_effect = {
+				TARGET = this
+				IMPRISONER = scope:defender
+			}
+			scope:defender = {
+				add_opinion = {
+					target = prev
+					modifier = vassal_lost_faction_revolt_war
+				}
+			}
+		}
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_defeat_effects = yes
+	}
+
+	should_invalidate = {
+		scope:attacker.liege != scope:defender
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	check_defender_inheritance_validity = no
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	transfer_behavior = transfer
+
+	war_name = "INDEPENDENCE_WAR_NAME"
+
+	interface_priority = 120
+
+	attacker_wargoal_percentage = 0.8
+
+	max_attacker_score_from_battles = 100
+	max_defender_score_from_battles = 50
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}
+
+
+nation_fracturing_faction_war = {
+	icon = dissolution_war
+	group = civil_war
+	allow_hostages = no
+
+	target_top_liege_if_outside_realm = no # In case of Adventurers starting this war
+
+	allowed_for_character = {
+		scope:attacker = {
+			is_ai = no
+		}
+	}
+
+	allowed_against_character = {
+		scope:attacker = {
+			liege = scope:defender
+		}
+	}
+
+	on_declaration = {
+		on_declared_war = yes
+		# Remove offending HumSac modifiers.
+		scope:attacker = {
+			hidden_effect = { fp1_remove_humsac_offended_counties_effect = yes }
+		}
+	}
+
+	on_victory_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { # Desc for only one player attacker
+					scope:attacker = {
+						is_local_player = yes
+					}
+				}
+				desc = nation_fracturing_faction_war_victory_desc_local_player_attacker_alone
+			}
+			triggered_desc = { # Desc for only one attacker, player defender
+				trigger = {
+					scope:defender = {
+						is_local_player = yes
+					}
+				}
+				desc = player_nation_fracturing_faction_war_victory_desc_local_player_defender_attacker_alone
+			}
+			desc = nation_fracturing_faction_war_victory_desc_local_player_attacker_alone # Desc for a third party involved
+		}
+
+	}
+
+	on_victory = {
+
+		scope:attacker = { show_pow_release_message_effect = yes }
+
+		#EP2 Accolade glory gain from winning against higher ranked enemy
+		scope:attacker = { accolade_attacker_war_end_glory_gain_med_effect = yes }
+		
+		create_title_and_vassal_change = {
+			type = independency
+			save_scope_as = change
+		}
+		scope:attacker.joined_faction = {
+			every_faction_member = {
+				change_liege_or_become_independent = {
+					CHANGE = scope:change
+					VASSAL = this
+				}
+
+				hidden_effect = {
+					set_variable = {
+						name = independence_war_former_liege
+						value = scope:defender
+					}
+					add_truce_both_ways = {
+						character = scope:defender
+						days = 1825
+						war = root.war
+						result = victory
+					}
+					save_scope_as = current_member
+					# Struggle Catalyst
+					if = {
+						limit = {
+							catalyst_gave_independence_to_powerful_diff_faith_culture_vassal_preliminary_trigger = {
+								CHAR1 = scope:defender
+								CHAR2 = scope:current_member
+							}
+							any_character_struggle = {
+								involvement = involved
+								activate_struggle_catalyst_secondary_character_involvement_involved_trigger = {
+									CATALYST = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+									CHAR = scope:current_member
+								}
+							}
+						}
+						every_character_struggle = {
+							involvement = involved
+							limit = {
+								activate_struggle_catalyst_secondary_character_involvement_either_trigger = {
+									CATALYST = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+									CHAR = scope:current_member
+								}
+							}
+							activate_struggle_catalyst = {
+								catalyst = catalyst_gave_independence_to_powerful_diff_faith_culture_vassal
+								character = scope:defender
+							}
+						}
+					}
+				}
+			}
+		}
+		scope:attacker = {
+			add_prestige = medium_prestige_value
+		}
+		scope:defender = {
+			add_prestige = {
+				value = medium_prestige_value
+				multiply = -1
+			}
+
+			every_vassal = {
+				limit = { is_ai = no }
+				send_interface_toast = {
+					type = msg_gained_independence
+					title = liege_primary_title_dissolution
+					desc = liege_primary_title_dissolution_desc
+					left_icon = scope:defender
+				}
+			}
+		}
+		resolve_title_and_vassal_change = scope:change
+
+		scope:defender = {
+			every_held_title = {
+				limit = {
+					OR = {
+						tier = prev.primary_title.tier
+						tier >= tier_kingdom
+					}
+				}
+				add_to_temporary_list = titles_to_destroy
+			}
+		}
+
+		every_in_list = {
+			list = titles_to_destroy
+			scope:attacker = {
+				destroy_title = prev
+			}
+		}
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_victory_effects = yes
+	}
+
+	on_white_peace_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = player_nation_fracturing_faction_war_white_peace_defender_desc
+			}
+			triggered_desc = {
+				trigger = {
+					scope:attacker = {
+						is_local_player = yes
+					}
+				}
+				desc = player_nation_fracturing_faction_war_white_peace_attacker_desc
+			}
+			desc = player_nation_fracturing_faction_war_white_peace_desc
+		}
+
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		hidden_effect = {
+			scope:attacker = {
+				add_truce_both_ways = {
+					character = scope:defender
+					days = 1825
+					war = root.war
+					result = white_peace
+				}
+			}
+		}
+
+		scope:defender = {
+			stress_impact = {
+ 				arrogant = medium_stress_impact_gain
+ 			}
+
+			add_character_flag = {
+				flag = recent_nation_fracturing_faction_war
+				years = faction_nation_fracturing_war_white_peace_cooldown
+			}
+			add_prestige = minor_prestige_value
+		}
+
+		on_white_peace_faction_revolt_war = yes
+	}
+
+	on_defeat_desc = {
+		first_valid = {
+			triggered_desc = {
+				trigger = { scope:defender = { is_local_player = yes } }
+				desc = nation_fracturing_faction_war_defeat_defender_desc
+			}
+			triggered_desc = {
+				trigger = {
+					scope:attacker = {
+						is_local_player = yes
+					}
+				}
+				desc = player_nation_fracturing_defeat_attacker_desc
+			}
+			desc = player_nation_fracturing_faction_war_defeat_desc
+		}
+
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_character_flag = {
+				flag = recent_nation_fracturing_faction_war
+				years = faction_nation_fracturing_war_defeat_cooldown
+			}
+			add_dread = medium_dread_gain
+			# Prestige for Defender
+			add_prestige_war_defender_effect = {
+				PRESTIGE_VALUE = medium_prestige_value
+			}
+			add_achievement_flag_effect = { FLAG = achievement_know_your_place_flag }
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+
+		on_lost_faction_revolt_war = yes
+
+		#Mandalas gain or lose piety/devotion depending on Decree
+		mandala_war_defeat_effects = yes
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	check_defender_inheritance_validity = no
+
+	on_primary_attacker_death = inherit
+	on_primary_defender_death = inherit
+
+	attacker_allies_inherit = yes
+	defender_allies_inherit = yes
+
+	transfer_behavior = transfer
+
+	war_name = "NATION_FRACTURING_WAR_NAME"
+
+	interface_priority = 120
+
+	attacker_wargoal_percentage = 0.8
+
+	max_attacker_score_from_battles = 100
+	max_defender_score_from_battles = 50
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}
+
+nomadic_war = {
+	icon = nomadic_riders
+	group = civil_war
+	ai_only_against_liege = yes
+	target_titles = all
+	allow_hostages = no
+	allowed_for_character =	{
+		scope:attacker = {
+			is_leading_faction_type = nomadic_faction
+		}
+	}
+
+	allowed_against_character = {
+	}
+
+	target_de_jure_regions_above = yes
+	target_top_liege_if_outside_realm = no
+
+	valid_to_start = {
+	}
+
+	should_invalidate = {
+		NOT = {
+			scope:attacker = {
+				exists = joined_faction
+			}
+		}
+	}
+
+	on_declaration = {
+		# Generate extra troops if the rebellion was financed
+		generate_troops_from_revolt_county_modifiers_effect = yes
+	}
+
+	on_victory_desc = {
+		desc = nomadic_war_victory_desc
+	}
+
+	on_victory = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:defender = {
+			add_prestige_level = -1
+		}
+
+		# LEGITIMACY FROM LOSING FACTION WAR
+		faction_war_end_defeat_legitimacy_effect = yes
+
+		random_in_list = {
+			list = target_titles
+			save_scope_as = target_title
+		}
+
+		scope:attacker = {
+			remove_variable = rebel_leader_peasants
+			joined_faction = {
+				every_faction_member = {
+					# Everyone involved gets a 5-year truce.
+					add_truce_both_ways = {
+						character = scope:defender
+						days = 1825
+						war = root.war
+						result = victory
+					}
+				}
+			}
+		}
+		
+		successful_nomadic_revolt_outcome_effect = {
+			FACTION_LEADER = scope:attacker
+		}
+	}
+
+	on_white_peace_desc = {
+		desc = nomadic_war_white_peace_desc
+	}
+
+	on_white_peace = {
+		scope:attacker = {
+			show_pow_release_message_effect = yes
+			stress_impact = {
+ 				ambitious = medium_stress_impact_gain
+ 				arrogant = medium_stress_impact_gain
+ 			}
+		}
+		on_white_peace_faction_revolt_war = yes
+		hidden_effect = {
+			scope:attacker = {
+				# Destroy the nomadic faction
+				if = {
+					limit = {
+						exists = joined_faction
+					}
+					joined_faction = {
+						destroy_faction = yes
+					}
+				}
+				
+				save_temporary_scope_as = destroyer_of_titles
+				if = {
+					limit = {
+						has_variable = peasant_title
+						exists = this.var:peasant_title.holder
+					}
+					destroy_title = this.var:peasant_title
+				}
+				every_held_title = {
+					limit = {
+						is_landless_type_title = yes
+					}
+					scope:destroyer_of_titles = { destroy_title = prev }
+				}
+
+				# Destroy or clean-up flags on faction leader
+				if = {
+					limit = {
+						has_character_flag = peasant_faction_random_peasant
+					}
+					death = {
+						death_reason = death_vanished
+					}
+				}
+				else = {
+					remove_variable = rebel_leader_peasants
+					add_truce_both_ways = {
+						character = scope:defender
+						days = 1825
+						war = root.war
+						result = victory
+					}
+				}
+			}
+		}
+	}
+	
+	on_invalidated = {
+		hidden_effect = {
+			scope:attacker = {
+				# Destroy the nomadic faction
+				if = {
+					limit = {
+						exists = joined_faction
+					}
+					joined_faction = {
+						destroy_faction = yes
+					}
+				}
+				
+				save_temporary_scope_as = destroyer_of_titles
+				if = {
+					limit = {
+						has_variable = peasant_title
+						exists = this.var:peasant_title.holder
+					}
+					destroy_title = this.var:peasant_title
+				}
+				every_held_title = {
+					limit = {
+						is_landless_type_title = yes
+					}
+					scope:destroyer_of_titles = { destroy_title = prev }
+				}
+
+				# Destroy or clean-up flags on faction leader
+				if = {
+					limit = {
+						has_character_flag = peasant_faction_random_peasant
+					}
+					death = {
+						death_reason = death_vanished
+					}
+				}
+			}
+		}
+	}
+
+	on_defeat_desc = {
+		desc = nomadic_war_defeat_desc
+	}
+
+	on_defeat = {
+		scope:attacker = { show_pow_release_message_effect = yes }
+		scope:attacker = {
+			joined_faction = {
+				every_faction_county_member = {
+					custom = peasant_faction_every_county
+					add_county_modifier = {
+						modifier = county_increased_opinion_modifier
+						years = 25
+					}
+					if = {
+						limit = {
+							has_county_modifier = peasant_war_lost_county_modifier
+						}
+						remove_county_modifier = peasant_war_lost_county_modifier
+					}
+				}
+			}
+			add_character_flag = peasant_revolt_do_not_kill
+			remove_variable = rebel_leader_peasants
+		}
+		on_lost_faction_revolt_war = yes # Imprison all faction members, including the faction leader.
+		scope:attacker = { # Imprison any war participant that isn't already in the faction.
+			every_character_war = {
+				limit = {
+					is_defender = scope:defender
+				}
+				every_war_attacker = {
+					limit = {
+						is_imprisoned = no
+					}
+					hidden_effect = {
+						hard_imprison_character_effect = {
+							TARGET = this
+							IMPRISONER = scope:defender
+						}
+					}
+				}
+			}
+		}
+		hidden_effect = {
+			scope:attacker = {
+				if = {
+					limit = { exists = joined_faction }
+					joined_faction = {
+						destroy_faction = yes # Destroy the faction if it wasn't already destroyed automatically.
+					}
+				}
+				save_temporary_scope_as = destroyer_of_titles
+				if = {
+					limit = {
+						has_variable = peasant_title
+						exists = this.var:peasant_title.holder
+					}
+					destroy_title = this.var:peasant_title
+				}
+				every_held_title = {
+					limit = {
+						is_landless_type_title = yes
+					}
+					scope:destroyer_of_titles = { destroy_title = prev }
+				}
+			}
+		}
+		scope:defender = {
+			mandala_peacemaker_perk_serenity_effect = yes
+			add_dread = medium_dread_gain
+
+			# LEGITIMACY FROM WINNING FACTION WAR
+			faction_war_end_victory_legitimacy_effect = yes
+		}
+	}
+
+	on_invalidated_desc = msg_invalidate_war_title
+
+	on_primary_attacker_death = invalidate
+	on_primary_defender_death = inherit
+
+	transfer_behavior = transfer
+
+	attacker_allies_inherit = no
+	defender_allies_inherit = yes
+
+	war_name = "NOMADIC_WAR_NAME"
+
+	interface_priority = 80
+
+	use_de_jure_wargoal_only = yes
+
+	attacker_wargoal_percentage = 0.5
+
+	defender_score_from_battles_scale = 300
+	max_attacker_score_from_battles = 150
+	max_defender_score_from_battles = 150
+	
+	max_defender_score_from_occupation = 150
+	max_attacker_score_from_occupation = 150
+
+	max_ai_diplo_distance_to_title = 500
+}

--- a/common/casus_belli_types/00_civil_war.txt
+++ b/common/casus_belli_types/00_civil_war.txt
@@ -243,30 +243,35 @@ independence_faction_war = {
 				multiply = -1
 			}
 			
-			if = {
-				limit = { has_realm_law = crown_authority_1 }
-				add_realm_law = crown_authority_0
-			}
-			if = {
-				limit = { has_realm_law = crown_authority_2 }
-				add_realm_law = crown_authority_1
-			}
-			if = {
-				limit = { has_realm_law = crown_authority_3 }
-				add_realm_law = crown_authority_2
-			}
-			if = {
-				limit = { has_realm_law = tribal_authority_1 }
-				add_realm_law = tribal_authority_0
-			}
-			if = {
-				limit = { has_realm_law = tribal_authority_2 }
-				add_realm_law = tribal_authority_1
-			}
-			if = {
-				limit = { has_realm_law = tribal_authority_3 }
-				add_realm_law = tribal_authority_2
-			}
+			#Unop Use the authority helpers so Administrative and Nomad rulers also lose authority, not just Feudal/Tribal
+#			if = {
+#				limit = { has_realm_law = crown_authority_1 }
+#				add_realm_law = crown_authority_0
+#			}
+#			if = {
+#				limit = { has_realm_law = crown_authority_2 }
+#				add_realm_law = crown_authority_1
+#			}
+#			if = {
+#				limit = { has_realm_law = crown_authority_3 }
+#				add_realm_law = crown_authority_2
+#			}
+#			if = {
+#				limit = { has_realm_law = tribal_authority_1 }
+#				add_realm_law = tribal_authority_0
+#			}
+#			if = {
+#				limit = { has_realm_law = tribal_authority_2 }
+#				add_realm_law = tribal_authority_1
+#			}
+#			if = {
+#				limit = { has_realm_law = tribal_authority_3 }
+#				add_realm_law = tribal_authority_2
+#			}
+			decrease_crown_authority_effect = yes
+			decrease_tribal_authority_effect = yes
+			decrease_imperial_bureaucracy_effect = yes
+			decrease_nomadic_authority_effect = yes
 		}
 		resolve_title_and_vassal_change = scope:change
 
@@ -803,7 +808,7 @@ populist_war = {
 					involvement = involved
 					activate_struggle_catalyst = {
 						catalyst = catalyst_populist_uprise
-						character = this
+						character = scope:defender #Unop `this` is the struggle here, not the character
 					}
 				}
 			}
@@ -1577,30 +1582,35 @@ refused_liege_demand_war = {
 					value = primary_title
 					months = 1
 				}
-				if = {
-					limit = { has_realm_law = crown_authority_1 }
-					add_realm_law = crown_authority_0
-				}
-				if = {
-					limit = { has_realm_law = crown_authority_2 }
-					add_realm_law = crown_authority_1
-				}
-				if = {
-					limit = { has_realm_law = crown_authority_3 }
-					add_realm_law = crown_authority_2
-				}
-				if = {
-					limit = { has_realm_law = tribal_authority_1 }
-					add_realm_law = tribal_authority_0
-				}
-				if = {
-					limit = { has_realm_law = tribal_authority_2 }
-					add_realm_law = tribal_authority_1
-				}
-				if = {
-					limit = { has_realm_law = tribal_authority_3 }
-					add_realm_law = tribal_authority_2
-				}
+				#Unop Use the authority helpers so Administrative and Nomad rulers also lose authority, not just Feudal/Tribal
+#				if = {
+#					limit = { has_realm_law = crown_authority_1 }
+#					add_realm_law = crown_authority_0
+#				}
+#				if = {
+#					limit = { has_realm_law = crown_authority_2 }
+#					add_realm_law = crown_authority_1
+#				}
+#				if = {
+#					limit = { has_realm_law = crown_authority_3 }
+#					add_realm_law = crown_authority_2
+#				}
+#				if = {
+#					limit = { has_realm_law = tribal_authority_1 }
+#					add_realm_law = tribal_authority_0
+#				}
+#				if = {
+#					limit = { has_realm_law = tribal_authority_2 }
+#					add_realm_law = tribal_authority_1
+#				}
+#				if = {
+#					limit = { has_realm_law = tribal_authority_3 }
+#					add_realm_law = tribal_authority_2
+#				}
+				decrease_crown_authority_effect = yes
+				decrease_tribal_authority_effect = yes
+				decrease_imperial_bureaucracy_effect = yes
+				decrease_nomadic_authority_effect = yes
 
 				add_prestige = -500
 

--- a/common/scripted_effects/00_realm_effects.txt
+++ b/common/scripted_effects/00_realm_effects.txt
@@ -165,7 +165,12 @@ decrease_nomadic_authority_effect = {
 	if = {
 		limit = { has_realm_law_flag = uses_nomadic_authority }
 		#Laws
+		#Unop Handle the top tier too, otherwise rulers at maximum nomadic authority lose nothing
 		if = {
+			limit = { has_realm_law = nomadic_authority_5 }
+			add_realm_law = nomadic_authority_4
+		}
+		else_if = {
 			limit = { has_realm_law = nomadic_authority_4 }
 			add_realm_law = nomadic_authority_3
 		}


### PR DESCRIPTION
Fixes #612

**fixer:** `independence_faction_war` and `refused_liege_demand_war` each contained an identical inline six-`if` chain stepping `crown_authority` and `tribal_authority` only. Because `imperial_bureaucracy` and `nomadic_authority` are separate law groups, every `if` silently no-opped for those governments — an Administrative ruler could lose a civil war with no authority penalty at all.

Replaced both inline chains with the government-agnostic helpers, which is the idiom vanilla already uses elsewhere (`00_diarch_interactions.txt`, `hold_court_events_general.txt`):

```
decrease_crown_authority_effect = yes
decrease_tribal_authority_effect = yes
decrease_imperial_bureaucracy_effect = yes
decrease_nomadic_authority_effect = yes
```

Each helper self-gates on its own `has_realm_law_flag = uses_*`, and the four flags sit on disjoint government types, so exactly one applies and the rest no-op. This also fixes Nomad/Herder, which the report didn't mention.

**Scope notes:**
- **`depose_war` deliberately excluded.** It has *no* realm-law change at all (verified: zero `realm_law` hits in its block), so it never lowered authority for anyone — that's not the reported asymmetry, and adding a penalty would be a balance change rather than a fix.
- **Celestial / Meritocratic / Steppe-Admin / Japanese cannot be fixed here.** `realm_law_use_imperial_bureaucracy` explicitly excludes them, so they have no authority ladder to lower. Giving them a penalty would need a different currency — new content, out of scope. The issue title overstates what is fixable.

Also fixed a pre-existing vanilla bug surfaced by adding this file as an override: `character = this` inside `every_character_struggle` (l.811) passed the *struggle* where a character was expected. Changed to `scope:defender`, matching vanilla's own `character = prev` idiom in `county_on_actions.txt:26`. Tiger is clean.