### PR TITLE
Add missing men-at-arms texticons

### DIFF
--- a/.claude/skills/unop-import-steam-comments/scripts/fetch_steam_comments.py
+++ b/.claude/skills/unop-import-steam-comments/scripts/fetch_steam_comments.py
@@ -24,10 +24,11 @@ import datetime as dt
 import html
 import json
 import re
+import subprocess
 import sys
 import time
-import urllib.request
 import urllib.error
+import urllib.request
 
 WORKSHOP_ID = "2871648329"
 OWNER_STEAMID64 = "76561198047801064"
@@ -51,16 +52,48 @@ _last_request = 0.0
 
 
 def http_get(url: str) -> str:
+    """Fetch a URL via curl.
+
+    Steam's edge rejects Python's urllib by TLS client fingerprint, answering
+    every request with HTTP 429 regardless of headers, User-Agent, or elapsed
+    time. The 429 is misleading: it is bot detection, not throttling, so
+    retrying or backing off never clears it. curl's handshake is accepted, so
+    shell out to it rather than using urllib.
+    """
     global _last_request
     wait = REQUEST_DELAY - (time.monotonic() - _last_request)
     if wait > 0:
         time.sleep(wait)
-    req = urllib.request.Request(url, headers={"User-Agent": UA})
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            return resp.read().decode("utf-8", errors="replace")
+        proc = subprocess.run(
+            [
+                "curl",
+                "--silent",
+                "--show-error",
+                "--location",
+                "--max-time",
+                "30",
+                "--user-agent",
+                UA,
+                "--write-out",
+                "\n%{http_code}",
+                url,
+            ],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError("curl not found; it is required to fetch Steam pages") from e
     finally:
         _last_request = time.monotonic()
+
+    if proc.returncode != 0:
+        raise RuntimeError(f"curl failed ({proc.returncode}): {proc.stderr.strip()}")
+
+    body, _, status = proc.stdout.rpartition("\n")
+    if status.strip() != "200":
+        raise RuntimeError(f"HTTP {status.strip()} for {url}")
+    return body
 
 
 def extract_comment_text(block: str) -> str:

--- a/gui/unop_texticons.gui
+++ b/gui/unop_texticons.gui
@@ -17,3 +17,64 @@ texticon = {
 		fontsize = 16
 	}
 }
+
+#Unop Register the men-at-arms texticons vanilla never declared, so @<icon>_icon! renders in localization
+texticon = {
+	icon = garudas_icon
+	iconsize = {
+		texture = "gfx/interface/icons/regimenttypes/garudas.dds"
+		size = { 25 25 }
+		offset = { 0 6 }
+		fontsize = 16
+	}
+}
+
+texticon = {
+	icon = handgonne_icon
+	iconsize = {
+		texture = "gfx/interface/icons/regimenttypes/handgonne.dds"
+		size = { 25 25 }
+		offset = { 0 6 }
+		fontsize = 16
+	}
+}
+
+texticon = {
+	icon = khandayat_icon
+	iconsize = {
+		texture = "gfx/interface/icons/regimenttypes/khandayat.dds"
+		size = { 25 25 }
+		offset = { 0 6 }
+		fontsize = 16
+	}
+}
+
+texticon = {
+	icon = mountaineer_icon
+	iconsize = {
+		texture = "gfx/interface/icons/regimenttypes/mountaineer.dds"
+		size = { 25 25 }
+		offset = { 0 6 }
+		fontsize = 16
+	}
+}
+
+texticon = {
+	icon = paiks_icon
+	iconsize = {
+		texture = "gfx/interface/icons/regimenttypes/paiks.dds"
+		size = { 25 25 }
+		offset = { 0 6 }
+		fontsize = 16
+	}
+}
+
+texticon = {
+	icon = palace_guards_icon
+	iconsize = {
+		texture = "gfx/interface/icons/regimenttypes/palace_guards.dds"
+		size = { 25 25 }
+		offset = { 0 6 }
+		fontsize = 16
+	}
+}


### PR DESCRIPTION
Fixes #618

**fixer:** The `.dds` asset was never missing — the **texticon registration** was. Two icon mechanisms exist: GUI widgets use `texture = "[MenAtArmsType.GetIcon]"` (resolves the path directly, so these icons show fine in the army windows), while localization uses `@[...GetIconKey]_icon!`, which resolves a texticon declared in `gui/texticons.gui`. With no matching texticon the token renders as nothing — the name appears, the icon slot is blank, exactly as screenshotted. That's also why the reporter only saw it on loc-driven surfaces.

Comparing all 60 distinct `icon =` values across `common/men_at_arms_types/*.txt` against the registered texticons yields exactly 6 gaps — and all 6 have their `.dds` present, so all 6 are the same registration bug, not an art gap:

| MaA type | `icon =` | texticon added |
|---|---|---|
| `mountaineer` | `mountaineer` | `mountaineer_icon` (reported) |
| `garudas` | `garudas` | `garudas_icon` |
| `handgunners` | `handgonne` | `handgonne_icon` |
| `khandayat` | `khandayat` | `khandayat_icon` |
| `paiks` | `paiks` | `paiks_icon` |
| `palace_guards` | `palace_guards` | `palace_guards_icon` |

Note `handgunners` declares `icon = handgonne`, so its texticon must be named for the **icon key**, not the type.

Added to the existing `gui/unop_texticons.gui` rather than overriding vanilla's 357-entry `texticons.gui` — same approach Unop already uses for `attrition_icon`, and it avoids copying a large file for six small additions. Blocks match vanilla's regimenttypes shape exactly.

Fixed all 6 rather than only Mountaineers: same root cause, same file, and the other five are equally broken. This also fixes other `@[...GetIconKey]_icon!` surfaces (`SUBJECT_MAA_HINT`, `MEN_AT_ARMS_PROVIDED_BY_SUBJECT`, `MAA_SIZE_CHANGE`), not just the reported tooltip.