### PR TITLE
Grant treatment modifier on risky wound treatment critical success

### DIFF
--- a/common/scripted_effects/20_health_effects.txt
+++ b/common/scripted_effects/20_health_effects.txt
@@ -3222,13 +3222,23 @@ add_wound_treatment_modifier_effect = {
 					remove_trait = wounded_3
 					add_trait = wounded_2
 				}
+				#Unop Also grant the treatment modifier, otherwise a critical success is worse than a regular one
+				if = {
+					limit = {
+						OR = {
+							has_trait = wounded_1
+							has_trait = wounded_2
+						}
+					}
+					add_character_modifier = { modifier = risky_wound_treatment_success_modifier days = wound_treatment_success_duration }
+				}
 			}
 
 			#Risky treatment regular success
 			else_if = {
 				limit = {
 					scope:treatment_result_treatment = flag:risky
-					scope:treatment_result_outcome = flag:critical_success
+					scope:treatment_result_outcome = flag:success #Unop Was critical_success, making this branch unreachable
 				}
 				add_character_modifier = { modifier = risky_wound_treatment_success_modifier days = wound_treatment_success_duration }
 			}

--- a/common/scripted_effects/20_health_effects.txt
+++ b/common/scripted_effects/20_health_effects.txt
@@ -3222,6 +3222,16 @@ add_wound_treatment_modifier_effect = {
 					remove_trait = wounded_3
 					add_trait = wounded_2
 				}
+				#Unop Also grant the treatment modifier, otherwise a critical success is worse than a regular one
+				if = {
+					limit = {
+						OR = {
+							has_trait = wounded_1
+							has_trait = wounded_2
+						}
+					}
+					add_character_modifier = { modifier = risky_wound_treatment_success_modifier days = wound_treatment_success_duration }
+				}
 			}
 
 			#Risky treatment regular success


### PR DESCRIPTION
Fixes #613

**fixer:** The risky-treatment **critical success** branch of `add_wound_treatment_modifier_effect` only downgraded the wound tier and granted no modifier, while the regular-success branch granted `risky_wound_treatment_success_modifier`. A critical success was therefore *worse* than a regular one.

Added the same modifier at the end of the critical-success branch, guarded on a *residual* wound remaining — a `wounded_1` is fully removed by the downgrade, so there is no penalty left to negate and granting one would be a gratuitous buff.

Net health outcomes (`negate_health_penalty_add = 2` offsets a penalty rather than adding health, so it cannot over-heal; trait penalties `wounded_1 = -1`, `wounded_2 = -2`, `wounded_3 = -4`):

| Wound | Critical success | Regular success |
|---|---|---|
| `wounded_1` | removed → **0** | -1 + 2 → **0** |
| `wounded_2` | → `wounded_1` (-1) + 2 → **0** | -2 + 2 → **0** |
| `wounded_3` | → `wounded_2` (-2) + 2 → **0** | -4 + 2 → **-2** |

Critical is now always at least as good as regular, which was the invariant vanilla broke.

Chose the minimal remedy (keep the tier downgrade, add the modifier) over removing the wound outright: it preserves the "so you can see the trait you've lost" behaviour the vanilla comment calls out, and avoids turning a -4 straight to 0, which would read as rebalancing. The safe-treatment branch is correct and untouched.

**Note:** #614 (the `flag:success` half) is **already fixed on `main`** by 5ba07d43, so it is no longer part of this PR.
