### PR TITLE
Fix Germania being uncreatable when the HRE already exists

### DIFF
--- a/common/landed_titles/00_landed_titles.txt
+++ b/common/landed_titles/00_landed_titles.txt
@@ -4566,6 +4566,7 @@ e_germany = {
 					}
 				}
 				exists = global_var:flag_restored_roman_empire
+				exists = title:e_hre.holder #Unop The HRE already exists, so it can no longer be formed instead
 			}
 		}
 		rule_title_creation_imperial_power_projection_title_creation_trigger = yes


### PR DESCRIPTION
Fixes #620

**fixer:** One line added to the existing `#Unop` `OR` in `e_germany.can_create`:

```
exists = title:e_hre.holder #Unop The HRE already exists, so it can no longer be formed instead
```

**Root cause** — the absorption is conditional but the block is not. `restore_holy_roman_empire_decision.is_valid` accepts `k_east_francia`, `k_bavaria`, `k_france`, `k_italy`, `k_lotharingia`, but the Germania de jure absorption in `restore_holy_roman_empire_decision_scripted_effect` only fires for `k_east_francia`/`k_bavaria`/`k_lotharingia`/`k_frisia`. A founder qualifying *only* via `k_france` or `k_italy` forms the HRE without absorbing Germania, so both empires coexist. Germania then stays blocked for Catholics ("form the HRE instead"), while the HRE can never be re-formed — `is_shown` contains `NOR = { exists = title:e_hre.holder }`. Permanent dead end. The existing #440 escape hatch doesn't help: `flag_restored_roman_empire` is only set by the Roman path.

**Why this gate, released this way.** The trigger's own loc states the intent outright — *"As a [Faith] ruler you can reform the $e_hre$ instead"*. That sentence is simply false once the HRE exists, so releasing the gate on exactly that condition targets the real intent rather than widening the proxy. It mirrors the #440 fix already sitting in this same `OR`.

**Rejected alternatives:**
- *Goryeo-style "decision consumed" test* — `restore_holy_roman_empire_decision` does **not** register in `unavailable_unique_decisions`; it only sets a global guarded by `is_ai = no`, so copying that pattern would silently fail when the AI forms the HRE.
- *Widening the absorption `limit`* — would prevent the coexistence entirely, but is a much larger change to the de jure map, and the reporter prefers coexistence to remain.

**Trade-off:** this also unblocks Germania for a Catholic when an HRE *did* absorb it — but in that case Germania has no de jure kingdoms left, so creation is inert and still governed by the normal de jure/tier requirements.

Note: the analysis flagged `form_germania_christian_trigger` as having no localization. It resolves via `common/trigger_localization/00_landed_title_triggers.txt` to `FORM_GERMANIA_CHRISTIAN_TRIGGER`, which does exist — no loc work needed.